### PR TITLE
chore(ci): cost-reduction sweep — concurrency + path filters

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -3,6 +3,16 @@ name: Deploy ECS - dev
 on:
   push:
     branches: [ "dev" ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+
+# Serialize deploys per-ref. Never cancel a mid-deploy — let it finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   AWS_REGION: us-east-1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,16 @@ name: Deploy ECS - main
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+
+# Serialize deploys per-ref. Never cancel a mid-deploy — let it finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   AWS_REGION: us-east-1


### PR DESCRIPTION
## Summary

Trim redundant CI minutes on the two ECS deploy workflows by mirroring the pattern shipped in droplinked-backend PR #966.

Per-workflow changes:

- **`dev.yml`** (Deploy ECS - dev) — added `paths-ignore` (`**.md`, `docs/**`, `LICENSE`, `.gitignore`) + `concurrency` group keyed on workflow+ref with `cancel-in-progress: false`.
- **`main.yml`** (Deploy ECS - main) — same treatment.

`cancel-in-progress: false` is deliberate. These are deploys — killing a mid-deploy mid-rollout is worse than letting it finish and being superseded by the next push.

Workflows untouched:
- `auto-changelog.yml` — single PR-closed hook, no build, no artifacts.
- CodeQL (org-level / `.github` repo) — security, out of scope.

## Out of scope

- No artifact-retention cut: this repo does not `upload-artifact`.
- No workflow disables: all three workflows are active within the last 5 days.

## Test plan

- [ ] First push to `dev` after merge still triggers `Deploy ECS - dev`.
- [ ] A docs-only push to `main` (e.g. README typo) is skipped — no ECS deploy.
- [ ] Two back-to-back pushes to `main` queue rather than run in parallel; neither is cancelled mid-flight.
