### PR TITLE
ci: auto-changelog draft workflow

### DIFF
--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -1,0 +1,92 @@
+name: Auto-changelog draft
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  append-draft:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Classify PR title
+        id: classify
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          title="$PR_TITLE"
+          prefix=$(printf "%s" "$title" | sed -E "s/^([a-zA-Z]+)(\([^)]*\))?!?:.*/\1/" | tr "[:upper:]" "[:lower:]")
+          case "$prefix" in
+            feat)             badge=new_feature ;;
+            fix)              badge=bugfix ;;
+            perf|refactor)    badge=improvement ;;
+            *)                badge="" ;;
+          esac
+          if [ -z "$badge" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "badge=$badge" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout community repo
+        if: steps.classify.outputs.skip == 'false'
+        uses: actions/checkout@v4
+        with:
+          repository: droplinked/droplinked-community
+          token: ${{ secrets.COMMUNITY_REPO_TOKEN }}
+          ref: main
+          path: community
+
+      - name: Append changelog line
+        if: steps.classify.outputs.skip == 'false'
+        env:
+          BADGE: ${{ steps.classify.outputs.badge }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+          cd community
+          mkdir -p releases/_drafts
+          file=releases/_drafts/UPCOMING.md
+          if [ ! -f "$file" ]; then
+            {
+              echo "# Upcoming release — draft"
+              echo ""
+              echo "Auto-appended by the auto-changelog workflow. Edit before publishing."
+              echo ""
+              echo "---"
+              echo ""
+              echo "## Changes"
+              echo ""
+            } > "$file"
+          fi
+          line="- **[${BADGE}]** ${REPO_NAME}#${PR_NUMBER} — ${PR_TITLE} (by @${PR_AUTHOR})"
+          printf "%s\n" "$line" >> "$file"
+
+      - name: Commit and push
+        if: steps.classify.outputs.skip == 'false'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+          cd community
+          git config user.name  "droplinked-bot"
+          git config user.email "bot@droplinked.com"
+          if git diff --quiet; then exit 0; fi
+          git add releases/_drafts/UPCOMING.md
+          git commit -m "chore(changelog): append entry for ${REPO_NAME}#${PR_NUMBER}"
+          for i in 1 2 3; do
+            if git push origin main; then exit 0; fi
+            git pull --rebase origin main
+          done
+          exit 1


### PR DESCRIPTION
Mirrors the auto-changelog workflow shipped in droplinked-backend#951. On every merged PR with a `feat:` / `fix:` / `perf:` / `refactor:` prefix, appends an entry to droplinked-community/releases/_drafts/UPCOMING.md for the next release post. COMMUNITY_REPO_TOKEN secret already set on this repo.