### PR TITLE
chore(test): adopt mobile-testing-starter Phase 1 scaffolding

### DIFF
--- a/.github/workflows/mobile-test.yml
+++ b/.github/workflows/mobile-test.yml
@@ -1,0 +1,86 @@
+name: Mobile tests
+
+on:
+  pull_request:
+    paths:
+      # Next-ShopFront layout: App Router lives under src/app/**.
+      - 'src/**'
+      - 'public/**'
+      - 'tests/**'
+      - 'helpers/**'
+      - 'playwright.config.ts'
+      - 'package.json'
+      - '.github/workflows/mobile-test.yml'
+  schedule:
+    - cron: '0 6 * * *'   # 06:00 UTC nightly full run
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    name: Smoke (PR gate)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium webkit
+      - name: Wait for Vercel preview URL
+        id: preview
+        # Customize for your deploy target. Two common patterns:
+        #   - Vercel: parse `vercel-deployment-action` output
+        #   - Netlify: wait for `netlify/deploy-preview` status
+        #   - Cloudflare Pages: poll the deployments API
+        # For local-only / no preview deploy, point at PLAYWRIGHT_BASE_URL.
+        run: |
+          # Replace with your project's preview-URL resolution
+          echo "url=${{ secrets.PREVIEW_URL_FALLBACK || 'http://localhost:3000' }}" >> $GITHUB_OUTPUT
+      - name: Run smoke tests
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ steps.preview.outputs.url }}
+        run: npm run test:mobile:smoke
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-smoke
+          path: playwright-report/
+          retention-days: 7
+
+  full:
+    name: Full nightly
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1/4, 2/4, 3/4, 4/4]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+      - name: Run full suite (sharded)
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ secrets.PRODUCTION_URL }}
+          # Optional cloud-device run on nightly only
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+        run: npx playwright test --shard=${{ matrix.shard }}
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ strategy.job-index }}
+          path: playwright-report/
+          retention-days: 14

--- a/BUGS_TO_NEVER_REGRESS.md
+++ b/BUGS_TO_NEVER_REGRESS.md
@@ -1,0 +1,36 @@
+# Bugs to Never Regress
+
+Every mobile-only bug, once fixed, gets a row here AND a regression test in
+`tests/`. The test must fail BEFORE the fix and pass AFTER.
+
+This file is enforced in PR review: "did you add a bug row + test?" If no,
+the bug will return.
+
+## Template
+
+```
+| Date       | Device      | Symptom                              | Fix PR | Test file                              |
+|------------|-------------|--------------------------------------|--------|----------------------------------------|
+| YYYY-MM-DD | iPhone 14   | <user-visible symptom in 1 line>     | #123   | tests/audio-playback.spec.ts::testname |
+```
+
+## Active log
+
+| Date       | Device      | Symptom                                                              | Fix PR | Test file                                          |
+|------------|-------------|----------------------------------------------------------------------|--------|----------------------------------------------------|
+| YYYY-MM-DD | iPhone 14   | MiniPlayer rendered on top of full player on `/story/*`              | #72    | tests/audio-playback.spec.ts::mini-player-suppress |
+| YYYY-MM-DD | iPhone 14   | Wallet didn't reconnect after returning from external wallet app     | #74    | tests/payment-flow.spec.ts::wallet-return-trip     |
+| YYYY-MM-DD | iPhone SE   | Apple Pay button clipped under iOS Safari bottom address bar         | TBD    | tests/bottom-nav-ergonomics.spec.ts::apple-pay-z   |
+| YYYY-MM-DD | Pixel 7     | Service worker failed to register on first visit                     | TBD    | tests/smoke.spec.ts::service-worker-registers      |
+| YYYY-MM-DD | iPad Pro    | Layout assumed phone-or-desktop; tablet got wrong nav                | TBD    | tests/visual-regression.spec.ts::ipad-nav          |
+```
+
+## Rules
+
+1. **One row per bug, even if related.** Don't fold three bugs into one row.
+2. **Test name must match the row.** Grep-ability matters — when the test
+   fails in 6 months, the row tells you the original context.
+3. **Don't delete rows.** If a test is removed (e.g. feature deprecated),
+   strike through the row but keep the history.
+4. **Periodic audit.** Quarterly, scan the log + verify every test still
+   runs and still tests its bug.

--- a/BUGS_TO_NEVER_REGRESS.md
+++ b/BUGS_TO_NEVER_REGRESS.md
@@ -34,3 +34,16 @@ the bug will return.
    strike through the row but keep the history.
 4. **Periodic audit.** Quarterly, scan the log + verify every test still
    runs and still tests its bug.
+
+## Historical seed (mined from git history 2026-05-17)
+
+**History shallow — no qualifying entries seeded.** This repo is a young
+Next.js shopfront fork; the visible `git log` contains only CI / dependency
+/ infra commits (Next.js bump #3, SKALE drop #11, OIDC migration #4, CVE
+overrides #5/#8/#9, auto-changelog #13, CI cost-reduction #14). No
+`fix:`-style commits touching mobile, iOS Safari, Android, viewport,
+safe-area, scroll, modal, drawer, sticky, or responsive surfaces exist
+yet.
+
+The first real mobile bug fix on this repo should be appended here as the
+first row, alongside its regression spec in `tests/`.

--- a/docs/adoption-checklist.md
+++ b/docs/adoption-checklist.md
@@ -1,0 +1,176 @@
+# Adoption Checklist
+
+Ordered steps to onboard a project to the mobile-testing-starter
+framework. Treat each item as a gate — don't skip ahead until the prior
+step is satisfied.
+
+## Phase 1 — Scaffolding (Day 1, <2 hours)
+
+- [ ] **Decide where to nest the suite**:
+      - If the project has NO existing `playwright.config.ts` at the
+        repo root: copy starter files to the repo root.
+      - If the project HAS a root `playwright.config.ts` (e.g. for desktop
+        e2e or Storybook): nest the mobile suite at `tests/mobile/` to
+        avoid colliding with the existing config. The starter's
+        `playwright.config.ts` should be moved to `tests/mobile/`, and
+        its `testDir` adjusted to `./` (relative to its own location).
+        npm scripts then point to the nested config:
+        `playwright test --config=tests/mobile/playwright.config.ts`.
+
+- [ ] **Copy starter files into the project**:
+      ```bash
+      # Flat layout (no existing config)
+      cp -R ~/Desktop/mobile-testing-starter/{tests,helpers,playwright.config.ts,tsconfig.json,BUGS_TO_NEVER_REGRESS.md,docs} <your-project>/
+      cp ~/Desktop/mobile-testing-starter/.github/workflows/mobile-test.yml <your-project>/.github/workflows/
+
+      # Nested layout (existing config — recommended for most multi-suite repos)
+      mkdir -p <your-project>/tests/mobile
+      cp -R ~/Desktop/mobile-testing-starter/{tests,helpers,playwright.config.ts,BUGS_TO_NEVER_REGRESS.md,docs} <your-project>/tests/mobile/
+      mv <your-project>/tests/mobile/tests/* <your-project>/tests/mobile/ && rmdir <your-project>/tests/mobile/tests
+      cp ~/Desktop/mobile-testing-starter/.github/workflows/mobile-test.yml <your-project>/.github/workflows/
+      ```
+
+- [ ] **Install Playwright** (if not already a dep):
+      ```bash
+      npm install -D @playwright/test
+      npx playwright install --with-deps chromium webkit
+      ```
+
+- [ ] **Merge npm scripts** from starter `package.json` into project
+      `package.json`. If the project has existing `test:e2e` or
+      `test:playwright` scripts, namespace yours as `test:mobile:*` to
+      avoid collision. Adjust `--config=` flag if nested.
+
+- [ ] **Customize `playwright.config.ts`**:
+      - `baseURL`: point at preview deploy or production
+      - `testDir`: matches your chosen layout (flat or nested)
+      - Device matrix: cut to what your analytics actually shows
+      - If nested AND a root config exists, add a `testIgnore: ['tests/mobile/**']`
+        to the root config so the root runner doesn't double-execute these
+        files.
+
+- [ ] **Customize `helpers/session.ts`**:
+      - Replace `app:session` (the default `storageKey` param) with your
+        project's actual localStorage session key
+      - Update `DEFAULT_TEST_SESSION` shape to match what your app reads
+
+- [ ] **Customize `helpers/network.ts`**:
+      - Add `custom` mocks for your project's specific external APIs
+      - If your app uses Web3, ALSO add `helpers/web3-network.ts` from the
+        starter and call `mockWeb3Network(page)` alongside `mockExternalServices(page)`
+
+- [ ] **Update `tests/smoke.spec.ts`**: replace `EXAMPLE_PATHS` with your
+      app's actual critical routes (start with 3-4 — `/`, primary content
+      route, conversion route)
+
+- [ ] **Run smoke locally**: `npm run test:mobile:smoke` against your dev
+      server or staging. Confirm tests EXECUTE (most will fail on missing
+      testids; that's expected at this stage)
+
+## Phase 2 — Generate visual regression baselines (Day 1, ~10 min)
+
+- [ ] **Customize `tests/visual-regression.spec.ts`**: set `ROUTES` to your
+      critical paths
+- [ ] **Run baseline generation against a STABLE deploy** (production,
+      not localhost — local renders too inconsistently):
+      ```bash
+      PLAYWRIGHT_BASE_URL=https://your-prod-url npm run test:mobile:update-snapshots
+      ```
+- [ ] **Inspect the generated baselines** under `tests/mobile/__screenshots__/`
+      — open each PNG, verify rendering matches expected production state
+- [ ] **Commit baselines** with a descriptive PR title: `test(mobile):
+      baseline visual regression for {device profiles}`. These become the
+      contract — every future test run diffs against them.
+
+## Phase 3 — Testid audit (Day 1-2)
+
+- [ ] **Run audio playback test**: identify missing testids. Note them down.
+- [ ] **Run payment flow test**: identify missing testids.
+- [ ] **Add testids in a SEPARATE PR** titled `test(mobile): backfill
+      data-testid on critical-path components`. Don't couple scaffold with
+      component changes — review pain.
+- [ ] **Standard testid coverage**: every interactive element + every
+      assertable region. Audit checklist:
+      - Audio player: `audio-player`, `play-button`, `pause-button`,
+        `mini-player`, `seek-bar`, `time-display`
+      - Payment: `tip-button`, `wallet-modal`, `wallet-modal-close`,
+        `wallet-connected-chip`, `tier-cta-{plus,pro,enterprise}`
+      - Auth: `signin-button`, `signup-button`, `account-menu`
+      - Navigation: `mobile-menu-toggle`, `back-button`
+
+## Phase 4 — Customize categories (Week 1)
+
+- [ ] **Drop categories that don't apply** (no payments → delete
+      `payment-flow.spec.ts`; no audio → delete `audio-playback.spec.ts`)
+- [ ] **Add project-specific categories** if needed (streaming →
+      `streaming-playback.spec.ts`; commerce → `cart-checkout.spec.ts`)
+- [ ] **Tighten `CSP_ALLOW`** in `csp-compliance.spec.ts` so legitimate
+      violations don't get suppressed. Useful starting allowlist for prod
+      noise: nothing; tighten as you discover false positives.
+- [ ] **Configure `ROUTES_WITH_BOTTOM_ANCHORED_UI`** in
+      `bottom-nav-ergonomics.spec.ts` with your sticky-bottom elements
+- [ ] **Set perf budgets** if applicable (LCP, First Load JS) — add an
+      optional `performance.spec.ts`
+
+## Phase 5 — CI integration (Week 1)
+
+- [ ] **Customize `.github/workflows/mobile-test.yml`**:
+      - Update the preview-URL extraction step to match your deploy
+        target (Vercel, Netlify, Cloudflare Pages)
+      - Set `secrets.PRODUCTION_URL` to your prod URL
+      - Adjust `paths:` trigger glob to your repo layout
+- [ ] **Verify PR run**: open a draft PR; confirm smoke job runs against
+      preview URL
+- [ ] **Enable required status check** (operator manual step in repo
+      settings → branch protection): add "Smoke (PR gate)" as required
+- [ ] **Set up BrowserStack / Sauce / LambdaTest** for nightly real-device
+      runs (optional, costs money — start without it)
+
+## Phase 6 — BUGS_TO_NEVER_REGRESS adoption (ongoing)
+
+- [ ] **Audit recent mobile bug history**: scan git log + PR titles for
+      the past 30-90 days, identify mobile-only bug fixes
+- [ ] **Backfill rows** in `BUGS_TO_NEVER_REGRESS.md` for each, with bug
+      description + fix PR + a TODO for the regression test
+- [ ] **Write the backfill tests** — at least the 5-10 most painful
+      historical bugs
+- [ ] **Enforce in PR review**: every mobile bug fix PR template must
+      include a checkbox "Added row to BUGS_TO_NEVER_REGRESS.md +
+      regression test"
+- [ ] **Quarterly audit**: prune quarantined tests; refresh device matrix
+      against actual user analytics
+
+## Phase 7 — Maturity (Month 2+)
+
+- [ ] **Track time-to-detect**: instrument a metric for "how long after a
+      mobile bug merged did the test catch it"; aim for "before merge"
+- [ ] **Visual regression review queue**: baseline updates should appear
+      in PR with clear before/after; reviewers must approve
+- [ ] **Performance baselines**: lock First Load JS per route; alert on
+      >5% regression
+- [ ] **Cross-team adoption**: if multiple frontend repos, copy starter
+      into each. Framework is repo-agnostic.
+- [ ] **Iterate the framework itself**: as you find gaps, update the
+      starter AND back-port improvements to projects that already adopted
+
+---
+
+## Common pitfalls during adoption
+
+- **Skipping the testid audit**: tests will be brittle from day 1. Pay
+  the cost upfront.
+- **Allowing `waitForTimeout` "just to get started"**: it never gets
+  fixed. Reject in code review.
+- **Over-mocking**: if you mock everything, tests stop reflecting
+  reality. Mock external services + sensitive operations; let internal
+  navigation hit real handlers.
+- **Visual regression baselines drifting silently**: enforce that
+  baseline updates need a human approver, ideally a designer.
+- **No required status check**: without it, devs will merge red and the
+  suite becomes decorative.
+- **Generating baselines from localhost**: font rendering, image loading,
+  and async hydration vary between local and prod. Always baseline from
+  production or a stable preview deploy.
+- **Coupling scaffold and testid PRs**: makes review painful. Always
+  ship the framework scaffold first, then a separate PR adds testids
+  across components.

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -1,0 +1,225 @@
+# Mobile Regression Testing Framework
+
+Framework-agnostic playbook for catching mobile-only regressions before
+production. Tuned for SPAs, MPAs, and JS-heavy sites where bugs surface
+differently on iOS Safari, Android Chrome, and tablets than they do on
+desktop.
+
+## Why this exists
+
+Mobile-only regressions are the most expensive class of bug:
+1. They survive desktop-only testing
+2. They surface late, often days after merge
+3. They affect the highest-intent users (mobile = active engagement)
+4. They compound — one broken interaction kills the conversion funnel
+
+This framework codifies the patterns that catch them BEFORE production.
+
+---
+
+## Core principles
+
+1. **Real-device emulation, not desktop-shrunk-viewports.** iOS Safari has
+   unique behaviors (suspended JS on tab blur, viewport recalculation on
+   scroll, third-party cookie blocking, autoplay restrictions) that no
+   amount of Chrome DevTools "responsive mode" reproduces. Use Playwright's
+   device profiles or a real-device cloud.
+
+2. **Test the bug-shaped paths.** Every mobile bug you've shipped becomes
+   a regression test. Maintain a `BUGS_TO_NEVER_REGRESS.md` and require a
+   test entry for each historical fix.
+
+3. **Speed gates merges; thoroughness gates releases.** Two-tier suite:
+   - Smoke (<60s) on every PR; blocks merge
+   - Full (5-15min) nightly on production; alerts but doesn't block
+
+4. **Deterministic or quarantined.** Flaky tests destroy trust faster than
+   they catch bugs. A test that flakes 3× in a week gets `.skip` with a
+   TODO. Zero tolerance for `sleep(N)` waits.
+
+5. **Stable selectors only.** `data-testid` is a contract; CSS classes are
+   an implementation detail. Don't couple tests to styling.
+
+6. **Visual regression as last-line defense.** Screenshot diffs catch
+   layout breaks no semantic assertion would. Threshold at 2% pixel diff;
+   require human approval for baseline updates.
+
+---
+
+## Device + browser matrix
+
+Minimum viable matrix (~95% mobile coverage):
+
+| Profile                       | Why                                                                          |
+|-------------------------------|------------------------------------------------------------------------------|
+| **iPhone 14**                 | Modern iOS Safari, default                                                   |
+| **iPhone SE (3rd gen)**       | Smallest modern iOS viewport — catches cramped text and CTAs                 |
+| **iPhone 14 Pro Max**         | Largest iOS viewport — catches "centered content drifts"                     |
+| **Pixel 7**                   | Modern Android Chrome — often diverges from iOS on Web APIs                  |
+| **iPad Pro 11"**              | Tablet — common regression source                                            |
+
+Optional tier-2 (high-stakes flows):
+
+| Profile                       | Why                                            |
+|-------------------------------|------------------------------------------------|
+| **Samsung Galaxy S22**        | Samsung Internet browser quirks                |
+| **iPhone 11**                 | Older iOS — still ~15% of iOS users            |
+| **Android Tablet**            | Catches "we tested iPad" assumptions           |
+
+Full matrix nightly; iPhone 14 + Pixel 7 on every PR.
+
+---
+
+## Test category taxonomy
+
+Organize tests into categories so coverage gaps are obvious. Each
+category gets its own `.spec.ts`:
+
+### 1. Smoke
+- Page loads without JS errors
+- Critical paths return 200 + render <3s on slow 3G
+- No console errors in first 5s
+- Goal: catch deploy disasters in <60s
+
+### 2. Audio / video playback
+- Play/pause synchronous (no stuck loading)
+- Media Session API metadata populated
+- Audio resumes after visibility-change → blur → return
+- Bluetooth-headset / AirPods hardware key handling
+- Goal: catch "audio dies on iOS" class
+
+### 3. Payment / wallet flows
+- Stripe / PayPal / Apple Pay buttons render above iOS bottom bar
+- Wallet modals (WalletConnect, Coinbase, MetaMask) don't clip
+- Return-trip from external wallet app preserves state
+- **DO NOT test real transactions** — mock the provider; assert UI intent
+- Goal: catch revenue-blocking regressions
+
+### 4. CSP / security headers
+- No CSP violations on critical pages
+- Cookies `SameSite=Strict` + `Secure` where intended
+- No mixed-content warnings
+- Goal: prevent CSP misconfig from breaking pages silently
+
+### 5. Service Worker / PWA
+- SW registers on first visit
+- Offline state shows correct banner
+- Install prompt renders on Android, hidden on iOS
+- Goal: catch SW + caching regressions
+
+### 6. Bottom-nav / safe-area ergonomics
+- No critical UI hides under iOS Safari's bottom bar
+- `env(safe-area-inset-bottom)` respected on notched devices
+- Modals don't trap users (close reachable)
+- Goal: catch iPhone-specific layout breaks
+
+### 7. Visual regression
+- Screenshot per (route × device) on first-paint
+- `maxDiffPixelRatio: 0.02`
+- Baselines committed; updates require review
+- Goal: catch unintended visual breaks
+
+### 8. Performance budget (optional)
+- First Load JS per route under N KiB
+- LCP <2.5s on slow 3G
+- Goal: prevent perf regressions
+
+---
+
+## Architecture standards
+
+### Selector contract
+
+```ts
+// ✅ Good — stable, refactor-proof
+await page.locator('[data-testid="play-button"]').click();
+
+// ❌ Bad — couples test to styling
+await page.locator('.btn-primary.large').click();
+
+// ❌ Bad — fragile to copy changes
+await page.getByRole('button', { name: 'Play now' }).click();
+```
+
+### State setup
+
+Don't authenticate via UI flow. Set state directly:
+
+```ts
+await page.addInitScript(() => {
+  localStorage.setItem('app:session', JSON.stringify({ token: 'test-...' }));
+});
+```
+
+For wallets, mock the provider — see `helpers/wallet-mock.ts`.
+
+### Network isolation
+
+Mock external services. Never hit real APIs:
+
+```ts
+await page.route('https://api.stripe.com/**', async (route) => {
+  await route.fulfill({ status: 200, body: JSON.stringify(MOCK) });
+});
+```
+
+### Determinism
+
+```ts
+// ✅ Wait for the thing
+await page.waitForResponse((r) => r.url().includes('/api/article'));
+await page.waitForLoadState('networkidle');
+
+// ❌ Sleep
+await page.waitForTimeout(2000);
+```
+
+If a test needs `waitForTimeout`, the underlying behavior is racy. Fix the
+race, not the test.
+
+---
+
+## Anti-patterns to refuse
+
+| Anti-pattern                          | Why it's wrong                            | Do instead                                       |
+|---------------------------------------|-------------------------------------------|--------------------------------------------------|
+| `waitForTimeout(N)`                   | Race conditions disguised                 | `waitForSelector` / `waitForResponse`            |
+| CSS class selectors                   | Brittle to refactors                      | `data-testid`                                    |
+| Real-API calls                        | Slow, non-deterministic, costs money      | Mock with `page.route`                           |
+| Real authentication                   | Slow, leaks creds                         | Inject session into localStorage via `addInitScript` |
+| Real transactions                     | Irreversible, costly                      | Mock wallet provider; assert UI intent           |
+| One giant test                        | Failure tells you nothing                 | One test per behavior                            |
+| Disabled flaky tests left to rot      | Tests bitrot; coverage silently degrades  | Quarantine with TODO + 2-week kill date          |
+| Skipping mobile because "desktop covers it" | Desktop ≠ mobile                    | Two separate suites                              |
+| Testing implementation, not behavior  | Tests break on refactor                   | Test what the user sees / does                   |
+| No visual regression                  | Layout breaks ship                        | Screenshot diffs with low threshold              |
+| Treating `begin_nested() + flush()` as durable | SAVEPOINTs only protect within the outer txn; if the outer rolls back, the row vanishes — but the side effect (alert sent, webhook fired, email delivered) already happened. Test catches this with: assert state survives outer-txn rollback. | For idempotency/dedup writes that gate side effects, commit in an INDEPENDENT session. Test it by deliberately rolling back the caller's txn after the write and verifying the dedup row still exists. |
+
+---
+
+## Success metrics
+
+A project has successfully adopted the framework when:
+1. Every merged PR that touches user-facing code runs smoke against a
+   preview deploy and blocks on failure
+2. Every mobile-only bug since adoption has a regression test
+3. No `sleep` / `waitForTimeout` exists in the suite
+4. Quarantined test count stays under 5% of total
+5. Time-to-detect a mobile regression dropped from "days after deploy" to
+   "before merge"
+
+---
+
+## Customization guide
+
+When applying to a specific project:
+
+| Section                  | Customization                                                              |
+|--------------------------|----------------------------------------------------------------------------|
+| Device matrix            | Cut/add based on actual user analytics                                     |
+| Test categories          | Drop categories that don't apply (no payments? drop §3)                    |
+| Smoke suite size         | Target <60s wall-clock on CI                                               |
+| Selector strategy        | If codebase uses `aria-label` consistently, fold that into the contract    |
+| Mock library             | Use `msw` if already present; otherwise Playwright's `page.route`          |
+| CI provider              | Translate workflow YAML to GitLab CI / CircleCI / Buildkite                |
+| Visual regression hosting| Percy / Chromatic / Argos if budget allows; otherwise local baselines      |

--- a/helpers/network.ts
+++ b/helpers/network.ts
@@ -1,0 +1,127 @@
+import type { Page, Route } from '@playwright/test';
+
+/**
+ * Stub external APIs so tests are deterministic, fast, and don't cost money.
+ *
+ * Call once at test setup: `await mockExternalServices(page)`.
+ * Customize the URL patterns + responses to match your app's external deps.
+ */
+
+export interface MockResponses {
+  stripe?: any;
+  paypal?: any;
+  sentry?: any;
+  analytics?: any;
+  custom?: Array<{ url: string | RegExp; response: any; status?: number }>;
+}
+
+export async function mockExternalServices(
+  page: Page,
+  responses: MockResponses = {},
+): Promise<void> {
+  // ─── Stripe ───
+  await page.route(/api\.stripe\.com/, async (route: Route) => {
+    const body = responses.stripe ?? {
+      id: 'pi_test_mock',
+      status: 'requires_payment_method',
+      client_secret: 'pi_test_mock_secret',
+    };
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+
+  // ─── PayPal ───
+  await page.route(/api[-.]paypal\.com|paypalobjects\.com/, async (route: Route) => {
+    const body = responses.paypal ?? { ack: 'success' };
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+
+  // ─── Sentry ───
+  // Drop event posts entirely — tests should NOT pollute Sentry quota.
+  await page.route(/sentry\.io|ingest\.sentry\.io/, async (route: Route) => {
+    await route.fulfill({ status: 200, body: '' });
+  });
+
+  // ─── Analytics (Vercel, GA, Mixpanel, PostHog, Segment) ───
+  await page.route(
+    /vitals\.vercel-(insights|analytics)\.com|google-analytics\.com|googletagmanager\.com|mixpanel\.com|posthog\.com|segment\.io/,
+    async (route: Route) => {
+      await route.fulfill({ status: 200, body: '' });
+    },
+  );
+
+  // ─── Droplinked apiv3 backend (Next-ShopFront talks to /api/v1/**) ───
+  // Production hosts: apiv3.droplinked.com / apiv3dev.droplinked.com.
+  // Mock by default to a generic success envelope so smoke specs don't depend
+  // on live backend availability. Per-spec overrides should be passed via
+  // `responses.custom` to assert specific payloads (cart, product, shipping).
+  await page.route(
+    /(apiv3|apiv3dev)\.droplinked\.com\/api\/v1\//,
+    async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, data: null }),
+      });
+    },
+  );
+
+  // ─── Coinbase Commerce ───
+  // Wallet-connection lib may post to api.commerce.coinbase.com on checkout.
+  await page.route(/api\.commerce\.coinbase\.com/, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: { code: 'mock-coinbase-charge' } }),
+    });
+  });
+
+  // ─── Next-ShopFront internal API routes ───
+  // The Next.js app exposes `/api/cart/**`, `/api/checkout/**`,
+  // `/api/checkout/stripe/**`, `/api/checkout/shipping-rates/**`. We
+  // intentionally do NOT route these here — specs that need deterministic
+  // cart/checkout payloads should add `responses.custom` overrides; otherwise
+  // requests fall through to the local route handlers.
+
+  // ─── Custom routes (project-specific) ───
+  for (const custom of responses.custom ?? []) {
+    await page.route(custom.url, async (route: Route) => {
+      await route.fulfill({
+        status: custom.status ?? 200,
+        contentType: 'application/json',
+        body: JSON.stringify(custom.response),
+      });
+    });
+  }
+}
+
+/**
+ * Throttle network to slow-3G — for performance-aware tests.
+ *
+ * Playwright doesn't expose network conditions directly on the page; use
+ * CDP for Chromium-based projects. For WebKit, skip + document.
+ */
+export async function throttleSlow3G(page: Page): Promise<void> {
+  const browserName = page.context().browser()?.browserType().name();
+  if (browserName !== 'chromium') {
+    console.warn('[throttle] slow-3G throttling only supported on chromium; skipping');
+    return;
+  }
+  const client = await page.context().newCDPSession(page);
+  await client.send('Network.emulateNetworkConditions', {
+    offline: false,
+    downloadThroughput: (500 * 1024) / 8,
+    uploadThroughput: (500 * 1024) / 8,
+    latency: 400,
+  });
+}
+
+/**
+ * Simulate offline mode (Service Worker testing).
+ */
+export async function goOffline(page: Page): Promise<void> {
+  await page.context().setOffline(true);
+}
+
+export async function goOnline(page: Page): Promise<void> {
+  await page.context().setOffline(false);
+}

--- a/helpers/session.ts
+++ b/helpers/session.ts
@@ -1,0 +1,99 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Next-ShopFront note:
+ * TODO(mobile-test): identify the canonical auth/session contract for the
+ * storefront. Audit found NO `localStorage.setItem` calls — only a single
+ * `localStorage.clear()` on 401 in `src/services/fetchConfig.ts`. The
+ * storefront authenticates outbound requests via the `x-shop-id` header
+ * sourced from `API_KEY` (build-time env). User identity, if any, likely
+ * arrives via Droplinked apiv3 cookie or a wallet-connection state managed
+ * by `@droplinked/wallet-connection`. Confirm the contract before relying
+ * on `injectSession` in specs; until then, anonymous storefront flows
+ * should NOT call this helper and should treat the suite as unauthenticated.
+ *
+ * Inject auth state into the page BEFORE any user code runs.
+ *
+ * Don't authenticate via UI flow — too slow + leaks creds. Set state
+ * directly via addInitScript so localStorage is populated by the time
+ * the page hydrates.
+ *
+ * Customize the storage key + shape to match your app's session contract.
+ */
+
+export interface MockSession {
+  token: string;
+  userId: string;
+  email?: string;
+  expiresAt?: string; // ISO timestamp
+  /**
+   * Free-form metadata for app-specific extensions (tier, flags, locale).
+   * The starter never reads from here — your project does.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+export const DEFAULT_TEST_SESSION: MockSession = {
+  token: 'test-token-do-not-use-in-prod',
+  userId: 'test-user-mobile-regression',
+  email: 'test@example.invalid',
+  expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+  metadata: {},
+};
+
+/**
+ * Standard listener/user session injection.
+ *
+ * Replace `app:session` with your project's actual localStorage key.
+ */
+export async function injectSession(
+  page: Page,
+  session: Partial<MockSession> = {},
+  // TODO(mobile-test): replace placeholder key once auth contract confirmed.
+  // No localStorage.setItem calls found in src/; storefront uses x-shop-id
+  // header from build-time API_KEY. Wallet-connection state shape unknown.
+  storageKey: string = 'next-shopfront:session',
+): Promise<void> {
+  const merged = {
+    ...DEFAULT_TEST_SESSION,
+    ...session,
+    metadata: { ...DEFAULT_TEST_SESSION.metadata, ...session.metadata },
+  };
+  await page.addInitScript(({ key, value }) => {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  }, { key: storageKey, value: merged });
+}
+
+/**
+ * Admin-scoped session for admin route testing.
+ *
+ * Most apps have a separate "admin" gate. Inject the admin token under
+ * the project's canonical key.
+ */
+export async function injectAdminSession(
+  page: Page,
+  adminToken: string = 'test-admin-token',
+  storageKey: string = 'app:admin-session',
+): Promise<void> {
+  await page.addInitScript(({ key, value }) => {
+    window.localStorage.setItem(key, JSON.stringify({
+      token: value,
+      adminAt: new Date().toISOString(),
+    }));
+  }, { key: storageKey, value: adminToken });
+}
+
+/**
+ * Logged-out state — useful for testing public flows.
+ *
+ * Clears any session keys the app might have set. Customize SESSION_KEYS
+ * to match your project's canonical session-key list.
+ */
+export async function clearSession(
+  page: Page,
+  sessionKeys: string[] = ['app:session', 'app:admin-session'],
+): Promise<void> {
+  await page.addInitScript((keys) => {
+    keys.forEach((k) => window.localStorage.removeItem(k));
+  }, sessionKeys);
+}

--- a/helpers/sse.ts
+++ b/helpers/sse.ts
@@ -1,0 +1,117 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Server-Sent Events (SSE) test helpers.
+ *
+ * SSE streams are common for live state push (playback state, notifications,
+ * collaborative cursors). Don't make tests depend on the real SSE endpoint —
+ * intercept and inject synthetic events on demand.
+ *
+ * Pattern:
+ *   1. Install the interceptor BEFORE navigation
+ *   2. Navigate; the app opens its EventSource and hits the mock
+ *   3. Push synthetic events with pushEvent()
+ *   4. Assert UI reaction
+ */
+
+export interface SseInterceptor {
+  /**
+   * Push a synthetic SSE event into all listeners on the page.
+   * Mirrors the browser's EventSource event delivery contract.
+   */
+  pushEvent: (event: { name?: string; data: unknown; id?: string }) => Promise<void>;
+  /**
+   * Close all open SSE streams (simulates server-side close or net failure).
+   */
+  closeAll: () => Promise<void>;
+}
+
+/**
+ * Intercept any EventSource opened during the page's lifetime and route it
+ * through a controlled in-page bus instead of hitting the network.
+ *
+ * Pass a URL pattern (string substring or RegExp) to scope which streams
+ * get intercepted. Omit to intercept all EventSource opens.
+ */
+export async function interceptSse(
+  page: Page,
+  urlPattern?: string | RegExp,
+): Promise<SseInterceptor> {
+  await page.addInitScript(({ pattern }) => {
+    const w = window as any;
+    if (w.__sseTestBus) return; // idempotent
+    w.__sseTestBus = {
+      listeners: new Set<EventSource>(),
+      match(url: string): boolean {
+        if (!pattern) return true;
+        if (pattern.kind === 'string') return url.includes(pattern.value);
+        if (pattern.kind === 'regex') return new RegExp(pattern.value, pattern.flags).test(url);
+        return false;
+      },
+    };
+
+    const NativeEventSource = w.EventSource;
+    class MockEventSource extends EventTarget {
+      url: string;
+      readyState = 0;
+      withCredentials = false;
+      onopen: ((e: Event) => void) | null = null;
+      onmessage: ((e: MessageEvent) => void) | null = null;
+      onerror: ((e: Event) => void) | null = null;
+      constructor(url: string, _init?: EventSourceInit) {
+        super();
+        this.url = url;
+        if (!w.__sseTestBus.match(url)) {
+          // Not in pattern — fall back to real EventSource
+          return new NativeEventSource(url, _init) as any;
+        }
+        w.__sseTestBus.listeners.add(this as any);
+        // Open asynchronously to mimic real EventSource
+        queueMicrotask(() => {
+          this.readyState = 1;
+          const e = new Event('open');
+          this.onopen?.(e);
+          this.dispatchEvent(e);
+        });
+      }
+      close() {
+        this.readyState = 2;
+        w.__sseTestBus.listeners.delete(this as any);
+      }
+    }
+    w.EventSource = MockEventSource;
+  }, {
+    pattern: !urlPattern
+      ? null
+      : typeof urlPattern === 'string'
+      ? { kind: 'string', value: urlPattern }
+      : { kind: 'regex', value: urlPattern.source, flags: urlPattern.flags },
+  });
+
+  return {
+    pushEvent: async (event) => {
+      await page.evaluate(({ name, data, id }) => {
+        const w = window as any;
+        const payload = typeof data === 'string' ? data : JSON.stringify(data);
+        for (const es of w.__sseTestBus.listeners) {
+          const evt = new MessageEvent(name || 'message', { data: payload, lastEventId: id });
+          if (name && name !== 'message') {
+            es.dispatchEvent(evt);
+          } else {
+            es.onmessage?.(evt);
+            es.dispatchEvent(evt);
+          }
+        }
+      }, event);
+    },
+    closeAll: async () => {
+      await page.evaluate(() => {
+        const w = window as any;
+        for (const es of w.__sseTestBus.listeners) {
+          es.close();
+          es.onerror?.(new Event('error'));
+        }
+      });
+    },
+  };
+}

--- a/helpers/testid.ts
+++ b/helpers/testid.ts
@@ -1,0 +1,26 @@
+import type { Page, Locator } from '@playwright/test';
+
+/**
+ * Typed data-testid helper.
+ *
+ * Mandate data-testid for all assertions. Classes and copy change with
+ * refactors; testids are stable contracts. This helper just gives you a
+ * one-line selector and removes the temptation to fall back to CSS.
+ *
+ * Usage:
+ *   await byTestId(page, 'play-button').click();
+ */
+
+export function byTestId(page: Page, id: string): Locator {
+  return page.locator(`[data-testid="${id}"]`);
+}
+
+/**
+ * Variant that supports nested testid scoping.
+ *
+ *   const modal = byTestId(page, 'wallet-modal');
+ *   await byTestIdWithin(modal, 'close-button').click();
+ */
+export function byTestIdWithin(scope: Locator, id: string): Locator {
+  return scope.locator(`[data-testid="${id}"]`);
+}

--- a/helpers/wallet-mock.ts
+++ b/helpers/wallet-mock.ts
@@ -1,0 +1,94 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Mock window.ethereum + WalletConnect-style providers.
+ *
+ * Tests assert UI intent only — DO NOT execute real transactions. The
+ * mock returns canned responses for the common provider methods.
+ *
+ * Inject BEFORE page navigation so wagmi/ethers/etc. see the provider
+ * during their boot phase.
+ */
+
+export interface MockWalletOptions {
+  address?: string;
+  chainId?: number; // hex string in actual provider; we accept number for ergonomics
+  shouldReject?: boolean; // simulate user-rejected transaction
+}
+
+const DEFAULT_ADDRESS = '0x0000000000000000000000000000000000000001';
+const DEFAULT_CHAIN_ID = 8453; // Base mainnet
+
+/**
+ * Inject a mock EIP-1193 provider as window.ethereum.
+ */
+export async function injectMockWallet(
+  page: Page,
+  options: MockWalletOptions = {},
+): Promise<void> {
+  const {
+    address = DEFAULT_ADDRESS,
+    chainId = DEFAULT_CHAIN_ID,
+    shouldReject = false,
+  } = options;
+
+  await page.addInitScript(({ address, chainId, shouldReject }) => {
+    const chainIdHex = `0x${chainId.toString(16)}`;
+    const listeners = new Map<string, Array<(...args: any[]) => void>>();
+
+    const provider = {
+      isMetaMask: true,
+      isCoinbaseWallet: false,
+      isWalletConnect: false,
+      chainId: chainIdHex,
+      selectedAddress: address,
+
+      async request({ method, params }: { method: string; params?: any[] }) {
+        if (shouldReject) {
+          throw { code: 4001, message: 'User rejected the request.' };
+        }
+        switch (method) {
+          case 'eth_chainId':
+            return chainIdHex;
+          case 'eth_accounts':
+          case 'eth_requestAccounts':
+            return [address];
+          case 'wallet_switchEthereumChain':
+            return null;
+          case 'personal_sign':
+            return '0x' + '00'.repeat(65);
+          case 'eth_sendTransaction':
+            return '0x' + 'aa'.repeat(32);
+          case 'eth_signTypedData_v4':
+            return '0x' + 'bb'.repeat(65);
+          default:
+            console.warn('[mock-wallet] unmocked method:', method);
+            return null;
+        }
+      },
+
+      on(event: string, handler: (...args: any[]) => void) {
+        if (!listeners.has(event)) listeners.set(event, []);
+        listeners.get(event)!.push(handler);
+      },
+
+      removeListener(event: string, handler: (...args: any[]) => void) {
+        const list = listeners.get(event);
+        if (!list) return;
+        const idx = list.indexOf(handler);
+        if (idx >= 0) list.splice(idx, 1);
+      },
+    };
+
+    (window as any).ethereum = provider;
+  }, { address, chainId, shouldReject });
+}
+
+/**
+ * Inject a "no wallet" state — for testing the "install MetaMask" CTA.
+ */
+export async function injectNoWallet(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    delete (window as any).ethereum;
+  });
+}

--- a/helpers/web3-network.ts
+++ b/helpers/web3-network.ts
@@ -1,0 +1,126 @@
+import type { Page, Route } from '@playwright/test';
+
+/**
+ * Web3-specific network mocks.
+ *
+ * Use ALONGSIDE helpers/network.ts (which handles Stripe/Sentry/analytics).
+ * This file specifically handles:
+ *   - JSON-RPC nodes (Alchemy, Infura, public RPCs)
+ *   - WalletConnect relay (wss://relay.walletconnect.com)
+ *   - Coinbase Wallet SDK + Smart Wallet (keys.coinbase.com, go.cb-w.com)
+ *   - Reown / Web3Modal bridges
+ *   - Token metadata APIs
+ *
+ * Use only on Web3-enabled projects; omit for Web2 SaaS.
+ */
+
+export interface Web3MockOptions {
+  chainId?: number;
+  blockNumber?: number;
+  defaultBalanceWei?: string;
+  /**
+   * Custom JSON-RPC method overrides.
+   * Key: method name (e.g. 'eth_call'), value: response or function.
+   */
+  rpcOverrides?: Record<string, unknown | ((params: any) => unknown)>;
+}
+
+const DEFAULT_CHAIN_ID = 8453; // Base mainnet
+const DEFAULT_BLOCK = 0x1000000;
+
+export async function mockWeb3Network(
+  page: Page,
+  options: Web3MockOptions = {},
+): Promise<void> {
+  const chainId = options.chainId ?? DEFAULT_CHAIN_ID;
+  const chainIdHex = `0x${chainId.toString(16)}`;
+  const blockHex = `0x${(options.blockNumber ?? DEFAULT_BLOCK).toString(16)}`;
+  const balanceHex = options.defaultBalanceWei ?? '0x16345785d8a0000'; // 0.1 ETH
+
+  const defaultRpc: Record<string, unknown> = {
+    eth_chainId: chainIdHex,
+    eth_blockNumber: blockHex,
+    eth_gasPrice: '0x3b9aca00',
+    eth_getBalance: balanceHex,
+    eth_call: '0x',
+    eth_estimateGas: '0x5208',
+    eth_sendRawTransaction: '0x' + 'aa'.repeat(32),
+    eth_getTransactionCount: '0x0',
+    eth_getCode: '0x',
+    net_version: String(chainId),
+  };
+
+  // ─── JSON-RPC endpoints (Alchemy, Infura, public RPCs, base.org) ───
+  await page.route(
+    /(alchemy|infura|alchemyapi|drpc\.org|publicnode\.com|base\.org|mainnet\.base\.org|sepolia\.base\.org|ankr\.com|quiknode|llamarpc|cloudflare-eth)/i,
+    async (route: Route) => {
+      const req = route.request();
+      if (req.method() !== 'POST') {
+        await route.fulfill({ status: 200, body: '{}' });
+        return;
+      }
+      let body: any = {};
+      try {
+        body = JSON.parse(req.postData() ?? '{}');
+      } catch {/* ignore */}
+      const { method, id = 1 } = body;
+      const override = options.rpcOverrides?.[method];
+      const result = typeof override === 'function' ? override(body.params) : (override ?? defaultRpc[method]);
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ jsonrpc: '2.0', id, result: result ?? null }),
+      });
+    },
+  );
+
+  // ─── WalletConnect relay (HTTP polyfill — WSS is more complex; see note below) ───
+  await page.route(
+    /relay\.walletconnect\.(com|org)|verify\.walletconnect\.(com|org)|pulse\.walletconnect/i,
+    async (route: Route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+    },
+  );
+
+  // ─── Coinbase Wallet + Smart Wallet ───
+  await page.route(
+    /(keys\.coinbase\.com|go\.cb-w\.com|api\.developer\.coinbase\.com|api\.wallet\.coinbase\.com)/i,
+    async (route: Route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+    },
+  );
+
+  // ─── Reown / Web3Modal cloud ───
+  await page.route(
+    /(cloud\.reown\.com|api\.web3modal|secure\.web3modal|secure-mobile\.walletconnect)/i,
+    async (route: Route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+    },
+  );
+
+  // ─── Token metadata APIs (CoinGecko, etc) ───
+  await page.route(
+    /(coingecko\.com|coinmarketcap\.com|defillama\.com)/i,
+    async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ prices: { usd: 1.0 } }),
+      });
+    },
+  );
+}
+
+/**
+ * NOTE on WalletConnect WSS:
+ *
+ * Playwright can't intercept native WebSocket traffic the same way it routes
+ * HTTP. If your tests need to interact with WalletConnect's relay protocol,
+ * the cleaner approach is to mock at the SDK boundary (the wagmi/viem connector
+ * layer) rather than the wire. The HTTP polyfill above handles WalletConnect's
+ * verify/pulse HTTP endpoints — usually enough for "wallet modal opens, user
+ * cancels" coverage.
+ *
+ * For deeper WC integration tests, use a real testnet wallet + a real WC relay
+ * in a dedicated e2e suite (not the mobile regression suite).
+ */

--- a/package.json
+++ b/package.json
@@ -7,7 +7,15 @@
     "build": "next build",
     "start": "next start",
     "prod": "next start -p 80",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:mobile": "playwright test --config=playwright.config.ts",
+    "test:mobile:smoke": "playwright test --config=playwright.config.ts smoke",
+    "test:mobile:ui": "playwright test --config=playwright.config.ts --ui",
+    "test:mobile:headed": "playwright test --config=playwright.config.ts --headed",
+    "test:mobile:debug": "playwright test --config=playwright.config.ts --debug",
+    "test:mobile:update-snapshots": "playwright test --config=playwright.config.ts --update-snapshots",
+    "test:mobile:report": "playwright show-report",
+    "test:mobile:install": "playwright install --with-deps chromium webkit"
   },
   "dependencies": {
     "@droplinked-dev/ui": "^1.2.11",
@@ -47,6 +55,7 @@
     "zustand": "^4.5.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.48.0",
     "@svgr/webpack": "^8.1.0",
     "@types/node": "^20",
     "@types/react": "^18",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,87 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Mobile regression testing config.
+ *
+ * Two-tier model:
+ *   - Smoke: tests/smoke.spec.ts — <60s, runs on every PR, blocks merge
+ *   - Full:  entire tests/ folder × device matrix — nightly
+ *
+ * Customize: baseURL, device matrix, reporter, timeouts.
+ */
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
+const IS_CI = !!process.env.CI;
+const USE_BROWSERSTACK = !!process.env.BROWSERSTACK_USERNAME && !!process.env.BROWSERSTACK_ACCESS_KEY;
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: IS_CI,
+  retries: IS_CI ? 2 : 0,
+  workers: IS_CI ? 4 : undefined,
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0.02,
+      threshold: 0.2,
+    },
+  },
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: 'playwright-report' }],
+    IS_CI ? ['github'] : ['null'],
+  ].filter(Boolean) as any,
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 10_000,
+    navigationTimeout: 15_000,
+  },
+
+  projects: [
+    // ─── Core matrix — runs on every PR via smoke gate, full nightly ───
+    {
+      name: 'iPhone 14 Safari',
+      use: { ...devices['iPhone 14'] },
+    },
+    {
+      name: 'iPhone SE Safari (small viewport)',
+      use: { ...devices['iPhone SE'] },
+    },
+    {
+      name: 'iPhone 14 Pro Max Safari (large viewport)',
+      use: { ...devices['iPhone 14 Pro Max'] },
+    },
+    {
+      name: 'Pixel 7 Chrome',
+      use: { ...devices['Pixel 7'] },
+    },
+    {
+      name: 'iPad Pro 11 Safari',
+      use: { ...devices['iPad Pro 11'] },
+    },
+
+    // ─── Tier-2 matrix — nightly only ───
+    // Uncomment when you have analytics showing users on these devices
+    // {
+    //   name: 'Galaxy S22 Chrome',
+    //   use: { ...devices['Galaxy S9+'], userAgent: SAMSUNG_INTERNET_UA },
+    // },
+    // {
+    //   name: 'iPhone 11 Safari (older iOS)',
+    //   use: { ...devices['iPhone 11'] },
+    // },
+  ],
+
+  // Optional: spin up your dev server before running locally
+  // webServer: {
+  //   command: 'npm run dev',
+  //   url: 'http://localhost:3000',
+  //   reuseExistingServer: !IS_CI,
+  //   timeout: 120_000,
+  // },
+});

--- a/tests/audio-playback.spec.ts
+++ b/tests/audio-playback.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+import { mockExternalServices } from '../helpers/network';
+import { injectSession } from '../helpers/session';
+import { byTestId } from '../helpers/testid';
+
+/**
+ * Audio playback — covers the "audio mysteriously dies on iOS" class of
+ * bugs. iOS Safari has unique constraints:
+ *   - Autoplay blocked until user gesture
+ *   - Audio suspended on visibilitychange → hidden
+ *   - Media Session API for lock-screen / Bluetooth headset control
+ *   - MiniPlayer must not stack with full player
+ *
+ * CUSTOMIZE: replace SAMPLE_STORY_PATH and the testids below to match
+ * your app's audio player contract.
+ */
+
+const SAMPLE_STORY_PATH = process.env.SAMPLE_STORY_PATH ?? '/story/sample';
+
+test.describe('Audio playback', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockExternalServices(page);
+    await injectSession(page);
+  });
+
+  test('player renders with poster + play button', async ({ page }) => {
+    await page.goto(SAMPLE_STORY_PATH);
+    await expect(byTestId(page, 'audio-player')).toBeVisible();
+    await expect(byTestId(page, 'play-button')).toBeVisible();
+  });
+
+  test('play → pause is synchronous (no stuck loading state)', async ({ page }) => {
+    await page.goto(SAMPLE_STORY_PATH);
+    const playBtn = byTestId(page, 'play-button');
+    await playBtn.click();
+
+    // Audio should report not-paused within 2s
+    await expect.poll(
+      async () => await page.evaluate(() => document.querySelector('audio')?.paused ?? true),
+      { timeout: 2_000 },
+    ).toBe(false);
+
+    const pauseBtn = byTestId(page, 'pause-button');
+    await pauseBtn.click();
+
+    // Pause should be immediate
+    await expect.poll(
+      async () => await page.evaluate(() => document.querySelector('audio')?.paused ?? false),
+      { timeout: 500 },
+    ).toBe(true);
+  });
+
+  test('MiniPlayer is suppressed on /story/* (no double player)', async ({ page }) => {
+    await page.goto(SAMPLE_STORY_PATH);
+    // Full player visible, mini player hidden
+    await expect(byTestId(page, 'audio-player')).toBeVisible();
+    await expect(byTestId(page, 'mini-player')).not.toBeVisible();
+  });
+
+  test('audio resumes after visibility-change → hidden → visible', async ({ page }) => {
+    await page.goto(SAMPLE_STORY_PATH);
+    await byTestId(page, 'play-button').click();
+    await page.waitForTimeout(500); // intentional: simulate playback start
+
+    // Simulate tab hide + return
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    // Player state should be coherent — not stuck in loading
+    const isStuck = await page.evaluate(() => {
+      const a = document.querySelector('audio');
+      return a?.readyState === 0;
+    });
+    expect(isStuck).toBe(false);
+  });
+
+  test('Media Session metadata populated for lock-screen control', async ({ page }) => {
+    await page.goto(SAMPLE_STORY_PATH);
+    await byTestId(page, 'play-button').click();
+
+    await expect.poll(
+      async () =>
+        await page.evaluate(() => navigator.mediaSession?.metadata?.title ?? null),
+      { timeout: 3_000 },
+    ).not.toBeNull();
+  });
+});

--- a/tests/bottom-nav-ergonomics.spec.ts
+++ b/tests/bottom-nav-ergonomics.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+import { mockExternalServices } from '../helpers/network';
+import { injectSession } from '../helpers/session';
+
+/**
+ * iOS Safari has a dynamic bottom address bar that appears/disappears on
+ * scroll. UI anchored to viewport-bottom often ends up under it. This suite
+ * asserts critical interactive elements stay reachable.
+ *
+ * CUSTOMIZE: ROUTES + testids for elements that anchor to bottom (CTAs,
+ * sticky checkout buttons, floating action buttons, mini-players).
+ */
+
+const ROUTES_WITH_BOTTOM_ANCHORED_UI = [
+  // { path: '/pricing', testIds: ['plus-tier-cta', 'pro-tier-cta'] },
+  // { path: '/listen', testIds: ['mini-player'] },
+];
+
+test.describe('Bottom-nav ergonomics', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockExternalServices(page);
+    await injectSession(page);
+  });
+
+  for (const { path, testIds } of ROUTES_WITH_BOTTOM_ANCHORED_UI) {
+    for (const id of testIds) {
+      test(`${path}: ${id} stays above iOS Safari bottom bar`, async ({ page }) => {
+        await page.goto(path);
+        const el = page.locator(`[data-testid="${id}"]`);
+        await expect(el).toBeVisible();
+
+        const clipped = await page.evaluate((selector) => {
+          const node = document.querySelector(selector);
+          if (!node || !window.visualViewport) return false;
+          const r = node.getBoundingClientRect();
+          // visualViewport excludes the iOS bottom bar when present
+          return r.bottom > window.visualViewport.height + window.visualViewport.offsetTop + 1;
+        }, `[data-testid="${id}"]`);
+
+        expect(clipped, `${id} on ${path} extends below the visual viewport`).toBe(false);
+      });
+    }
+  }
+
+  test('respects env(safe-area-inset-bottom) on notched devices', async ({ page, isMobile }) => {
+    test.skip(!isMobile, 'safe-area-inset is mobile-only');
+    await page.goto('/');
+    const safeAreaUsed = await page.evaluate(() => {
+      // Look for any element that uses safe-area-inset in its computed padding/margin
+      const all = document.querySelectorAll('*');
+      for (const el of Array.from(all).slice(0, 200)) {
+        const s = getComputedStyle(el as Element);
+        if (
+          s.paddingBottom.includes('safe-area-inset') ||
+          s.marginBottom.includes('safe-area-inset') ||
+          (s as any).getPropertyValue?.('padding-bottom')?.includes('env(')
+        ) {
+          return true;
+        }
+      }
+      return false;
+    });
+    // This is a soft check — warns but doesn't fail if your app doesn't use it
+    if (!safeAreaUsed) {
+      console.warn('No element uses env(safe-area-inset-bottom); notched iPhones may show UI under home indicator');
+    }
+  });
+});

--- a/tests/csp-compliance.spec.ts
+++ b/tests/csp-compliance.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+import { mockExternalServices } from '../helpers/network';
+
+/**
+ * CSP compliance — verify Content-Security-Policy doesn't break pages.
+ *
+ * Both directions:
+ *   1. Report-Only CSP: catch violations early but don't break the page
+ *   2. Enforcing CSP: assert no `Refused to ...` console errors
+ *
+ * CUSTOMIZE: PATHS, CSP_ALLOW (known-safe violation patterns to ignore).
+ */
+
+const PATHS = ['/', '/story/sample', '/pricing', '/listen'];
+
+// Substrings that, if present in a CSP violation, are known-safe and ignored.
+// Tighten this list aggressively for your app.
+const CSP_ALLOW: string[] = [
+  // Example: 'chrome-extension://',  // user browser extensions
+];
+
+test.describe('CSP compliance', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockExternalServices(page);
+  });
+
+  for (const path of PATHS) {
+    test(`${path}: zero CSP violations`, async ({ page }) => {
+      const violations: string[] = [];
+      page.on('console', (msg) => {
+        const text = msg.text();
+        if (msg.type() !== 'error') return;
+        if (!text.includes('Content Security Policy') && !text.startsWith('Refused to')) return;
+        if (CSP_ALLOW.some((ok) => text.includes(ok))) return;
+        violations.push(text);
+      });
+
+      const response = await page.goto(path);
+      await page.waitForLoadState('networkidle').catch(() => {/* SSE-OK */});
+
+      // Verify a CSP header is present (Report-Only or enforcing)
+      const cspHeader =
+        response?.headers()['content-security-policy'] ??
+        response?.headers()['content-security-policy-report-only'];
+      expect(cspHeader, `${path} has no CSP header at all`).toBeDefined();
+
+      expect(violations, `${path} produced CSP violations:\n${violations.join('\n')}`).toEqual([]);
+    });
+  }
+});

--- a/tests/payment-flow.spec.ts
+++ b/tests/payment-flow.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from '@playwright/test';
+import { mockExternalServices } from '../helpers/network';
+import { injectSession } from '../helpers/session';
+import { injectMockWallet } from '../helpers/wallet-mock';
+import { byTestId } from '../helpers/testid';
+
+/**
+ * Payment flow — Next-ShopFront cart → checkout, Stripe Elements, Apple Pay,
+ * wallet/PayPal/Coinbase modals, post-redirect reconciliation.
+ *
+ * Critical: DO NOT execute real transactions. We assert UI INTENT — the
+ * button renders, the modal opens, the iframe loads, post-return state
+ * reconciles. The wallet / Stripe / PayPal / Coinbase layers are mocked
+ * via helpers/network.ts.
+ *
+ * Routes covered:
+ *   /[productId]  → PDP "Add to cart" entrypoint
+ *   /checkout     → checkout shell (Stripe Elements iframe, PSP picker)
+ *
+ * Cart is a drawer/sheet (not a route) launched from the header. Specs
+ * reference it through `cart-drawer` / `cart-checkout-cta` testids.
+ * TODO(mobile-test): backfill these testids in the Phase 3 audit PR.
+ */
+
+const SAMPLE_PRODUCT_ID = process.env.SAMPLE_PRODUCT_ID ?? 'sample-product';
+const PRODUCT_PATH = process.env.PRODUCT_PATH ?? `/${SAMPLE_PRODUCT_ID}`;
+const CHECKOUT_PATH = process.env.CHECKOUT_PATH ?? '/checkout';
+
+test.describe('Payment flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockExternalServices(page);
+    await injectSession(page);
+    await injectMockWallet(page);
+  });
+
+  test('Apple Pay button renders on /checkout on iPhone profile', async ({ page, browserName, isMobile }) => {
+    test.skip(browserName !== 'webkit', 'Apple Pay is iOS Safari only');
+    test.skip(!isMobile, 'Apple Pay button only renders on mobile viewport');
+
+    await page.goto(CHECKOUT_PATH);
+
+    // The Stripe Apple Pay button mounts via iframe from js.stripe.com
+    const stripeFrame = page.frameLocator('iframe[name^="__privateStripeFrame"]').first();
+    await expect(stripeFrame.locator('body')).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('Checkout primary CTA stays above iOS Safari bottom bar (no z-index clip)', async ({ page }) => {
+    await page.goto(CHECKOUT_PATH);
+    const cta = byTestId(page, 'checkout-pay-cta');
+    await expect(cta).toBeVisible();
+
+    const isClipped = await page.evaluate(() => {
+      const el = document.querySelector('[data-testid="checkout-pay-cta"]');
+      if (!el || !window.visualViewport) return false;
+      const r = el.getBoundingClientRect();
+      return r.bottom > window.visualViewport.height + window.visualViewport.offsetTop;
+    });
+    expect(isClipped, 'Checkout pay CTA is clipped under iOS Safari bottom bar').toBe(false);
+  });
+
+  test('Cart drawer opens from PDP and exposes a checkout CTA', async ({ page }) => {
+    await page.goto(PRODUCT_PATH);
+    await byTestId(page, 'add-to-cart').click();
+    await byTestId(page, 'header-cart-trigger').click();
+
+    const drawer = byTestId(page, 'cart-drawer');
+    await expect(drawer).toBeVisible();
+
+    const overflow = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > document.documentElement.clientWidth;
+    });
+    expect(overflow, 'page has horizontal overflow when cart drawer is open').toBe(false);
+
+    const checkoutCta = byTestId(page, 'cart-checkout-cta');
+    await expect(checkoutCta).toBeVisible();
+  });
+
+  test('Wallet modal opens without horizontal scroll on mobile viewport', async ({ page }) => {
+    await page.goto(CHECKOUT_PATH);
+    await byTestId(page, 'connect-wallet-button').click();
+
+    const modal = byTestId(page, 'wallet-modal');
+    await expect(modal).toBeVisible();
+
+    const overflow = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > document.documentElement.clientWidth;
+    });
+    expect(overflow, 'page has horizontal overflow when wallet modal is open').toBe(false);
+
+    const closeBtn = byTestId(page, 'wallet-modal-close');
+    await expect(closeBtn).toBeVisible();
+    await closeBtn.click();
+    await expect(modal).not.toBeVisible();
+  });
+
+  test('Wallet reconnects after visibility-change return (deep-link flow)', async ({ page }) => {
+    await page.goto(CHECKOUT_PATH);
+    await byTestId(page, 'connect-wallet-button').click();
+
+    // Simulate user being deep-linked to wallet app and returning
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    await page.waitForTimeout(200); // intentional: wallet apps deep-link briefly
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    // After return, wallet state should be reconnected (chip flipped to 0x...)
+    await expect.poll(
+      async () => await byTestId(page, 'wallet-connected-chip').isVisible(),
+      { timeout: 5_000 },
+    ).toBe(true);
+  });
+});

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+import { mockExternalServices } from '../helpers/network';
+
+/**
+ * Smoke suite — <60s wall-clock, runs on every PR via GitHub Action.
+ * Blocks merge on failure. Covers critical-path "did the deploy break
+ * everything" checks.
+ *
+ * Next-ShopFront route map (Next.js App Router, src/app/(routes)/):
+ *   /               → src/app/page.tsx (storefront root)
+ *   /home           → src/app/(routes)/home/page.tsx (home tab)
+ *   /[productId]    → src/app/(routes)/[productId]/page.tsx (PDP)
+ *   /checkout       → src/app/(routes)/checkout/page.tsx
+ *   /orders         → src/app/(routes)/orders/page.tsx
+ *
+ * Cart is a drawer component, not a dedicated route — covered in
+ * payment-flow.spec.ts via data-testid.
+ *
+ * TODO(mobile-test): wire the spec to seed/resolve a real product id from
+ * the apiv3 fixture mock so smoke does not rely on production data.
+ */
+
+const SAMPLE_PRODUCT_ID = process.env.SAMPLE_PRODUCT_ID ?? 'sample-product';
+
+const EXAMPLE_PATHS = [
+  '/',
+  '/home',
+  `/${SAMPLE_PRODUCT_ID}`,
+  '/checkout',
+];
+
+test.describe('Smoke @smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockExternalServices(page);
+  });
+
+  for (const path of EXAMPLE_PATHS) {
+    test(`${path} loads without JS errors`, async ({ page }) => {
+      const errors: string[] = [];
+      page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`));
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') {
+          // Ignore known third-party noise; tighten this list for your app
+          const text = msg.text();
+          if (text.includes('Failed to load resource') && text.includes('favicon')) return;
+          errors.push(`console.error: ${text}`);
+        }
+      });
+
+      const response = await page.goto(path);
+      expect(response?.status(), `${path} returned non-200`).toBeLessThan(400);
+
+      await page.waitForLoadState('domcontentloaded');
+      // Give a brief moment for hydration + early-fire errors
+      await page.waitForLoadState('networkidle').catch(() => {/* networkidle can race on SSE */});
+
+      expect(errors, `unexpected errors on ${path}:\n${errors.join('\n')}`).toEqual([]);
+    });
+  }
+
+  test('first paint is reasonable (under 3s on default network)', async ({ page }) => {
+    const start = Date.now();
+    await page.goto(EXAMPLE_PATHS[0]);
+    await page.waitForLoadState('domcontentloaded');
+    const elapsed = Date.now() - start;
+    expect(elapsed, `first paint took ${elapsed}ms (budget: 3000ms)`).toBeLessThan(3000);
+  });
+});

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"],
+    "baseUrl": "..",
+    "paths": {
+      "@helpers/*": ["helpers/*"]
+    }
+  },
+  "include": ["./**/*.ts", "../helpers/**/*.ts", "../playwright.config.ts"]
+}

--- a/tests/visual-regression.spec.ts
+++ b/tests/visual-regression.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import { mockExternalServices } from '../helpers/network';
+import { injectSession } from '../helpers/session';
+
+/**
+ * Visual regression — screenshot-diff per (route × device).
+ *
+ * Last-line defense for layout breaks no semantic assertion would catch:
+ *   - z-index battles
+ *   - safe-area-inset issues on notched devices
+ *   - font-loading-induced reflow
+ *   - missing assets
+ *
+ * Baselines committed to repo; updating requires `npm run test:mobile:update-snapshots`
+ * and human PR review.
+ *
+ * CUSTOMIZE: ROUTES list. Add app-specific waits before screenshot if your
+ * page has animations or skeleton states.
+ */
+
+const ROUTES = [
+  '/',
+  // '/story/sample',
+  // '/pricing',
+  // '/listen',
+];
+
+test.describe('Visual regression', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockExternalServices(page);
+    await injectSession(page);
+    // Disable animations so screenshots are deterministic
+    await page.addStyleTag({
+      content: `
+        *, *::before, *::after {
+          animation-duration: 0s !important;
+          transition-duration: 0s !important;
+          animation-delay: 0s !important;
+          transition-delay: 0s !important;
+        }
+      `,
+    });
+  });
+
+  for (const route of ROUTES) {
+    test(`${route} matches baseline`, async ({ page }) => {
+      await page.goto(route);
+      await page.waitForLoadState('networkidle').catch(() => {/* SSE-OK */});
+
+      // Wait for fonts to load to avoid FOUT-induced reflow
+      await page.evaluate(() => document.fonts?.ready);
+
+      await expect(page).toHaveScreenshot({
+        fullPage: true,
+        animations: 'disabled',
+      });
+    });
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,10 @@
     "index.d.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "tests",
+    "helpers",
+    "playwright-report",
+    "test-results"
   ]
 }


### PR DESCRIPTION
## Summary

Adopts Phase 1 of the mobile-testing-starter into Next-ShopFront so future user-surfacing changes (cart, PDP, checkout, header drawer, mobile bottom-nav) can be paired with mobile-Playwright coverage per the `mobile-testing-framework` rule.

- Scaffold-only PR — no component changes, no live test runs, no `npx playwright install`.
- Flat layout (no pre-existing root `playwright.config.ts`): `tests/`, `helpers/`, `playwright.config.ts`, `BUGS_TO_NEVER_REGRESS.md`, `docs/` at repo root.
- CI workflow `.github/workflows/mobile-test.yml` runs smoke on PRs touching `src/**` / `public/**` / suite files; nightly full matrix at 06:00 UTC against `secrets.PRODUCTION_URL`.
- `tsconfig.json` excludes `tests/`, `helpers/`, `playwright-report/`, `test-results/` so the Next build is unaffected; `tests/tsconfig.json` carries the suite-scoped strict config.

### Customizations applied

- `playwright.config.ts` `baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000'`.
- `tests/smoke.spec.ts` routes: `/`, `/home`, `/[productId]` (via `SAMPLE_PRODUCT_ID` env, default `sample-product`), `/checkout` — mirrors `src/app/(routes)/` App Router layout.
- `tests/payment-flow.spec.ts` rewired to PDP → header cart drawer → `/checkout` (no dedicated `/cart` route — cart is a header drawer at `src/components/core/header/triggers/cart`).
- `helpers/network.ts` adds mocks for the droplinked apiv3 backend (`(apiv3|apiv3dev).droplinked.com/api/v1/**`) and Coinbase Commerce, alongside the starter’s Stripe / PayPal / Sentry / analytics mocks. Internal Next.js `/api/cart/**` + `/api/checkout/**` routes intentionally fall through to the dev handler.
- `helpers/session.ts` carries a TODO: audit found NO `localStorage.setItem` of an auth token in `src/` — only a 401-driven `localStorage.clear()` in `services/fetchConfig.ts`. The storefront auths outbound calls via the `x-shop-id` header from build-time `API_KEY`; user/wallet state likely flows through `@droplinked/wallet-connection`. Session contract must be confirmed before any spec depends on `injectSession`.

### Follow-ups (separate PRs, per adoption-checklist Phase 2-6)

- Phase 2: generate visual baselines against production storefront, commit under `tests/__screenshots__/`.
- Phase 3: `data-testid` backfill across `src/components/` for cart drawer (`cart-drawer`, `cart-checkout-cta`, `header-cart-trigger`, `add-to-cart`), checkout (`checkout-pay-cta`, `connect-wallet-button`, `wallet-modal`, `wallet-modal-close`).
- Phase 5: operator enables "Smoke (PR gate)" as a required status check on `main` branch protection.

## Test plan

- [ ] CI workflow appears in the Actions tab and the smoke job is dispatched on this PR.
- [ ] Smoke job fails on missing testids (expected at Phase 1 — backfill lands in the Phase 3 PR).
- [ ] `npm run lint` is unaffected by the new top-level dirs.
- [ ] `next build` is unaffected (verify locally; `tsconfig.json` excludes the suite paths).
- [ ] Reviewer audits `helpers/network.ts` mocks against the actual storefront network calls.
- [ ] Operator confirms `secrets.PRODUCTION_URL` is populated before the first nightly run.
