### PR TITLE
fix(infra): standalone output + public/ dir — unblocks LIVE deploy (closes #38)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -19,6 +19,10 @@ const cspReportOnly = [
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+    // Dockerfile (runner stage) copies /app/.next/standalone — require Next.js
+    // to emit that directory at build time. Without this, every LIVE deploy
+    // fails at `COPY --from=builder /app/.next/standalone ./` (issue #38).
+    output: 'standalone',
     images: {
         remotePatterns: [
             {


### PR DESCRIPTION
Closes #38. Two structural fixes for 100% LIVE deploy failures since this Dockerfile pattern landed:

1. next.config.mjs: add output: standalone
2. Create public/.gitkeep so Dockerfile COPY of /app/public succeeds

Will trigger main.yml LIVE on merge. The fix itself is the validation — if build succeeds, the structural issue is resolved.