### PR TITLE
feat(observability): upload Sentry source maps so production stack traces de-minify

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -64,8 +64,24 @@ jobs:
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         IMAGE_TAG: ${{ github.sha }}
+        # --- Sentry source-map upload 2026-05-19 ---
+        # When SENTRY_AUTH_TOKEN secret is set, withSentryConfig in
+        # next.config.mjs uploads source maps during `yarn build` so
+        # production stack traces de-minify. Build still succeeds with
+        # no token (warns + skips). Operator: mint org-level
+        # SENTRY_AUTH_TOKEN, SENTRY_ORG=droplinked, and per-project
+        # SENTRY_PROJECT_NEXT_SHOPFRONT in GH org secrets.
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT_NEXT_SHOPFRONT }}
       run: |
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker build \
+          --build-arg SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN" \
+          --build-arg SENTRY_ORG="$SENTRY_ORG" \
+          --build-arg SENTRY_PROJECT="$SENTRY_PROJECT" \
+          --build-arg SENTRY_RELEASE="$IMAGE_TAG" \
+          --build-arg NEXT_PUBLIC_SENTRY_RELEASE="$IMAGE_TAG" \
+          -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,8 +64,21 @@ jobs:
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         IMAGE_TAG: ${{ github.sha }}
+        # --- Sentry source-map upload 2026-05-19 ---
+        # See dev.yml for full rationale. Operator must set
+        # SENTRY_AUTH_TOKEN, SENTRY_ORG=droplinked,
+        # SENTRY_PROJECT_NEXT_SHOPFRONT in org-level secrets.
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT_NEXT_SHOPFRONT }}
       run: |
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker build \
+          --build-arg SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN" \
+          --build-arg SENTRY_ORG="$SENTRY_ORG" \
+          --build-arg SENTRY_PROJECT="$SENTRY_PROJECT" \
+          --build-arg SENTRY_RELEASE="$IMAGE_TAG" \
+          --build-arg NEXT_PUBLIC_SENTRY_RELEASE="$IMAGE_TAG" \
+          -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_ENV
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,23 @@ COPY . .
 # Set NEXT_TELEMETRY_DISABLED to 1 to disable telemetry during build.
 ENV NEXT_TELEMETRY_DISABLED 1
 
+# --- Sentry source-map upload build-args 2026-05-19 ---
+# Passed in by .github/workflows/{dev,main}.yml via `docker build
+# --build-arg`. When SENTRY_AUTH_TOKEN is set, next.config.mjs
+# (withSentryConfig) auto-uploads source maps so production stack
+# traces de-minify in Sentry. When unset, build still succeeds —
+# the Sentry CLI warns + skips upload.
+ARG SENTRY_AUTH_TOKEN
+ARG SENTRY_ORG
+ARG SENTRY_PROJECT
+ARG SENTRY_RELEASE
+ARG NEXT_PUBLIC_SENTRY_RELEASE
+ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
+ENV SENTRY_ORG=$SENTRY_ORG
+ENV SENTRY_PROJECT=$SENTRY_PROJECT
+ENV SENTRY_RELEASE=$SENTRY_RELEASE
+ENV NEXT_PUBLIC_SENTRY_RELEASE=$NEXT_PUBLIC_SENTRY_RELEASE
+
 # Build the Next.js application.
 # This command requires the full dependencies (including devDependencies).
 # Ensure your next.config.js or next.config.mjs includes `output: 'standalone'`

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -55,13 +55,22 @@ const nextConfig = {
 };
 
 export default withSentryConfig(nextConfig, {
-    // Suppress all Sentry CLI logs during build; we are not uploading
-    // source maps in CI yet (no SENTRY_AUTH_TOKEN wired).
-    silent: true,
-    // Org / project are optional at build time when no auth token is set;
-    // the SDK still functions at runtime via the DSN.
+    // Suppress all Sentry CLI logs during build unless the auth token
+    // is wired (then we want CI to surface upload failures).
+    silent: !process.env.SENTRY_AUTH_TOKEN,
+    // Org / project / authToken are optional at build time when no auth
+    // token is set; the SDK still functions at runtime via the DSN.
+    // When all three are present (CI), `withSentryConfig` automatically
+    // uploads source maps so production stack traces de-minify.
     org: process.env.SENTRY_ORG,
     project: process.env.SENTRY_PROJECT,
+    authToken: process.env.SENTRY_AUTH_TOKEN,
+    // Tag uploaded source maps with the same release identifier used by
+    // the SDK at runtime — without this, uploaded maps don't match the
+    // events Sentry receives.
+    release: {
+        name: process.env.SENTRY_RELEASE || process.env.NEXT_PUBLIC_SENTRY_RELEASE,
+    },
     // Don't upload source maps unless an auth token is explicitly provided.
     disableServerWebpackPlugin: !process.env.SENTRY_AUTH_TOKEN,
     disableClientWebpackPlugin: !process.env.SENTRY_AUTH_TOKEN,


### PR DESCRIPTION
## Summary
`withSentryConfig` was already wired in `next.config.mjs` but lacked the auth-token passthrough needed to actually upload maps. This PR:
- adds `authToken` + `release.name` fields to `withSentryConfig`
- adds `ARG`/`ENV` passthrough for `SENTRY_*` in Dockerfile (build runs inside `docker build`, so build-args are required)
- threads `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT_NEXT_SHOPFRONT` via `docker --build-arg` in dev.yml + main.yml
- preserves `disable*WebpackPlugin` gating so token-less builds still succeed (warns + skips upload — verified locally, `yarn build` green)

## HOLD-MERGE — operator action required
- `SENTRY_AUTH_TOKEN` (org-level)
- `SENTRY_ORG=droplinked`
- `SENTRY_PROJECT_NEXT_SHOPFRONT`

## Test plan
- [ ] Operator mints 3 secrets above
- [ ] DEV deploy + commerce-smoke 8/8 green
- [ ] Mobile UX check (storefront-visible — Next-ShopFront PDP/PLP)
- [ ] Confirm Sentry shows uploaded artifacts tagged with deploy SHA
- [ ] Then LIVE per standing rule

NO LIVE dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)