### PR TITLE
chore(supply-chain): swap droplinked-web3 -> @droplinked_inc/web3 (draft, pending npm publish)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "droplinked-payment-intent": "1.3.0",
-    "droplinked-web3": "2.0.9",
+    "@droplinked_inc/web3": "*",
     "ethers": "^5.7.2",
     "formik": "^2.4.5",
     "material-ui-popup-state": "^5.0.10",
@@ -59,7 +59,7 @@
   "overrides": {
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "@solana/web3.js": "^1.98.4",
-    "droplinked-web3": {
+    "@droplinked_inc/web3": {
       "@solana/web3.js": "^1.98.4"
     },
     "base-x": "^5.0.0",

--- a/src/state/hooks/droplinked/payment/usePayment.ts
+++ b/src/state/hooks/droplinked/payment/usePayment.ts
@@ -2,7 +2,7 @@ import CheckoutPageContext, { ICheckoutState } from "@/app/(routes)/checkout/con
 import { checkoutCryptoPaymentService, fetchStripePaymentDetails, submitOrderService } from '@/services/checkout/service';
 import useAppStore from '@/lib/stores/app/appStore';
 import { APP_DEVELOPMENT } from '@/lib/variables/variables';
-import { Chain, ChainWallet, DropWeb3, Network, Web3Actions, PaymentTokens } from 'droplinked-web3';
+import { Chain, ChainWallet, DropWeb3, Network, Web3Actions, PaymentTokens } from '@droplinked_inc/web3';
 import { useRouter } from 'next/navigation';
 import { useContext, useState, useTransition } from 'react';
 


### PR DESCRIPTION
## Summary

Stages the import swap from hostile `droplinked-web3@2.0.9` to the rebuilt `@droplinked_inc/web3` package being published from the `droplinked/droplink-packages` monorepo as part of the supply-chain rebuild sprint.

- `package.json`: `droplinked-web3@2.0.9` -> `@droplinked_inc/web3@*` (override entry also moved)
- `src/state/hooks/droplinked/payment/usePayment.ts`: 1 import site rewritten

## Status: DRAFT

**Do not merge** until `@droplinked_inc/web3` is live on npm. Verify with:

```
npm view @droplinked_inc/web3 version
```

Once published, replace the `*` version specifier with the published version (or leave for operator to pin) and merge.

## Lockfile

`package-lock.json` is intentionally NOT regenerated in this PR. The target package isn't published yet, so `npm install` would fail. Operator regenerates the lockfile post-merge.

## Smoke checklist (post-merge)

- [ ] `npm install` succeeds and resolves `@droplinked_inc/web3`
- [ ] `npm run build` clean
- [ ] Storefront loads, wallet connect modal renders
- [ ] Checkout: crypto payment path (`usePayment.ts`) signs and submits a test order on dev
- [ ] No console errors mentioning `droplinked-web3` or missing exports (`Chain`, `ChainWallet`, `DropWeb3`, `Network`, `Web3Actions`, `PaymentTokens`)

## Context

Part of the @droplinked_inc supply-chain rebuild — replaces hostile npm publishes with operator-owned scope `@droplinked_inc/*`.
