### PR TITLE
chore(infra): point at dedicated ECS service (closes #41)

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,11 +16,17 @@ concurrency:
 
 env:
   AWS_REGION: us-east-1
-  ECR_REPOSITORY: shopdev_droplinked_com
+  # --- ECS split closes #41 (2026-05-19) ---
+  # Previously deployed to shopdev_droplinked_com_service, which is shared
+  # with droplinked-shop-builder historically. Last-deploy-wins overwrote.
+  # Migrated to a dedicated service/repo/task-def/container so the two
+  # codebases can ship independently. Operator-provisioned via the AWS
+  # CLI block in docs/ECS_SPLIT_MIGRATION.md.
+  ECR_REPOSITORY: nextshopfront_droplinked_com
   ECS_CLUSTER: droplinked-cluster
-  ECS_SERVICE: shopdev_droplinked_com_service
-  CONTAINER_NAME: shopdev_droplinked_com
-  TASK_DEFINITION: shopdev_droplinked_com
+  ECS_SERVICE: nextshopfront_droplinked_com_service
+  CONTAINER_NAME: nextshopfront_droplinked_com
+  TASK_DEFINITION: nextshopfront_droplinked_com
 
 permissions:
   contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,17 @@ concurrency:
 
 env:
   AWS_REGION: us-east-1
-  ECR_REPOSITORY: shop_droplinked_com
+  # --- ECS split closes #41 (2026-05-19) ---
+  # Previously deployed to shop_droplinked_com_service (shared historically
+  # with droplinked-shop-builder PROD). Migrated to dedicated service/repo/
+  # task-def/container. Operator-provisioned via the AWS CLI block in
+  # docs/ECS_SPLIT_MIGRATION.md. nextshopfront.droplinked.com R53 record
+  # is flipped to the new ALB target group as the final cutover step.
+  ECR_REPOSITORY: nextshopfront_droplinked_com_prod
   ECS_CLUSTER: droplinked-cluster
-  ECS_SERVICE: shop_droplinked_com_service
-  CONTAINER_NAME: shop_droplinked_com
-  TASK_DEFINITION: shop_droplinked_com
+  ECS_SERVICE: nextshopfront_droplinked_com_prod_service
+  CONTAINER_NAME: nextshopfront_droplinked_com_prod
+  TASK_DEFINITION: nextshopfront_droplinked_com_prod
 
 permissions:
   contents: read

--- a/docs/ECS_SPLIT_MIGRATION.md
+++ b/docs/ECS_SPLIT_MIGRATION.md
@@ -1,0 +1,173 @@
+# ECS split migration — Next-ShopFront dedicated service (closes #41)
+
+## Why
+
+Both `droplinked-shop-builder` and `Next-ShopFront` historically targeted
+the same ECS service/ECR repo/task-def/container/ALB target group:
+
+| Env | Shared resource                                     |
+| --- | --------------------------------------------------- |
+| DEV | `shopdev_droplinked_com_service` / `shopdev_droplinked_com` ECR  |
+| PROD | `shop_droplinked_com_service` / `shop_droplinked_com` ECR        |
+
+Whichever repo merged last overwrote the other. Two repos hardening in
+parallel (Sentry, CSP, source-map upload) trampled each other.
+
+This PR re-points **Next-ShopFront** workflows at dedicated AWS
+resources. **shop-builder workflows are unchanged** — it keeps the
+existing shared names for backward compat.
+
+## New resource names
+
+| Env | ECR repo | ECS service | Task definition | Container name | ALB target group | DNS |
+| --- | --- | --- | --- | --- | --- | --- |
+| DEV  | `nextshopfront_droplinked_com`      | `nextshopfront_droplinked_com_service`      | `nextshopfront_droplinked_com`      | `nextshopfront_droplinked_com`      | `tg-nextshopfront-droplinked-com`      | `nextshopfront-dev.droplinked.com` |
+| PROD | `nextshopfront_droplinked_com_prod` | `nextshopfront_droplinked_com_prod_service` | `nextshopfront_droplinked_com_prod` | `nextshopfront_droplinked_com_prod` | `tg-nextshopfront-droplinked-com-prod` | `nextshopfront.droplinked.com`     |
+
+## Operator AWS CLI playbook (DO NOT RUN until cost approval)
+
+Run in `us-east-1`. Estimated added cost: see "Cost" section.
+
+> Replace placeholders: `<VPC_ID>`, `<SUBNET_A>`, `<SUBNET_B>`,
+> `<TASK_SECURITY_GROUP>`, `<ALB_ARN>`, `<HOSTED_ZONE_ID>`,
+> `<TASK_ROLE_ARN>`, `<EXECUTION_ROLE_ARN>`, `<ALB_DNS_NAME>`,
+> `<ALB_HOSTED_ZONE_ID>`. Pull current values from
+> `aws ecs describe-services --cluster droplinked-cluster --services shopdev_droplinked_com_service`
+> for the existing shared service.
+
+### Phase A — DEV
+
+```bash
+# 1. Create dedicated ECR repository (DEV)
+aws ecr create-repository \
+  --repository-name nextshopfront_droplinked_com \
+  --image-scanning-configuration scanOnPush=true \
+  --image-tag-mutability MUTABLE \
+  --region us-east-1
+
+# 2. Set lifecycle policy (keep last 30 images — match shopdev_droplinked_com)
+aws ecr put-lifecycle-policy \
+  --repository-name nextshopfront_droplinked_com \
+  --lifecycle-policy-text '{"rules":[{"rulePriority":1,"description":"Keep last 30 images","selection":{"tagStatus":"any","countType":"imageCountMoreThan","countNumber":30},"action":{"type":"expire"}}]}' \
+  --region us-east-1
+
+# 3. Register first task definition (copy from existing shared one, rename)
+aws ecs describe-task-definition \
+  --task-definition shopdev_droplinked_com \
+  --query 'taskDefinition' --output json \
+  | jq 'del(.taskDefinitionArn,.revision,.status,.requiresAttributes,.compatibilities,.registeredAt,.registeredBy,.enableFaultInjection)
+        | .family = "nextshopfront_droplinked_com"
+        | .containerDefinitions[0].name = "nextshopfront_droplinked_com"' \
+  > /tmp/nextshopfront-taskdef-dev.json
+
+aws ecs register-task-definition --cli-input-json file:///tmp/nextshopfront-taskdef-dev.json --region us-east-1
+
+# 4. Create ALB target group (DEV)
+aws elbv2 create-target-group \
+  --name tg-nextshopfront-droplinked-com \
+  --protocol HTTP --port 3000 --target-type ip \
+  --vpc-id <VPC_ID> \
+  --health-check-path / --health-check-interval-seconds 30 \
+  --healthy-threshold-count 2 --unhealthy-threshold-count 3 \
+  --region us-east-1
+
+# 5. Add listener rule on ALB for host nextshopfront-dev.droplinked.com
+aws elbv2 create-rule \
+  --listener-arn <ALB_HTTPS_LISTENER_ARN_DEV> \
+  --priority 200 \
+  --conditions Field=host-header,Values=nextshopfront-dev.droplinked.com \
+  --actions Type=forward,TargetGroupArn=<NEW_TG_ARN_FROM_STEP_4> \
+  --region us-east-1
+
+# 6. Create ECS service (DEV) — DESIRED COUNT 1, Fargate, awsvpc
+aws ecs create-service \
+  --cluster droplinked-cluster \
+  --service-name nextshopfront_droplinked_com_service \
+  --task-definition nextshopfront_droplinked_com \
+  --desired-count 1 \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[<SUBNET_A>,<SUBNET_B>],securityGroups=[<TASK_SECURITY_GROUP>],assignPublicIp=DISABLED}" \
+  --load-balancers "targetGroupArn=<NEW_TG_ARN_FROM_STEP_4>,containerName=nextshopfront_droplinked_com,containerPort=3000" \
+  --deployment-configuration "maximumPercent=200,minimumHealthyPercent=100,deploymentCircuitBreaker={enable=true,rollback=true}" \
+  --region us-east-1
+
+# 7. Route53 A-alias for DEV hostname
+aws route53 change-resource-record-sets \
+  --hosted-zone-id <HOSTED_ZONE_ID> \
+  --change-batch '{"Changes":[{"Action":"UPSERT","ResourceRecordSet":{"Name":"nextshopfront-dev.droplinked.com","Type":"A","AliasTarget":{"HostedZoneId":"<ALB_HOSTED_ZONE_ID>","DNSName":"<ALB_DNS_NAME>","EvaluateTargetHealth":true}}}]}'
+```
+
+### Phase B — PROD (mirror of A, suffix `_prod`)
+
+Repeat steps 1–7 with PROD names:
+
+- ECR: `nextshopfront_droplinked_com_prod`
+- task-def family: `nextshopfront_droplinked_com_prod` (copy from `shop_droplinked_com`)
+- target group: `tg-nextshopfront-droplinked-com-prod`
+- ALB listener rule host: `nextshopfront.droplinked.com`
+- ECS service: `nextshopfront_droplinked_com_prod_service`
+
+### Phase C — IAM
+
+Verify `arn:aws:iam::353643723135:role/github-actions-deploy` policy
+already allows `ecs:UpdateService` / `ecs:RegisterTaskDefinition` /
+`ecr:*` on the new resource ARNs. If scoped tightly, add:
+
+```
+arn:aws:ecs:us-east-1:353643723135:service/droplinked-cluster/nextshopfront_droplinked_com_service
+arn:aws:ecs:us-east-1:353643723135:service/droplinked-cluster/nextshopfront_droplinked_com_prod_service
+arn:aws:ecs:us-east-1:353643723135:task-definition/nextshopfront_droplinked_com:*
+arn:aws:ecs:us-east-1:353643723135:task-definition/nextshopfront_droplinked_com_prod:*
+arn:aws:ecr:us-east-1:353643723135:repository/nextshopfront_droplinked_com
+arn:aws:ecr:us-east-1:353643723135:repository/nextshopfront_droplinked_com_prod
+```
+
+### Phase D — Workflow merge + smoke
+
+1. Merge this PR.
+2. Push to `dev` → `dev.yml` builds + deploys to
+   `nextshopfront_droplinked_com_service`.
+3. Curl `https://nextshopfront-dev.droplinked.com/` → 200.
+4. Run commerce-smoke (storefront browse + add-to-cart + shipping rates
+   + plans) against the new DEV host. 8/8 required before LIVE dispatch.
+5. `workflow_dispatch` `main.yml` only after DEV is GREEN.
+
+## Cost delta (estimate, us-east-1)
+
+Per-env Fargate task @ 0.5 vCPU / 1 GB / 24x7:
+
+- vCPU: 0.5 × $0.04048/hr × 730 = **~$14.78/mo**
+- Memory: 1 × $0.004445/hr × 730 = **~$3.24/mo**
+- ALB target group: $0 (uses existing ALB; LCU may tick up marginally)
+- ECR storage: <$0.10/mo (30 images × ~200MB × $0.10/GB)
+
+**DEV alone: ~$18/mo. DEV + PROD: ~$36/mo.**
+
+> Crosses the $5/mo threshold per `feedback-actions-budget-elasticity`.
+> **Operator authorization required before Phase A step 6 (create-service)
+> on either env.** Phases 1–5 (ECR/task-def/TG/listener) are zero-cost
+> and safe to pre-provision.
+
+## Rollback
+
+If the new DEV service is unhealthy after merge:
+
+1. Revert this PR (one commit, env-block only).
+2. Re-deploy `dev` branch — workflow falls back to
+   `shopdev_droplinked_com_service` and shop-builder sharing resumes.
+3. Optionally scale the new service to 0 to stop cost:
+   `aws ecs update-service --cluster droplinked-cluster --service nextshopfront_droplinked_com_service --desired-count 0`
+4. Leave ECR/target-group/listener-rule in place — they're harmless
+   when unused and avoid having to recreate on next attempt.
+
+LIVE rollback is the same with `_prod` names. Route53 cutover is the
+final irreversible step — keep both old and new R53 records co-existing
+for 24h after cutover, swap back by editing the alias if needed.
+
+## Verification post-merge
+
+- [ ] `dev.yml` runs to completion and ECS task is RUNNING
+- [ ] `nextshopfront-dev.droplinked.com` returns 200
+- [ ] commerce-smoke 8/8 green
+- [ ] shop-builder DEV (`dev.droplinked.com`) untouched and still 200
+- [ ] CloudWatch logs for the new service show only Next-ShopFront SHAs

--- a/scripts/provision-nextshopfront-ecs.sh
+++ b/scripts/provision-nextshopfront-ecs.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+#
+# provision-nextshopfront-ecs.sh
+#
+# One-shot, idempotent provisioner for the Next-ShopFront dedicated ECS
+# service (closes #41). Replaces the manual AWS CLI playbook in
+# docs/ECS_SPLIT_MIGRATION.md.
+#
+# Usage:
+#   bash scripts/provision-nextshopfront-ecs.sh [dev|prod]
+#
+# Defaults to "dev". Idempotent — re-runs are safe; every step catches
+# AlreadyExists / DuplicateResource and continues.
+#
+# Cost gate: prompts Y/N before creating the ECS service (the only
+# resource that incurs ongoing Fargate cost — ~$18/mo per env).
+#
+# Logs to /tmp/provision-nextshopfront-<env>-<YYYYMMDD-HHMMSS>.log
+#
+# Pre-reqs: awscli v2, jq, an AWS profile with ECR/ECS/ELBv2/Route53
+# create permissions on account 353643723135 us-east-1.
+
+set -Eeuo pipefail
+
+ENV_ARG="${1:-dev}"
+if [[ "$ENV_ARG" != "dev" && "$ENV_ARG" != "prod" ]]; then
+  echo "ERROR: arg must be 'dev' or 'prod' (got '$ENV_ARG')" >&2
+  exit 2
+fi
+
+LOG_FILE="/tmp/provision-nextshopfront-${ENV_ARG}-$(date +%Y%m%d-%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+REGION="us-east-1"
+ACCOUNT_ID="353643723135"
+CLUSTER="droplinked-cluster"
+ALB_NAME="ecs-load-balancer"
+
+if [[ "$ENV_ARG" == "prod" ]]; then
+  SUFFIX="_prod"
+  TG_SUFFIX="-prod"
+  HOST="nextshopfront.droplinked.com"
+  SOURCE_TASKDEF="shop_droplinked_com"
+  SOURCE_SERVICE="shop_droplinked_com_service"
+  LISTENER_RULE_PRIORITY=201
+else
+  SUFFIX=""
+  TG_SUFFIX=""
+  HOST="nextshopfront-dev.droplinked.com"
+  SOURCE_TASKDEF="shopdev_droplinked_com"
+  SOURCE_SERVICE="shopdev_droplinked_com_service"
+  LISTENER_RULE_PRIORITY=200
+fi
+
+ECR_REPO="nextshopfront_droplinked_com${SUFFIX}"
+TASKDEF_FAMILY="nextshopfront_droplinked_com${SUFFIX}"
+CONTAINER_NAME="nextshopfront_droplinked_com${SUFFIX}"
+TG_NAME="tg-nextshopfront-droplinked-com${TG_SUFFIX}"
+SERVICE_NAME="nextshopfront_droplinked_com${SUFFIX}_service"
+
+echo "=========================================================="
+echo " Next-ShopFront ECS provisioner"
+echo " Env:        $ENV_ARG"
+echo " Region:     $REGION"
+echo " Cluster:    $CLUSTER"
+echo " ECR repo:   $ECR_REPO"
+echo " Task-def:   $TASKDEF_FAMILY"
+echo " TG:         $TG_NAME"
+echo " Service:    $SERVICE_NAME"
+echo " Host:       $HOST"
+echo " Source td:  $SOURCE_TASKDEF"
+echo " Log:        $LOG_FILE"
+echo "=========================================================="
+echo
+
+set -x
+
+############################################
+# 1. ECR repository (idempotent)
+############################################
+if aws ecr describe-repositories --repository-names "$ECR_REPO" --region "$REGION" >/dev/null 2>&1; then
+  echo "[skip] ECR repo $ECR_REPO already exists"
+else
+  aws ecr create-repository \
+    --repository-name "$ECR_REPO" \
+    --image-scanning-configuration scanOnPush=true \
+    --image-tag-mutability MUTABLE \
+    --region "$REGION"
+fi
+
+# Lifecycle policy is overwrite-safe — re-apply unconditionally
+aws ecr put-lifecycle-policy \
+  --repository-name "$ECR_REPO" \
+  --lifecycle-policy-text '{"rules":[{"rulePriority":1,"description":"Keep last 30 images","selection":{"tagStatus":"any","countType":"imageCountMoreThan","countNumber":30},"action":{"type":"expire"}}]}' \
+  --region "$REGION"
+
+############################################
+# 2. Task definition — clone source, rename, register
+############################################
+EXISTING_TD=$(aws ecs describe-task-definition \
+  --task-definition "$TASKDEF_FAMILY" \
+  --region "$REGION" \
+  --query 'taskDefinition.taskDefinitionArn' --output text 2>/dev/null || echo "NONE")
+
+if [[ "$EXISTING_TD" != "NONE" && "$EXISTING_TD" != "None" ]]; then
+  echo "[skip] task-def family $TASKDEF_FAMILY already registered: $EXISTING_TD"
+else
+  TD_FILE="/tmp/${TASKDEF_FAMILY}-taskdef.json"
+  aws ecs describe-task-definition \
+    --task-definition "$SOURCE_TASKDEF" \
+    --region "$REGION" \
+    --query 'taskDefinition' --output json \
+    | jq --arg fam "$TASKDEF_FAMILY" --arg cn "$CONTAINER_NAME" '
+        del(.taskDefinitionArn,.revision,.status,.requiresAttributes,
+            .compatibilities,.registeredAt,.registeredBy,.enableFaultInjection)
+        | .family = $fam
+        | .containerDefinitions[0].name = $cn
+      ' > "$TD_FILE"
+  aws ecs register-task-definition \
+    --cli-input-json "file://${TD_FILE}" \
+    --region "$REGION"
+fi
+
+############################################
+# 3. ALB + target group
+############################################
+ALB_ARN=$(aws elbv2 describe-load-balancers \
+  --names "$ALB_NAME" --region "$REGION" \
+  --query 'LoadBalancers[0].LoadBalancerArn' --output text)
+ALB_DNS=$(aws elbv2 describe-load-balancers \
+  --names "$ALB_NAME" --region "$REGION" \
+  --query 'LoadBalancers[0].DNSName' --output text)
+ALB_ZONE=$(aws elbv2 describe-load-balancers \
+  --names "$ALB_NAME" --region "$REGION" \
+  --query 'LoadBalancers[0].CanonicalHostedZoneId' --output text)
+VPC_ID=$(aws elbv2 describe-load-balancers \
+  --names "$ALB_NAME" --region "$REGION" \
+  --query 'LoadBalancers[0].VpcId' --output text)
+
+TG_ARN=$(aws elbv2 describe-target-groups \
+  --names "$TG_NAME" --region "$REGION" \
+  --query 'TargetGroups[0].TargetGroupArn' --output text 2>/dev/null || echo "NONE")
+
+if [[ "$TG_ARN" == "NONE" || "$TG_ARN" == "None" || -z "$TG_ARN" ]]; then
+  TG_ARN=$(aws elbv2 create-target-group \
+    --name "$TG_NAME" \
+    --protocol HTTP --port 3000 --target-type ip \
+    --vpc-id "$VPC_ID" \
+    --health-check-path / --health-check-interval-seconds 30 \
+    --healthy-threshold-count 2 --unhealthy-threshold-count 3 \
+    --region "$REGION" \
+    --query 'TargetGroups[0].TargetGroupArn' --output text)
+else
+  echo "[skip] target group $TG_NAME already exists: $TG_ARN"
+fi
+
+############################################
+# 4. ALB HTTPS listener rule (host header)
+############################################
+HTTPS_LISTENER_ARN=$(aws elbv2 describe-listeners \
+  --load-balancer-arn "$ALB_ARN" --region "$REGION" \
+  --query 'Listeners[?Port==`443`]|[0].ListenerArn' --output text)
+
+EXISTING_RULE=$(aws elbv2 describe-rules \
+  --listener-arn "$HTTPS_LISTENER_ARN" --region "$REGION" \
+  --query "Rules[?Conditions[?Field=='host-header' && contains(Values, '$HOST')]]|[0].RuleArn" \
+  --output text 2>/dev/null || echo "None")
+
+if [[ "$EXISTING_RULE" == "None" || -z "$EXISTING_RULE" ]]; then
+  aws elbv2 create-rule \
+    --listener-arn "$HTTPS_LISTENER_ARN" \
+    --priority "$LISTENER_RULE_PRIORITY" \
+    --conditions "Field=host-header,Values=$HOST" \
+    --actions "Type=forward,TargetGroupArn=$TG_ARN" \
+    --region "$REGION"
+else
+  echo "[skip] listener rule for host $HOST already exists: $EXISTING_RULE"
+fi
+
+############################################
+# 5. ECS service — COST-GATED
+############################################
+EXISTING_SVC=$(aws ecs describe-services \
+  --cluster "$CLUSTER" --services "$SERVICE_NAME" --region "$REGION" \
+  --query 'services[?status==`ACTIVE`]|[0].serviceName' --output text 2>/dev/null || echo "None")
+
+if [[ "$EXISTING_SVC" != "None" && -n "$EXISTING_SVC" && "$EXISTING_SVC" != "null" ]]; then
+  echo "[skip] ECS service $SERVICE_NAME already ACTIVE"
+else
+  set +x
+  echo
+  echo "=========================================================="
+  echo " COST WARNING"
+  echo "=========================================================="
+  echo " About to create Fargate ECS service: $SERVICE_NAME"
+  echo " Estimated ongoing cost: ~\$18/mo (0.5 vCPU, 1 GB, 24x7)"
+  echo " Combined DEV+PROD when both provisioned: ~\$36/mo"
+  echo " This is the ONLY cost-incurring step in this script."
+  echo "=========================================================="
+  read -r -p "Proceed with create-service? (Y/N) " CONFIRM
+  if [[ "$CONFIRM" != "Y" && "$CONFIRM" != "y" ]]; then
+    echo "Aborted by operator before create-service. ECR/task-def/TG/listener are in place; re-run anytime."
+    exit 0
+  fi
+  set -x
+
+  # Pull network config from source service (subnets, security groups)
+  SRC_NET=$(aws ecs describe-services \
+    --cluster "$CLUSTER" --services "$SOURCE_SERVICE" --region "$REGION" \
+    --query 'services[0].networkConfiguration' --output json)
+  SUBNETS=$(echo "$SRC_NET" | jq -r '.awsvpcConfiguration.subnets | join(",")')
+  SGS=$(echo "$SRC_NET" | jq -r '.awsvpcConfiguration.securityGroups | join(",")')
+  ASSIGN_PUBLIC=$(echo "$SRC_NET" | jq -r '.awsvpcConfiguration.assignPublicIp // "DISABLED"')
+
+  aws ecs create-service \
+    --cluster "$CLUSTER" \
+    --service-name "$SERVICE_NAME" \
+    --task-definition "$TASKDEF_FAMILY" \
+    --desired-count 1 \
+    --launch-type FARGATE \
+    --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SGS],assignPublicIp=$ASSIGN_PUBLIC}" \
+    --load-balancers "targetGroupArn=$TG_ARN,containerName=$CONTAINER_NAME,containerPort=3000" \
+    --deployment-configuration "maximumPercent=200,minimumHealthyPercent=100,deploymentCircuitBreaker={enable=true,rollback=true}" \
+    --region "$REGION"
+fi
+
+############################################
+# 6. Route53 A-alias
+############################################
+ZONE_ID=$(aws route53 list-hosted-zones-by-name \
+  --dns-name "droplinked.com." \
+  --query 'HostedZones[?Name==`droplinked.com.`]|[0].Id' --output text \
+  | sed 's|/hostedzone/||')
+
+CHANGE_BATCH=$(jq -n \
+  --arg name "$HOST." \
+  --arg zone "$ALB_ZONE" \
+  --arg dns "$ALB_DNS" \
+  '{Changes:[{Action:"UPSERT",ResourceRecordSet:{Name:$name,Type:"A",AliasTarget:{HostedZoneId:$zone,DNSName:$dns,EvaluateTargetHealth:true}}}]}')
+
+aws route53 change-resource-record-sets \
+  --hosted-zone-id "$ZONE_ID" \
+  --change-batch "$CHANGE_BATCH"
+
+set +x
+
+############################################
+# Done — print rollback commands
+############################################
+echo
+echo "=========================================================="
+echo " PROVISIONING COMPLETE — env=$ENV_ARG"
+echo "=========================================================="
+echo " Log:        $LOG_FILE"
+echo " Hostname:   https://$HOST/"
+echo " Service:    $SERVICE_NAME (desired=1)"
+echo " Target grp: $TG_ARN"
+echo
+echo " Next steps:"
+echo "   1. Wait for ECS task to reach RUNNING (aws ecs describe-services ...)."
+echo "   2. curl -I https://$HOST/  → expect 200."
+echo "   3. Run commerce-smoke 8/8 on $HOST."
+echo "   4. Merge PR #43 → workflow deploys to $SERVICE_NAME."
+echo
+echo "=========================================================="
+echo " ROLLBACK (run if new service is unhealthy)"
+echo "=========================================================="
+cat <<EOF
+# Scale service to 0 (stops cost immediately)
+aws ecs update-service --cluster $CLUSTER --service $SERVICE_NAME --desired-count 0 --region $REGION
+
+# Delete service
+aws ecs delete-service --cluster $CLUSTER --service $SERVICE_NAME --force --region $REGION
+
+# Delete listener rule
+RULE_ARN=\$(aws elbv2 describe-rules --listener-arn $HTTPS_LISTENER_ARN --region $REGION \\
+  --query "Rules[?Conditions[?Field=='host-header' && contains(Values, '$HOST')]]|[0].RuleArn" --output text)
+aws elbv2 delete-rule --rule-arn "\$RULE_ARN" --region $REGION
+
+# Delete target group
+aws elbv2 delete-target-group --target-group-arn $TG_ARN --region $REGION
+
+# (Optional) Delete Route53 alias
+# Edit the A record back to the previous shared ALB target, or DELETE via change-resource-record-sets.
+
+# ECR repo + task-def can be left in place — harmless when unused, avoids recreate on retry.
+EOF
+echo "=========================================================="


### PR DESCRIPTION
## Summary

Re-point Next-ShopFront `dev.yml` and `main.yml` at a **dedicated** ECS service / ECR repo / task-def / container name, so this repo no longer collides with `droplinked-shop-builder` on the shared `shopdev_droplinked_com_service` / `shop_droplinked_com_service`. Closes #41.

- DEV  → `nextshopfront_droplinked_com{,_service}`
- PROD → `nextshopfront_droplinked_com_prod{,_service}`
- shop-builder workflows **unchanged** (it actually publishes to S3+CloudFront — the historical name overlap is now purely cosmetic on its side).

## Files

- `.github/workflows/dev.yml` — env block re-pointed, with inline rationale.
- `.github/workflows/main.yml` — env block re-pointed, with inline rationale.
- `docs/ECS_SPLIT_MIGRATION.md` — operator playbook (now a fallback reference; script below is the supported path).
- `scripts/provision-nextshopfront-ecs.sh` — **one-shot idempotent provisioner** (NEW).

## HOLD — operator action required before merge

This PR **does not provision AWS resources**. Per `feedback-actions-budget-elasticity`, the ~$36/mo Fargate delta crosses the $5/mo threshold and needs operator authorization.

Once the cost is approved, provisioning is a single command:

```bash
# DEV
bash scripts/provision-nextshopfront-ecs.sh dev

# PROD (after DEV smoke is GREEN)
bash scripts/provision-nextshopfront-ecs.sh prod
```

The script is idempotent — re-running it skips resources that already exist. It prompts `Y/N` before the only cost-incurring step (`ecs create-service`), tees a full audit log to `/tmp/provision-nextshopfront-<env>-<ts>.log`, and prints copy-pasteable rollback commands when it finishes.

Sequence:

1. Operator runs `bash scripts/provision-nextshopfront-ecs.sh dev`, confirms cost prompt.
2. Operator confirms new DEV `nextshopfront-dev.droplinked.com` task is RUNNING.
3. Merge this PR → `dev.yml` deploys → commerce-smoke 8/8 on the new DEV host.
4. Operator runs `bash scripts/provision-nextshopfront-ecs.sh prod`.
5. Per `feedback-never-dispatch-live-without-dev-smoke-2026-05-19` and `feedback-storefront-mobile-smoke-before-live-2026-05-19`: only after DEV smoke + mobile-viewport check is GREEN do we `workflow_dispatch main.yml` for LIVE.

The manual CLI block previously listed in this PR description is preserved in `docs/ECS_SPLIT_MIGRATION.md` as a break-glass reference.

## Test plan

- [ ] Operator: `bash scripts/provision-nextshopfront-ecs.sh dev` completes, ECS task RUNNING.
- [ ] Merge to `main`-equivalent → `dev.yml` GitHub Actions run completes green.
- [ ] `curl -I https://nextshopfront-dev.droplinked.com/` → 200.
- [ ] Commerce smoke 8/8 on `nextshopfront-dev.droplinked.com` (browse, PDP, add-to-cart, shipping rates, subscription/plans, payment-page reachable).
- [ ] Mobile-viewport check (iPhone/Pixel/iPad — no horizontal scroll, no clipped dropdowns, CTAs above fold).
- [ ] `dev.droplinked.com` (shop-builder DEV) still 200 — unaffected.
- [ ] CloudWatch logs for new service contain only Next-ShopFront SHAs.
- [ ] Operator `bash scripts/provision-nextshopfront-ecs.sh prod` + `workflow_dispatch main.yml` only AFTER all of the above.