### PR TITLE
feat(ui): persistent DEV-environment banner

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { AppThemeProvider } from "@/components/providers/theme/AppThemeProvider"
 import type { Metadata, Viewport } from "next";
 import { Toaster } from "sonner";
 import AppLayout from "@/components/core/AppLayout";
+import DevEnvironmentBanner from "@/components/core/DevEnvironmentBanner";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -22,6 +23,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
     return (
         <html lang="en" suppressHydrationWarning>
             <body>
+                <DevEnvironmentBanner />
                 <AppLayout>
                     <Toaster position="bottom-center" />
                     <AppThemeProvider>{children}</AppThemeProvider>

--- a/src/components/core/DevEnvironmentBanner.tsx
+++ b/src/components/core/DevEnvironmentBanner.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { BASE_API_URL } from "@/lib/variables/variables";
+
+/**
+ * Renders a persistent, non-dismissable banner when the app is pointed
+ * at the DEV API (apiv3dev). Hidden in all other environments.
+ *
+ * Part of DEV-tightening cleanup 2026-05-19 — landed now that real DEV
+ * cluster isolation is in place.
+ */
+export default function DevEnvironmentBanner() {
+    const apiBase = BASE_API_URL || "";
+    if (!apiBase.includes("apiv3dev")) return null;
+
+    return (
+        <div
+            data-testid="dev-environment-banner"
+            role="status"
+            aria-live="polite"
+            style={{
+                position: "sticky",
+                top: 0,
+                left: 0,
+                right: 0,
+                zIndex: 9999,
+                width: "100%",
+                backgroundColor: "#FFEB3B",
+                color: "#000000",
+                textAlign: "center",
+                padding: "6px 12px",
+                fontSize: "13px",
+                fontWeight: 600,
+                lineHeight: 1.3,
+                fontFamily: "system-ui, -apple-system, sans-serif",
+                borderBottom: "1px solid #000000",
+            }}
+        >
+            ⚠️ DEV ENVIRONMENT — data is sanitized, not real
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- Adds a thin sticky yellow banner rendered at the very top of every page whenever `NEXT_PUBLIC_BASE_API_URL` points at `apiv3dev`.
- Non-dismissable. Text: `⚠️ DEV ENVIRONMENT — data is sanitized, not real`. Black on `#FFEB3B`. `z-index: 9999`. `data-testid="dev-environment-banner"`.
- Hidden in all non-DEV builds (string-includes check on the API base URL).
- Inline styles only — no new dependencies.

## Why
Part of DEV-tightening cleanup 2026-05-19 — landed now that real DEV cluster isolation is in place per [[project-droplinked-dev-pollution-confirmed-2026-05-19]]. Clear visual cue prevents demo/QA confusion between DEV and LIVE.

## Related PRs (same banner, sibling frontends)
- droplinked/droplinked-shopfront — `chore/dev-environment-banner-2026-05-19`
- droplinked/droplinked-shop-builder — `chore/dev-environment-banner-2026-05-19`
- droplinked/droplinked-checkout — `chore/dev-environment-banner-2026-05-19`

## Test plan
- [ ] Build LIVE (`NEXT_PUBLIC_BASE_API_URL=https://apiv3.droplinked.com`) — banner absent
- [ ] Build DEV (`NEXT_PUBLIC_BASE_API_URL=https://apiv3dev.droplinked.com`) — banner visible on every route, sticky
- [ ] DOM probe: `document.querySelector('[data-testid="dev-environment-banner"]')`