### PR TITLE
feat(security): CSP Report-Only headers (week-1 of rollout)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,6 +18,34 @@ const cspReportOnly = [
 ].join('; ');
 
 /** @type {import('next').NextConfig} */
+
+// CSP Report-Only — week 1 of rollout. See droplink-packages docs PR #36
+// (`docs/csp-audit-2026-05-19.md`). Report-Only collects violations
+// without blocking. Promote to enforcing `Content-Security-Policy` only
+// after 7-day Sentry observation window per the rollout plan.
+//
+// `'unsafe-eval'` is required by ethers@5 BigNumber internals + some
+// Solana RPC adapters. Tracked for removal via ethers@6 / viem upgrade.
+// `'unsafe-inline'` is required for GTM bootstrap + Next.js style-jsx.
+const cspReportOnly = [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.cdnfonts.com",
+    "font-src 'self' https://fonts.gstatic.com https://fonts.cdnfonts.com data:",
+    "img-src 'self' data: blob: https://upload-file-droplinked.s3.amazonaws.com https://upload-file-flatlay.s3.us-west-2.amazonaws.com https://files.cdn.printful.com https://*.cloudfront.net https://www.google-analytics.com",
+    "connect-src 'self' https://apiv3.droplinked.com https://apiv3dev.droplinked.com https://tools.droplinked.com https://ipapi.co https://accept.paymob.com https://*.ingest.sentry.io https://www.google-analytics.com",
+    "frame-src 'self' https://accept.paymob.com",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self' https://accept.paymob.com",
+    "object-src 'none'",
+    "upgrade-insecure-requests",
+    // TODO(security): wire report-uri to project Sentry CSP endpoint once
+    // operator confirms project DSN. Pattern:
+    //   https://oXXXX.ingest.sentry.io/api/<project_id>/security/?sentry_key=<key>
+    // "report-uri https://<sentry-ingest-host>/api/<project_id>/security/?sentry_key=<key>",
+].join('; ')
+
 const nextConfig = {
     // Dockerfile (runner stage) copies /app/.next/standalone — require Next.js
     // to emit that directory at build time. Without this, every LIVE deploy


### PR DESCRIPTION
## Summary
- Adds `Content-Security-Policy-Report-Only` via `next.config.mjs` `headers()` async function (applies to all routes).
- Report-Only mode: collects violations, does **not** block anything. 7-day Sentry observation window before promoting to enforcing.
- Whitelisted origins enumerated from the audit: apiv3, Sentry, GTM, Google Analytics, Paymob, ipapi, Printful CDN, S3 upload buckets, fonts.

Cites: droplinked/droplink-packages PR #36 (`docs/csp-audit-2026-05-19.md`) — paste-ready policy per repo.

## Rollout plan (from the audit doc)
1. **Week 1 (this PR)** — Report-Only on all 4 frontends, wire Sentry CSP `report-uri`.
2. Week 2 — flip to enforcing `Content-Security-Policy` on `shop.droplinked.com` DEV only.
3. Week 3 — enforce on LIVE in smallest-blast-radius order (shop-builder, shopfront, Next-ShopFront, checkout last).
4. Week 4+ — remove unsafe-inline (nonce via middleware), remove unsafe-eval (ethers@6 / viem), add HSTS + Referrer-Policy + Permissions-Policy.

## Known concessions (week-1 acceptable, tracked for week-4)
- `unsafe-eval` — required by ethers@5 BigNumber internals + some Solana RPC adapters.
- `unsafe-inline` — required by GTM bootstrap + Next.js style-jsx.

## Operator follow-up
- Confirm Sentry CSP `report-uri` endpoint for this project's Sentry DSN — placeholder is commented in source pending the project ID + public key.

## Test plan
- [ ] `npm run build` clean.
- [ ] Local smoke: open DevTools, Network, response headers include `Content-Security-Policy-Report-Only` with the new policy on `/` and on a product page.
- [ ] Watch Sentry CSP reports for 7 days; whitelist any operator-legitimate origins surfaced.
- [ ] Commerce smoke: browse, add-to-cart, shipping rates, plans, payment-page-reachable, Paymob iframe load. Confirm NO console-blocked errors (Report-Only should never block).

Generated with Claude Code.
