### PR TITLE
[P0 HOTFIX] Remove duplicate cspReportOnly in next.config.mjs — restore shop.droplinked.com

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,22 +1,5 @@
 import { withSentryConfig } from '@sentry/nextjs';
 
-// Content-Security-Policy in Report-Only mode. Mirrors the directives
-// shipped on the other three droplinked frontends so violation reports
-// are comparable. NOT enforcing yet — emits violations to the
-// configured report-uri so we can audit before flipping to enforce.
-// Operator: replace the placeholder report-uri with the project's real
-// Sentry Security endpoint.
-const cspReportOnly = [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.droplinked.com https://*.googletagmanager.com https://www.google-analytics.com",
-    "connect-src 'self' https://apiv3.droplinked.com https://apiv3dev.droplinked.com https://*.algolia.net https://*.algolianet.com https://*.sentry.io wss://* https://*.googleapis.com",
-    "img-src 'self' data: blob: https:",
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-    "font-src 'self' data: https://fonts.gstatic.com",
-    "frame-src 'self' https://*.stripe.com",
-    "report-uri https://sentry.io/api/<project>/security/?sentry_key=<key>",
-].join('; ');
-
 /** @type {import('next').NextConfig} */
 
 // CSP Report-Only — week 1 of rollout. See droplink-packages docs PR #36


### PR DESCRIPTION
**P0 — shop.droplinked.com is 503ing right now because of this.**

## Diagnosis

`next.config.mjs` contains two `const cspReportOnly = [...]` blocks (collision between PR #23 CSP Report-Only merge and a re-roll, likely from PR #27 or #40). This causes:

```
SyntaxError: Identifier 'cspReportOnly' has already been declared
```

→ `next build` fails → ECS task cannot start → no healthy targets behind ALB → **503 on shop.droplinked.com**.

## Fix

Remove the **first** (older / less-complete) block at lines 9-18. Keep the second block which has the more-complete CSP directives including `frame-ancestors 'none'`, `base-uri`, `form-action`, `object-src 'none'`, and `upgrade-insecure-requests`.

One file change. One declaration removed. The surviving block begins with `default-src 'self'` and includes `frame-ancestors 'none'`, `base-uri 'self'`, `form-action 'self' https://accept.paymob.com`, `object-src 'none'`, `upgrade-insecure-requests`.

## Verification

Before:
```
 ⨯ Failed to load next.config.mjs
[SyntaxError: Identifier 'cspReportOnly' has already been declared]
```

After:
```
 ✓ Generating static pages (14/14)
   Finalizing page optimization ...
   Collecting build traces ...
```

Exit 0. Standalone output emitted.

## Re-audit required before merge

Needs adversarial re-audit:
- Confirm the deleted block is the older / less-complete one (the one without `frame-ancestors`/`base-uri`/`form-action`/`object-src`/`upgrade-insecure-requests`).
- Confirm the surviving block has the intended CSP directives intact.
- Note: the deleted block had `frame-src 'self' https://*.stripe.com`; the surviving block has `frame-src 'self' https://accept.paymob.com` only. If Stripe Elements iframes are used on this surface, that's a follow-up — but not a regression vs. main since main does not build at all.

## DO NOT LIVE-dispatch until

1. PR re-audited and merged.
2. PR #47 (lockfile heal) also resolved **OR** build verified to succeed on the broken lockfile (this hotfix was verified with `npm install`, which worked clean — `npm ci` not tested).
3. ECS service confirmed to scale back up after the deploy (target group healthy hosts > 0, shop.droplinked.com returns 200).

## Related

- Next-ShopFront issue #46 (full diagnosis)
- PR #47 (lockfile heal — separate workstream)
- PR #23 (CSP Report-Only merge — origin of one of the two declarations)

## Operator notes

- `npm install` ran clean.
- `npx next build` ran clean — exit 0, standalone bundle emitted.
- Branched off current main HEAD.
