### PR TITLE
chore: drop SKALE chain support (Phase 2)

### DIFF
--- a/src/state/hooks/droplinked/payment/usePayment.ts
+++ b/src/state/hooks/droplinked/payment/usePayment.ts
@@ -81,8 +81,6 @@ export function usePayment() {
               return Chain.BINANCE;
             case 'ETHEREUM':
               return Chain.ETH;
-            case 'SKALE':
-              return Chain.SKALE;
             case 'BITLAYER':
               return Chain.BITLAYER;
             default:


### PR DESCRIPTION
Phase 2 of SKALE removal. Drops the SKALE switch case from `getChainFromWalletType()` in `src/state/hooks/droplinked/payment/usePayment.ts`. Sole reference in this repo.