### PR TITLE
chore(observability): inject SENTRY_RELEASE + NEXT_PUBLIC_SENTRY_RELEASE in dev/main workflows

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -50,6 +50,14 @@ jobs:
       id: create-env
       run: |
         echo "${{ secrets.ENV_FILE_dev }}" > .env
+        # --- Sentry release tagging 2026-05-19 ---
+        # Source: sentry.server.config.ts:7 + sentry.edge.config.ts:7 read
+        # process.env.SENTRY_RELEASE; instrumentation-client.ts:6 reads
+        # NEXT_PUBLIC_SENTRY_RELEASE. Without these, all events bucket into
+        # a single fake release in Sentry UI, breaking regression detection
+        # + deploy correlation.
+        echo "SENTRY_RELEASE=${{ github.sha }}" >> .env
+        echo "NEXT_PUBLIC_SENTRY_RELEASE=${{ github.sha }}" >> .env
     
     - name: Build, tag, and push image to Amazon ECR
       id: build-image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,14 @@ jobs:
       id: create-env
       run: |
         echo "${{ secrets.ENV_FILE }}" > .env
+        # --- Sentry release tagging 2026-05-19 ---
+        # Source: sentry.server.config.ts:7 + sentry.edge.config.ts:7 read
+        # process.env.SENTRY_RELEASE; instrumentation-client.ts:6 reads
+        # NEXT_PUBLIC_SENTRY_RELEASE. Without these, all events bucket into
+        # a single fake release in Sentry UI, breaking regression detection
+        # + deploy correlation.
+        echo "SENTRY_RELEASE=${{ github.sha }}" >> .env
+        echo "NEXT_PUBLIC_SENTRY_RELEASE=${{ github.sha }}" >> .env
 
     - name: Build, tag, and push image to Amazon ECR
       id: build-image


### PR DESCRIPTION
## Audit finding

Three Sentry config files read release env vars:

- `sentry.server.config.ts:7` -> `process.env.SENTRY_RELEASE`
- `sentry.edge.config.ts:7` -> `process.env.SENTRY_RELEASE`
- `instrumentation-client.ts:6` -> `process.env.NEXT_PUBLIC_SENTRY_RELEASE`

Neither `dev.yml` nor `main.yml` was setting these — the `Create env file` step only echoed `\${{ secrets.ENV_FILE }}` / `\${{ secrets.ENV_FILE_dev }}`. Result: every server, edge, and client event in Sentry buckets under whatever (if anything) is baked into ENV_FILE — effectively one fake release for the lifetime of the deployed image. Regression detection, "first seen in release", and deploy-correlation views are all broken across the storefront.

## Change

Append two lines to the existing `Create env file` step in both workflows:

\`\`\`yaml
echo "SENTRY_RELEASE=\${{ github.sha }}" >> .env
echo "NEXT_PUBLIC_SENTRY_RELEASE=\${{ github.sha }}" >> .env
\`\`\`

The `NEXT_PUBLIC_` variant is required because client-side reads must be inlined at Next build time.

## Before / after in Sentry UI

- **Before:** all events (server + edge + client) bucket into one release tag. Releases dashboard does not advance per deploy.
- **After:** one Sentry release per deploy SHA. "Regression in release" alerts work. Deploy markers correlate to commits.

## Smoke

Workflow-only change, no runtime code touched. YAML validated locally via \`python3 -c "import yaml; yaml.safe_load(...)"\` on both files. Operator-merge after CI green.