### PR TITLE
chore(security): migrate dev.yml from static AWS keys to OIDC (#1241)

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -24,6 +24,7 @@ env:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   deploy:
@@ -35,11 +36,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
 
-    - name: Configure AWS credentials
+    - name: Configure AWS credentials (OIDC)
       uses: aws-actions/configure-aws-credentials@v6
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: arn:aws:iam::353643723135:role/github-actions-deploy
         aws-region: ${{ env.AWS_REGION }}
 
     - name: Login to Amazon ECR


### PR DESCRIPTION
## Summary

Migrates `.github/workflows/dev.yml` from static `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` repo secrets to GitHub OIDC trusted-publisher pattern.

- Replaces access-key/secret-key inputs with `role-to-assume: arn:aws:iam::353643723135:role/github-actions-deploy`
- Adds `id-token: write` permission at job level (kept `contents: read`)
- Uses already-current `aws-actions/configure-aws-credentials@v6` + `actions/checkout@v6`
- Pattern mirrors what droplinked-backend `dev.yml` + `main.yml` already use

Refs: droplinked/droplinked-backend#1241
Runbook: droplinked/droplinked-backend#1255

## DO NOT AUTO-MERGE — operator-gated

Merge to `main` triggers a LIVE-tier deploy for shop.droplinked.com. Operator pre-flight required:

1. Confirm `github-actions-deploy` IAM role trust policy permits `repo:droplinked/Next-ShopFront:*` (current wildcard `repo:droplinked/*` covers it, but operator may have tightened to an explicit allowlist).
2. Confirm role policy grants the ECR push + ECS describe/register/update-service actions the existing static-key user had.
3. After merge: monitor first `dev.yml` run, run commerce-smoke 8/8 on shop.droplinked.com.
4. After both this PR + SuperAdmin-Front sibling PR are deployed + verified green: delete the org-level `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (stale 2023-05-27 IAM user) per #1241.

## Test plan

- [ ] Operator verifies IAM role trust + permission policies cover this repo
- [ ] Operator merges; first `dev.yml` run authenticates via OIDC (no 403 from STS AssumeRoleWithWebIdentity)
- [ ] ECR push + ECS deploy succeed
- [ ] Commerce-smoke 8/8 green on shop.droplinked.com
- [ ] Org-level static keys deleted after sibling SuperAdmin-Front PR is also verified