### PR TITLE
feat(security): add CSP Report-Only header on Next-ShopFront

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,22 @@
 import { withSentryConfig } from '@sentry/nextjs';
 
+// Content-Security-Policy in Report-Only mode. Mirrors the directives
+// shipped on the other three droplinked frontends so violation reports
+// are comparable. NOT enforcing yet — emits violations to the
+// configured report-uri so we can audit before flipping to enforce.
+// Operator: replace the placeholder report-uri with the project's real
+// Sentry Security endpoint.
+const cspReportOnly = [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.droplinked.com https://*.googletagmanager.com https://www.google-analytics.com",
+    "connect-src 'self' https://apiv3.droplinked.com https://apiv3dev.droplinked.com https://*.algolia.net https://*.algolianet.com https://*.sentry.io wss://* https://*.googleapis.com",
+    "img-src 'self' data: blob: https:",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "font-src 'self' data: https://fonts.gstatic.com",
+    "frame-src 'self' https://*.stripe.com",
+    "report-uri https://sentry.io/api/<project>/security/?sentry_key=<key>",
+].join('; ');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     images: {
@@ -13,6 +30,19 @@ const nextConfig = {
                 hostname: 'upload-file-droplinked.s3.amazonaws.com',
             },
         ],
+    },
+    async headers() {
+        return [
+            {
+                source: '/:path*',
+                headers: [
+                    {
+                        key: 'Content-Security-Policy-Report-Only',
+                        value: cspReportOnly,
+                    },
+                ],
+            },
+        ];
     },
     webpack(config, options) {
         config.module.rules.push({


### PR DESCRIPTION
## Summary

- Adds a `Content-Security-Policy-Report-Only` header on all routes via the Next.js `headers()` config.
- Report-Only mode means **no requests are blocked** — the browser only POSTs violation reports to the configured `report-uri`. Safe to ship.
- Directives mirror the CSP already shipped on the other three droplinked frontends so violation reports are comparable across surfaces.

## Why

Next-ShopFront is the last of the four droplinked frontends without CSP plumbing. We need observability on what third-party scripts / connects / styles real users hit before we can flip to enforcing mode and lock down the storefront against script injection.

## Directives

- `default-src 'self'`
- `script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.droplinked.com https://*.googletagmanager.com https://www.google-analytics.com`
- `connect-src 'self' https://apiv3.droplinked.com https://apiv3dev.droplinked.com https://*.algolia.net https://*.algolianet.com https://*.sentry.io wss://* https://*.googleapis.com`
- `img-src 'self' data: blob: https:`
- `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`
- `font-src 'self' data: https://fonts.gstatic.com`
- `frame-src 'self' https://*.stripe.com`
- `report-uri` (placeholder — operator fills in the project Sentry Security endpoint before merge)

## Operator follow-up before merge

Replace the placeholder `report-uri https://sentry.io/api/<project>/security/?sentry_key=<key>` in `next.config.mjs` with the real Sentry Security endpoint (Sentry → Project → Settings → Security Headers → copy the report URI). Without this swap the violation reports will 404.

## Test plan

- [x] `npm run build` succeeds locally with the new `headers()` block.
- [ ] After merge + deploy, hit the storefront in a real browser and confirm the response carries `Content-Security-Policy-Report-Only` (DevTools → Network → response headers).
- [ ] Confirm violation reports land in Sentry Security tab.
- [ ] Triage the first 24h of reports; tighten directives; then plan the flip to enforcing.

## Risk

Negligible. Report-Only is observation-mode; the browser does not block anything. Worst case: noisy report endpoint until directives are tuned.
