### PR TITLE
[follow-up to #48] Restore Stripe + PSP frame-src in CSP Report-Only

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -29,12 +29,12 @@ const cspReportOnly = [
 // `'unsafe-inline'` is required for GTM bootstrap + Next.js style-jsx.
 const cspReportOnly = [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://js.stripe.com",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.cdnfonts.com",
     "font-src 'self' https://fonts.gstatic.com https://fonts.cdnfonts.com data:",
     "img-src 'self' data: blob: https://upload-file-droplinked.s3.amazonaws.com https://upload-file-flatlay.s3.us-west-2.amazonaws.com https://files.cdn.printful.com https://*.cloudfront.net https://www.google-analytics.com",
-    "connect-src 'self' https://apiv3.droplinked.com https://apiv3dev.droplinked.com https://tools.droplinked.com https://ipapi.co https://accept.paymob.com https://*.ingest.sentry.io https://www.google-analytics.com",
-    "frame-src 'self' https://accept.paymob.com",
+    "connect-src 'self' https://apiv3.droplinked.com https://apiv3dev.droplinked.com https://tools.droplinked.com https://ipapi.co https://accept.paymob.com https://*.ingest.sentry.io https://www.google-analytics.com https://api.stripe.com",
+    "frame-src 'self' https://accept.paymob.com https://js.stripe.com https://hooks.stripe.com",
     "frame-ancestors 'none'",
     "base-uri 'self'",
     "form-action 'self' https://accept.paymob.com",


### PR DESCRIPTION
## Follow-up to #48 (P0 hotfix)

PR #48 removes the older of two duplicate `cspReportOnly` blocks to unblock `next build`. The deleted block had `frame-src https://*.stripe.com`; the surviving block does not.

## Why this matters

Next-ShopFront uses **Stripe Elements** (iframe-based, not redirect):

- `src/components/ui/stripe/AppStripe.tsx` — `import { Elements } from '@stripe/react-stripe-js'`
- `src/components/ui/stripe/form/CheckoutForm.tsx` — `import { PaymentElement, useElements, useStripe } from '@stripe/react-stripe-js'`
- `package.json` — `@stripe/react-stripe-js ^2.6.2`, `@stripe/stripe-js ^3.0.10`

These mount iframes from `js.stripe.com` (Elements UI) and `hooks.stripe.com` (3DS challenge) and XHR to `api.stripe.com`. Once #48 ships, the Report-Only header will start logging violations on every Stripe checkout; the moment we flip CSP to enforce, Stripe payments BREAK.

## Change

Scope is strict: only `next.config.mjs`, only the surviving `cspReportOnly` block (the one with `frame-ancestors 'none'`).

```diff
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://js.stripe.com",
-    "connect-src 'self' ... https://www.google-analytics.com",
+    "connect-src 'self' ... https://www.google-analytics.com https://api.stripe.com",
-    "frame-src 'self' https://accept.paymob.com",
+    "frame-src 'self' https://accept.paymob.com https://js.stripe.com https://hooks.stripe.com",
```

## Other PSP audit (Next-ShopFront `src/`)

| PSP | Client SDK present? | iframe? | Action |
|-----|--------------------:|--------:|--------|
| Stripe | YES (`@stripe/react-stripe-js`) | Elements | Added in this PR |
| PayMob | (server-redirect) | iframe | Already in surviving block |
| PayPal | No `@paypal/*`, no `paypal.com` refs in `src/` | server-side | none needed |
| Crossmint | No client refs in `src/` | server-side | none needed |
| Telr | No client refs in `src/` | server-side | none needed |
| Circle / WalletConnect | No frame-mounting modal refs found | n/a | none needed |

## Sequencing

Land AFTER #48. #48 stays a clean single-block deletion; this PR is the additive companion.

## Verification

- Diff is 3 lines, all to the surviving block.
- `next build` not run here because the duplicate declaration on main makes build fail — that is exactly what #48 fixes; rebase after #48 merges and CI runs clean.

## Re-audit

`needs-re-audit` per standing rule. Specifically confirm:
1. The block being edited is the one with `frame-ancestors 'none'` (yes — second block on main, surviving after #48).
2. No other CSP directives loosened (script-src `unsafe-eval` unchanged; default-src still `self`).
3. No other PSP iframe surfaces missed.
