### PR TITLE
chore(deps): close 14+ HIGH CVEs (transitive overrides + axios bump)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@stripe/stripe-js": "^3.0.10",
     "@tanstack/react-query": "^5.20.1",
     "@uauth/js": "^2.8.0",
-    "axios": "^1.6.7",
+    "axios": "^1.16.0",
     "buffer": "^6.0.3",
     "casper-js-sdk": "^2.15.4",
     "class-variance-authority": "^0.7.0",
@@ -57,5 +57,21 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
+  },
+  "overrides": {
+    "@babel/plugin-transform-modules-systemjs": "^7.29.4",
+    "@solana/web3.js": "^1.95.8",
+    "base-x": "^5.0.0",
+    "braces": "^3.0.3",
+    "cross-spawn": "^7.0.6",
+    "flatted": "^3.4.3",
+    "glob": "^10.5.0",
+    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
+    "minimatch": "^9.0.9",
+    "picomatch": "^4.0.4",
+    "rollup": "^4.27.0",
+    "svgo": "^3.3.4",
+    "ws": "^8.18.0"
   }
 }


### PR DESCRIPTION
Closes most remaining HIGH alerts via overrides; bigint-buffer dismissed separately (no upstream patch).

## Direct bump
- axios 1.6.7 → 1.16.0 (closes 6 CVEs: 25639, 27152, 42033, 42035, 42043, 42264, 58754)

## Transitive overrides
ws, svgo, rollup, picomatch, minimatch, lodash, lodash-es, glob, flatted, cross-spawn, braces, base-x, @babel/plugin-transform-modules-systemjs, @solana/web3.js

Total CVEs closed: 14+ across HIGH + dev-scope HIGH.