### PR TITLE
fix(infra): bump Dockerfile node 20 → 22 for @droplinked_inc/web3 engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 
 # ---- Base Stage ----
 # Use a specific Node.js version on Alpine Linux for a small base image.
-FROM node:20-alpine AS base
+# Node 22 required by @droplinked_inc/web3@1.0.0 (engines.node >=22.0.0).
+FROM node:22-alpine AS base
 
 # ---- Dependencies Stage ----
 # Install dependencies first to leverage Docker cache.


### PR DESCRIPTION
Bumps Next-ShopFront Dockerfile base image from node:20-alpine to node:22-alpine.

## Why
@droplinked_inc/web3@1.0.0 requires engines.node >=22.0.0. The current node:20-alpine base causes yarn install to fail at the build step with an engine-incompatibility error. Blocks LIVE deploys that depend on the Sentry instrumentation work.

## Smoke
- Type-check / build verification deferred to CI (local node version mismatch)
- DO NOT auto-merge → operator-gated LIVE per standing rule