### PR TITLE
docs: add CONTRIBUTING.md pointer to droplinked-community

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing to droplinked
+
+Thanks for your interest! All contribution guidance lives in the **public community repo**:
+
+👉 **https://github.com/droplinked/droplinked-community/blob/main/CONTRIBUTING.md**
+
+That doc covers:
+- PR workflow + conventional-commit format
+- Code style + tests
+- Attribution + changelog rules
+- Security disclosure (do NOT open public issues for security)
+
+For **bug reports / feature requests**, open issues in [droplinked-community](https://github.com/droplinked/droplinked-community/issues/new/choose) — they get triaged + routed from there.
+
+For **security vulnerabilities**, email `security@droplinked.com` directly.
+
+Discussion: [GitHub Discussions](https://github.com/droplinked/droplinked-community/discussions).


### PR DESCRIPTION
Centralized contribution doc now lives in droplinked-community. This repo gets a small pointer file so contributors land in the right flow.