### PR TITLE
ci: migrate to OIDC for AWS credentials (Sprint 1 pilot)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ "main" ]
 
-
 env:
   AWS_REGION: us-east-1
   ECR_REPOSITORY: shop_droplinked_com
@@ -15,6 +14,7 @@ env:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   deploy:
@@ -24,24 +24,23 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+    - name: Configure AWS credentials (OIDC)
+      uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: arn:aws:iam::353643723135:role/github-actions-deploy
         aws-region: ${{ env.AWS_REGION }}
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
 
     - name: Create env file
       id: create-env
       run: |
         echo "${{ secrets.ENV_FILE }}" > .env
-    
+
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
       env:
@@ -61,13 +60,13 @@ jobs:
 
     - name: Extract task definition
       run: |
-        jq '.taskDefinition' task-def.json > temp-task-def.json 
+        jq '.taskDefinition' task-def.json > temp-task-def.json
         jq 'del(.enableFaultInjection)' temp-task-def.json > task-definition-fixed.json
         mv task-definition-fixed.json task-definition.json
 
     - name: Display task definition
       run: cat task-definition.json
-      
+
     - name: Fill in the new image ID in the Amazon ECS task definition
       id: task-def
       uses: aws-actions/amazon-ecs-render-task-definition@v1
@@ -77,7 +76,7 @@ jobs:
         image: ${{ env.image }}
 
     - name: Deploy Amazon ECS task definition
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v2
       with:
         task-definition: ${{ steps.task-def.outputs.task-definition }}
         service: ${{ env.ECS_SERVICE }}


### PR DESCRIPTION
## Summary

Replaces long-lived `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` repo secrets with GitHub OIDC role-assumption against the existing `github-actions-deploy` IAM role.

## Why

Long-lived AWS access keys in repo secrets are an antipattern:
- Rotation requires coordinated updates across every repo
- Compromise persists until manual rotation
- The `deploy` user backing those keys carries `AdministratorAccess` (overprovisioned)

OIDC fixes all three:
- Short-lived (1-hour) STS tokens minted per workflow run
- Compromise expires automatically
- Role is least-privilege (only the ECR repos + ECS services this workflow needs)

## What changed

| | Before | After |
|---|---|---|
| Auth mechanism | Static `secrets.AWS_ACCESS_KEY_ID` / `SECRET` | OIDC role-assumption |
| Trust policy | n/a | Already provisioned: `repo:droplinked/*:ref:refs/heads/main` etc. |
| Permissions added to workflow | — | `id-token: write` (required for OIDC) |
| `aws-actions/configure-aws-credentials` | `@v1` | `@v4` |
| `aws-actions/amazon-ecr-login` | `@v1` | `@v2` |
| `aws-actions/amazon-ecs-deploy-task-definition` | `@v1` | `@v2` |
| `actions/checkout` | `@v3` | `@v4` |

Diff is **10 insertions, 11 deletions** — minimal blast radius.

## Verification

The `github-actions-deploy` role's permissions policy includes:
- ECR push/pull on `*_droplinked_com` and other Droplinked repos
- ECS describe/update/register-task-definition
- `iam:PassRole` on the existing task execution roles
- S3 + CloudFront for the static-frontend buckets

So this workflow will have everything it needs after merge.

## Rollback

If the new workflow fails on first push: revert this PR. The
`AWS_ACCESS_KEY_ID` / `SECRET` repo secrets are still in place — the
workflow file is the only change.

## Why this repo first

Sprint 1 OIDC pilot. Lowest blast radius:
- `Next-ShopFront`'s deploy is currently broken for unrelated reasons (the shop investigation), so traffic risk is zero
- Successful migration here proves the pattern for the other 6 backend / frontend repos in subsequent PRs

## Context

Part of the Sprint 1 plan tracked in the operator workspace at
`agents/playbooks/sprint-1-operate.md`. Sister docs:
- `agents/playbooks/oidc-migration.md` — the migration playbook
- `reports/security-audit-2026-05-08.md` — finding #5 (deploy user overprivilege)
