### PR TITLE
fix(checkout): preserve /s/ path prefix in Stripe return_url for droplinked.com/s/{store} routing

### DIFF
--- a/src/app/(routes)/checkout/components/summary/components/PaymentModal.tsx
+++ b/src/app/(routes)/checkout/components/summary/components/PaymentModal.tsx
@@ -171,7 +171,12 @@ const PaymentModal = ({ stripe }: { stripe: { client_secret: string; orderID: st
             then: (
               <Elements stripe={stripePromise} options={elementsOptions!}>
                 <StripePaymentForm
-                  return_url={typeof window !== 'undefined' ? `${window.location.origin}/orders/${stripe?.orderID}` : `/orders/${stripe?.orderID}`}
+                  return_url={(() => {
+                    if (typeof window === 'undefined') return `/orders/${stripe?.orderID}`;
+                    // Preserve droplinked.com/s/{shop} prefix so post-payment lands back inside the path-routed shop surface
+                    const prefix = window.location.pathname.startsWith('/s/') ? '/s' : '';
+                    return `${window.location.origin}${prefix}/orders/${stripe?.orderID}`;
+                  })()}
                   onSuccess={() => {
                     toast.success('Payment successful');
                   }}


### PR DESCRIPTION
## Why

Companion fix for the new CloudFront /s/* routing on `droplinked.com` (SEO/AEO consolidation per AM 5-20 strategic ask — Option B in `~/droplinked-ops/cloudfront-droplinked-com-shop-prefix-2026-05-20.md`).

When a customer reaches a storefront via `droplinked.com/s/{shopUrl}`, the Stripe `return_url` was being built as `\${window.location.origin}/orders/\${id}` → `https://droplinked.com/orders/{id}` — which drops the `/s/` segment and lands the customer on the droplinked.com marketing S3 origin (404 / SPA shell) after successful payment.

## Fix

Detect the `/s/` prefix on `window.location.pathname` and preserve it in `return_url` so post-payment customers land back inside the path-routed shop surface.

## Backward compatibility

When pathname has no `/s/` prefix (customers on `shop.droplinked.com` or `shopdev.droplinked.com` directly), behavior is identical to before — no prefix prepended. **Zero regression risk for existing shop.droplinked.com surface.**

## Audit notes

- Single file changed: `src/app/(routes)/checkout/components/summary/components/PaymentModal.tsx` (~6 lines)
- No new deps, no env-vars, no API contract changes
- Compile-clean on my patch (pre-existing TS errors in `footer.tsx`, `Header.tsx`, `empty-cart.tsx`, `CartTrigger.tsx` are unrelated to this PR)

## Verification

After CloudFront /s/* routing is activated:
1. Visit `https://droplinked.com/s/unstoppable` → browse → add to cart → checkout
2. Complete Stripe test payment
3. Confirm landing URL is `https://droplinked.com/s/unstoppable/orders/{id}` (not `https://droplinked.com/orders/{id}`)
4. Negative check on `https://shop.droplinked.com/unstoppable` — same flow, lands at `https://shop.droplinked.com/orders/{id}` as before

## Standing rules

- Needs adversarial re-audit before merge per [[feedback-pre-merge-reaudit-required]]
- LIVE on Vercel deploy on merge — confirm DEV smoke green per [[feedback-never-dispatch-live-without-dev-smoke-2026-05-19]]
- This is a revenue-path file — extra care per [[feedback-checkout-type-errors-top-priority]]