### PR TITLE
[DRAFT] feat: affiliate-products + MCP + public-API scaffolds (path-agnostic)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "prod": "next start -p 80",
     "lint": "next lint",
-    "test": "node --test 'src/__smoke__/*.test.mjs'",
+    "test": "node --test 'src/__smoke__/*.test.mjs' 'src/app/api/mcp/tools/__tests__/*.test.mjs'",
     "test:mobile": "playwright test --config=playwright.config.ts",
     "test:mobile:smoke": "playwright test --config=playwright.config.ts smoke",
     "test:mobile:ui": "playwright test --config=playwright.config.ts --ui",

--- a/src/app/(routes)/affiliate-products/page.tsx
+++ b/src/app/(routes)/affiliate-products/page.tsx
@@ -1,19 +1,286 @@
 import { Suspense } from 'react'
-type AffiliateProduct = { id: string; title: string; price: { amount: number; currency: string } }
-async function fetchProducts(sp: URLSearchParams): Promise<AffiliateProduct[]> {
-  try {
-    const res = await fetch(`/api/public/products?${sp.toString()}`, { cache: 'no-store' })
-    if (!res.ok) return []
-    const json = await res.json()
-    return Array.isArray(json?.data) ? json.data : []
-  } catch { return [] }
+import type { Metadata } from 'next'
+
+/**
+ * Public affiliate-product listing — path-agnostic scaffold.
+ *
+ * Sidekick's /<storename>/ URL framework hasn't landed yet, so this route is
+ * mounted directly under (routes) without a store prefix. Once the framework
+ * lands the page can be relocated under the dynamic [store] segment without
+ * touching the component — the `store` searchParam already drives the query.
+ *
+ * Backend contract: apiv3 PR #1278 → GET /products/public proxied via
+ * /api/public/products. We pass `affiliate=true` so apiv3 returns the
+ * commission-eligible subset.
+ */
+
+type AffiliateProduct = {
+  id: string
+  title: string
+  slug?: string
+  image?: string
+  price: { amount: number; currency: string }
+  commission?: { percentage?: number; amount?: number; currency?: string }
+  category?: string
 }
-export default async function AffiliateProductsPage({ searchParams }: { searchParams: Promise<{ store?: string; category?: string; q?: string }> }) {
-  const p = await searchParams
+
+type ListResponse = {
+  data: AffiliateProduct[]
+  page?: number
+  totalPages?: number
+  total?: number
+  categories?: string[]
+}
+
+// Product `category` enum as known to the public products endpoint. Mirrors
+// the apiv3 schema; keep this in sync if backend adds categories.
+const KNOWN_CATEGORIES = [
+  'apparel',
+  'accessories',
+  'home',
+  'beauty',
+  'electronics',
+  'collectibles',
+  'digital',
+  'other',
+] as const
+
+type SearchParamsShape = {
+  store?: string
+  category?: string
+  q?: string
+  page?: string
+}
+
+function buildQuery(p: SearchParamsShape): URLSearchParams {
   const sp = new URLSearchParams({ affiliate: 'true' })
   if (p.store) sp.set('store', p.store)
   if (p.category) sp.set('category', p.category)
   if (p.q) sp.set('q', p.q)
-  const products = await fetchProducts(sp)
-  return (<main><h1>Affiliate Products</h1><Suspense><ul>{products.map(x => <li key={x.id}>{x.title} — {x.price.amount} {x.price.currency}</li>)}</ul></Suspense></main>)
+  if (p.page) sp.set('page', p.page)
+  sp.set('limit', '24')
+  return sp
+}
+
+async function fetchProducts(sp: URLSearchParams, origin: string): Promise<ListResponse> {
+  try {
+    const res = await fetch(`${origin}/api/public/products?${sp.toString()}`, {
+      cache: 'no-store',
+    })
+    if (!res.ok) return { data: [] }
+    const json = await res.json()
+    if (Array.isArray(json?.data)) return json as ListResponse
+    if (Array.isArray(json)) return { data: json }
+    return { data: [] }
+  } catch {
+    return { data: [] }
+  }
+}
+
+function getOrigin(): string {
+  // Support SSR fetch in dev + prod. Server-side fetch requires absolute URL.
+  const envOrigin = process.env.NEXT_PUBLIC_BASE_URL || process.env.NEXTAUTH_URL
+  if (envOrigin) return envOrigin.replace(/\/$/, '')
+  const port = process.env.PORT || '3000'
+  return `http://127.0.0.1:${port}`
+}
+
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParamsShape>
+}): Promise<Metadata> {
+  const p = await searchParams
+  const storeLabel = p.store ? ` from ${p.store}` : ''
+  const titleBase = `Affiliate products${storeLabel}`
+  return {
+    title: titleBase,
+    description: `Discover affiliate-ready products${storeLabel} on Droplinked. Earn commissions by sharing.`,
+    openGraph: { title: titleBase, type: 'website' },
+  }
+}
+
+function ProductCard({ product }: { product: AffiliateProduct }) {
+  const commissionPct = product.commission?.percentage
+  return (
+    <li className="group flex flex-col overflow-hidden rounded-lg border border-neutral-200 bg-white shadow-sm transition hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="relative aspect-square w-full overflow-hidden bg-neutral-100 dark:bg-neutral-800">
+        {product.image ? (
+          // Using <img> intentionally — public product images come from arbitrary
+          // merchant origins and we don't want to widen next/image remotePatterns
+          // for an MVP listing.
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={product.image}
+            alt={product.title}
+            loading="lazy"
+            className="h-full w-full object-cover transition group-hover:scale-105"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-sm text-neutral-400">
+            No image
+          </div>
+        )}
+        {typeof commissionPct === 'number' && (
+          <span className="absolute right-2 top-2 rounded-full bg-emerald-600 px-2 py-0.5 text-xs font-medium text-white shadow">
+            {commissionPct}% commission
+          </span>
+        )}
+      </div>
+      <div className="flex flex-1 flex-col gap-1 p-3">
+        <h3 className="line-clamp-2 text-sm font-medium text-neutral-900 dark:text-neutral-100">
+          {product.title}
+        </h3>
+        <div className="mt-auto flex items-baseline gap-1">
+          <span className="text-base font-semibold text-neutral-900 dark:text-neutral-50">
+            {product.price.amount}
+          </span>
+          <span className="text-xs uppercase text-neutral-500">{product.price.currency}</span>
+        </div>
+      </div>
+    </li>
+  )
+}
+
+function EmptyState({ q }: { q?: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-neutral-300 p-8 text-center dark:border-neutral-700">
+      <p className="text-base font-medium text-neutral-700 dark:text-neutral-200">
+        No affiliate products found
+      </p>
+      <p className="mt-1 text-sm text-neutral-500">
+        {q
+          ? `Nothing matched "${q}". Try a broader search or clear filters.`
+          : 'Check back soon — merchants add affiliate-ready products often.'}
+      </p>
+    </div>
+  )
+}
+
+function Skeleton() {
+  return (
+    <ul className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <li
+          key={i}
+          className="aspect-[3/4] animate-pulse rounded-lg bg-neutral-100 dark:bg-neutral-800"
+        />
+      ))}
+    </ul>
+  )
+}
+
+async function ProductsGrid({ params }: { params: SearchParamsShape }) {
+  const sp = buildQuery(params)
+  const origin = getOrigin()
+  const { data, page = 1, totalPages = 1 } = await fetchProducts(sp, origin)
+
+  if (data.length === 0) return <EmptyState q={params.q} />
+
+  // Preserve current filters across pagination links.
+  const linkParams = new URLSearchParams()
+  if (params.store) linkParams.set('store', params.store)
+  if (params.category) linkParams.set('category', params.category)
+  if (params.q) linkParams.set('q', params.q)
+  const prevPage = Math.max(1, page - 1)
+  const nextPage = page + 1
+  const prevHref = `?${(() => { const x = new URLSearchParams(linkParams); x.set('page', String(prevPage)); return x.toString() })()}`
+  const nextHref = `?${(() => { const x = new URLSearchParams(linkParams); x.set('page', String(nextPage)); return x.toString() })()}`
+
+  return (
+    <>
+      <ul className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+        {data.map((product) => (
+          <ProductCard key={product.id} product={product} />
+        ))}
+      </ul>
+      <nav
+        aria-label="Pagination"
+        className="mt-6 flex items-center justify-between text-sm text-neutral-600 dark:text-neutral-300"
+      >
+        <a
+          href={prevHref}
+          aria-disabled={page <= 1}
+          className={`rounded-md border border-neutral-300 px-3 py-1.5 dark:border-neutral-700 ${
+            page <= 1 ? 'pointer-events-none opacity-40' : 'hover:bg-neutral-50 dark:hover:bg-neutral-800'
+          }`}
+        >
+          Previous
+        </a>
+        <span>
+          Page {page} of {totalPages || 1}
+        </span>
+        <a
+          href={nextHref}
+          aria-disabled={page >= totalPages}
+          className={`rounded-md border border-neutral-300 px-3 py-1.5 dark:border-neutral-700 ${
+            page >= totalPages ? 'pointer-events-none opacity-40' : 'hover:bg-neutral-50 dark:hover:bg-neutral-800'
+          }`}
+        >
+          Next
+        </a>
+      </nav>
+    </>
+  )
+}
+
+export default async function AffiliateProductsPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParamsShape>
+}) {
+  const params = await searchParams
+
+  return (
+    <main className="mx-auto w-full max-w-6xl px-4 py-6 sm:py-10">
+      <header className="mb-6">
+        {/* Sentence-case D1 per UXUI doc. */}
+        <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-50 sm:text-3xl">
+          Affiliate products
+        </h1>
+        <p className="mt-1 text-sm text-neutral-500">
+          Earn commissions by sharing these products.
+        </p>
+      </header>
+
+      <form
+        method="GET"
+        className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center"
+        role="search"
+      >
+        {params.store && <input type="hidden" name="store" value={params.store} />}
+        <input
+          type="search"
+          name="q"
+          defaultValue={params.q ?? ''}
+          placeholder="Search products"
+          aria-label="Search products"
+          className="flex-1 rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-neutral-500 focus:outline-none dark:border-neutral-700 dark:bg-neutral-900"
+        />
+        <select
+          name="category"
+          defaultValue={params.category ?? ''}
+          aria-label="Filter by category"
+          className="rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm dark:border-neutral-700 dark:bg-neutral-900"
+        >
+          <option value="">All categories</option>
+          {KNOWN_CATEGORIES.map((c) => (
+            <option key={c} value={c}>
+              {c.charAt(0).toUpperCase() + c.slice(1)}
+            </option>
+          ))}
+        </select>
+        <button
+          type="submit"
+          className="rounded-md bg-neutral-900 px-4 py-2 text-sm font-medium text-white hover:bg-neutral-800 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-white"
+        >
+          Apply
+        </button>
+      </form>
+
+      <Suspense fallback={<Skeleton />}>
+        <ProductsGrid params={params} />
+      </Suspense>
+    </main>
+  )
 }

--- a/src/app/(routes)/affiliate-products/page.tsx
+++ b/src/app/(routes)/affiliate-products/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from 'react'
+type AffiliateProduct = { id: string; title: string; price: { amount: number; currency: string } }
+async function fetchProducts(sp: URLSearchParams): Promise<AffiliateProduct[]> {
+  try {
+    const res = await fetch(`/api/public/products?${sp.toString()}`, { cache: 'no-store' })
+    if (!res.ok) return []
+    const json = await res.json()
+    return Array.isArray(json?.data) ? json.data : []
+  } catch { return [] }
+}
+export default async function AffiliateProductsPage({ searchParams }: { searchParams: Promise<{ store?: string; category?: string; q?: string }> }) {
+  const p = await searchParams
+  const sp = new URLSearchParams({ affiliate: 'true' })
+  if (p.store) sp.set('store', p.store)
+  if (p.category) sp.set('category', p.category)
+  if (p.q) sp.set('q', p.q)
+  const products = await fetchProducts(sp)
+  return (<main><h1>Affiliate Products</h1><Suspense><ul>{products.map(x => <li key={x.id}>{x.title} — {x.price.amount} {x.price.currency}</li>)}</ul></Suspense></main>)
+}

--- a/src/app/.well-known/mcp/route.ts
+++ b/src/app/.well-known/mcp/route.ts
@@ -1,16 +1,132 @@
 import { NextResponse } from 'next/server'
+
+/**
+ * MCP discovery manifest served at /.well-known/mcp.
+ *
+ * Each tool definition includes a short `description`, an extended
+ * `description_long` (usage guidance for autonomous agents), and an
+ * `examples` array (input + expected-output shape) so an agent can learn
+ * the surface from this document alone without a separate doc round-trip.
+ */
+
 export async function GET(request: Request) {
   const host = request.headers.get('host') ?? 'droplinked.com'
   const base = `https://${host}`
+
+  const tools = [
+    {
+      name: 'list_products',
+      endpoint: `${base}/api/mcp/tools/list_products`,
+      method: 'POST',
+      description: 'List affiliate-available products.',
+      description_long:
+        'Returns a paginated list of products that have affiliate commissions enabled. Supports filtering by `store` (shop URL slug), `category` (one of the storefront category enums), and free-text `q`. Use this to populate a browsable catalogue or to find candidate products to share. Pair with `get_affiliate_link` once the user picks a product.',
+      input_schema: {
+        type: 'object',
+        properties: {
+          store: { type: 'string', description: 'Optional shop URL slug to scope results.' },
+          category: { type: 'string', description: 'Optional category filter; see get_categories.' },
+          q: { type: 'string', description: 'Optional free-text search.' },
+          page: { type: 'integer', minimum: 1, default: 1 },
+          limit: { type: 'integer', minimum: 1, maximum: 100, default: 20 },
+        },
+      },
+      examples: [
+        {
+          input: { category: 'apparel', limit: 5 },
+          output_shape: { data: '[{id,title,price,commission}]', page: 1, totalPages: 'number' },
+        },
+        {
+          input: { q: 'hoodie', store: 'roomours' },
+          output_shape: { data: '[Product]' },
+        },
+      ],
+    },
+    {
+      name: 'get_product',
+      endpoint: `${base}/api/mcp/tools/get_product`,
+      method: 'POST',
+      description: 'Fetch product details by id or slug.',
+      description_long:
+        'Returns the full public-facing product record. `id_or_slug` may be either the MongoDB ObjectId hex or the URL slug; the API resolves both. Use after `list_products` to fetch full descriptions, image galleries, and SKU variants.',
+      input_schema: {
+        type: 'object',
+        required: ['id_or_slug'],
+        properties: {
+          id_or_slug: { type: 'string', description: 'Product ObjectId or URL slug.' },
+        },
+      },
+      examples: [
+        { input: { id_or_slug: '6710abc...' }, output_shape: { id: 'string', title: 'string', variants: 'array' } },
+      ],
+    },
+    {
+      name: 'get_affiliate_link',
+      endpoint: `${base}/api/mcp/tools/get_affiliate_link`,
+      method: 'POST',
+      description: 'Generate affiliate-tagged checkout URL.',
+      description_long:
+        'Returns a shareable URL that attributes any resulting purchase to the supplied `affiliate_code`. `affiliate_code` is 3-64 chars of [A-Za-z0-9_-]; the apiv3 backend resolves it to the registered affiliate at checkout time. No upstream call — pure URL synthesis, safe to call at high frequency.',
+      input_schema: {
+        type: 'object',
+        required: ['product_id', 'affiliate_code'],
+        properties: {
+          product_id: { type: 'string' },
+          affiliate_code: { type: 'string', pattern: '^[A-Za-z0-9_-]{3,64}$' },
+        },
+      },
+      examples: [
+        {
+          input: { product_id: '6710abc', affiliate_code: 'ali_2026' },
+          output_shape: { url: 'https://droplinked.com/p/6710abc?aff=ali_2026' },
+        },
+      ],
+    },
+    {
+      name: 'search_stores',
+      endpoint: `${base}/api/mcp/tools/search_stores`,
+      method: 'POST',
+      description: 'Search storefronts by name or slug. (apiv3 endpoint pending — currently stubbed.)',
+      description_long:
+        "Returns up to `limit` storefronts matching the query string. When the apiv3 endpoint is unavailable the tool returns `{stub: true, data: []}` so agents can detect the placeholder and fall back. Treat results as best-effort discovery hints, not an authoritative catalogue.",
+      input_schema: {
+        type: 'object',
+        required: ['q'],
+        properties: {
+          q: { type: 'string', maxLength: 128 },
+          limit: { type: 'integer', minimum: 1, maximum: 50, default: 10 },
+        },
+      },
+      examples: [
+        { input: { q: 'roomours' }, output_shape: { stub: 'boolean', data: '[Store]' } },
+      ],
+    },
+    {
+      name: 'get_categories',
+      endpoint: `${base}/api/mcp/tools/get_categories`,
+      method: 'POST',
+      description: 'List the supported product categories.',
+      description_long:
+        'Returns the canonical list of category slugs accepted by `list_products`. Use this to render a category filter or to validate user input before calling `list_products`. The list is currently sourced from a static enum and rarely changes.',
+      input_schema: { type: 'object', properties: {} },
+      examples: [
+        {
+          input: {},
+          output_shape: {
+            categories: ['apparel', 'accessories', 'home', '...'],
+            source: 'static-enum',
+          },
+        },
+      ],
+    },
+  ]
+
   return NextResponse.json({
-    mcp_version: '0.1', server_name: 'droplinked-storefront',
+    mcp_version: '0.1',
+    server_name: 'droplinked-storefront',
     description: 'Droplinked storefront MCP server — query products, inventory, affiliate links.',
     capabilities: { tools: true, resources: false, prompts: false },
-    tools: [
-      { name: 'list_products', endpoint: `${base}/api/mcp/tools/list_products`, description: 'List affiliate-available products.' },
-      { name: 'get_product', endpoint: `${base}/api/mcp/tools/get_product`, description: 'Fetch product details by id or slug.' },
-      { name: 'get_affiliate_link', endpoint: `${base}/api/mcp/tools/get_affiliate_link`, description: 'Generate affiliate-tagged checkout URL.' },
-    ],
+    tools,
     rate_limits: { per_minute: 60, per_hour: 1000 },
     auth: { type: 'none', note: 'Public read-only; writes require API key.' },
   })

--- a/src/app/.well-known/mcp/route.ts
+++ b/src/app/.well-known/mcp/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+export async function GET(request: Request) {
+  const host = request.headers.get('host') ?? 'droplinked.com'
+  const base = `https://${host}`
+  return NextResponse.json({
+    mcp_version: '0.1', server_name: 'droplinked-storefront',
+    description: 'Droplinked storefront MCP server — query products, inventory, affiliate links.',
+    capabilities: { tools: true, resources: false, prompts: false },
+    tools: [
+      { name: 'list_products', endpoint: `${base}/api/mcp/tools/list_products`, description: 'List affiliate-available products.' },
+      { name: 'get_product', endpoint: `${base}/api/mcp/tools/get_product`, description: 'Fetch product details by id or slug.' },
+      { name: 'get_affiliate_link', endpoint: `${base}/api/mcp/tools/get_affiliate_link`, description: 'Generate affiliate-tagged checkout URL.' },
+    ],
+    rate_limits: { per_minute: 60, per_hour: 1000 },
+    auth: { type: 'none', note: 'Public read-only; writes require API key.' },
+  })
+}

--- a/src/app/api/mcp/tools/[tool]/route.ts
+++ b/src/app/api/mcp/tools/[tool]/route.ts
@@ -1,16 +1,46 @@
 import { NextResponse } from 'next/server'
-import { fetchInstance } from '@/lib/fetchInstance'
-type Input = Record<string, unknown>
-async function listProducts(i: Input) { const sp = new URLSearchParams({ affiliate: 'true' }); for (const k of ['store','category','q'] as const) if (typeof i[k]==='string') sp.set(k, i[k] as string); return fetchInstance(`products?${sp.toString()}`) }
-async function getProduct(i: Input) { return typeof i.id_or_slug === 'string' ? fetchInstance(`products/${encodeURIComponent(i.id_or_slug)}`) : { error: 'id_or_slug required' } }
-async function getAffiliateLink(i: Input) { return (typeof i.product_id==='string' && typeof i.affiliate_code==='string') ? { url: `https://droplinked.com/p/${encodeURIComponent(i.product_id)}?aff=${encodeURIComponent(i.affiliate_code)}` } : { error: 'product_id + affiliate_code required' } }
-const TOOLS: Record<string, (i: Input) => Promise<unknown>> = { list_products: listProducts, get_product: getProduct, get_affiliate_link: getAffiliateLink }
-export async function POST(request: Request, { params }: { params: Promise<{ tool: string }> }) {
+import { dispatch, type ToolInput } from '../dispatcher'
+
+/**
+ * MCP tool route — thin transport wrapper around `dispatch()`.
+ *
+ * Rate limit header is currently a stub (always reports a fixed remaining
+ * count). The real per-IP/per-key limiter lands with sidekick's framework;
+ * this header lets MCP clients start parsing it now so the contract is
+ * stable when the real limiter ships.
+ */
+
+const RATE_LIMIT_PER_MINUTE = 60
+
+function rateLimitHeaders(): Record<string, string> {
+  return {
+    'X-RateLimit-Limit': String(RATE_LIMIT_PER_MINUTE),
+    // Stub: real limiter will compute this per caller. Reporting the limit
+    // itself is a safe placeholder until sidekick's framework lands.
+    'X-RateLimit-Remaining': String(RATE_LIMIT_PER_MINUTE),
+    'X-RateLimit-Policy': 'stub; real limiter pending sidekick framework',
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ tool: string }> },
+) {
   const { tool } = await params
-  const handler = TOOLS[tool]
-  if (!handler) return NextResponse.json({ error: `Unknown tool: ${tool}` }, { status: 404 })
-  let input: Input = {}
-  try { input = await request.json() } catch { /* empty */ }
-  try { return NextResponse.json({ tool, data: await handler(input) }) }
-  catch (e) { return NextResponse.json({ tool, error: e instanceof Error ? e.message : 'tool failed' }, { status: 500 }) }
+  let input: ToolInput = {}
+  try {
+    const parsed = await request.json()
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      input = parsed as ToolInput
+    }
+  } catch {
+    // Empty / non-JSON body → treat as empty input. Validators below decide
+    // whether that's acceptable for the targeted tool.
+  }
+
+  const outcome = await dispatch(tool, input)
+  return NextResponse.json(outcome.body, {
+    status: outcome.status,
+    headers: rateLimitHeaders(),
+  })
 }

--- a/src/app/api/mcp/tools/[tool]/route.ts
+++ b/src/app/api/mcp/tools/[tool]/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+import { fetchInstance } from '@/lib/fetchInstance'
+type Input = Record<string, unknown>
+async function listProducts(i: Input) { const sp = new URLSearchParams({ affiliate: 'true' }); for (const k of ['store','category','q'] as const) if (typeof i[k]==='string') sp.set(k, i[k] as string); return fetchInstance(`products?${sp.toString()}`) }
+async function getProduct(i: Input) { return typeof i.id_or_slug === 'string' ? fetchInstance(`products/${encodeURIComponent(i.id_or_slug)}`) : { error: 'id_or_slug required' } }
+async function getAffiliateLink(i: Input) { return (typeof i.product_id==='string' && typeof i.affiliate_code==='string') ? { url: `https://droplinked.com/p/${encodeURIComponent(i.product_id)}?aff=${encodeURIComponent(i.affiliate_code)}` } : { error: 'product_id + affiliate_code required' } }
+const TOOLS: Record<string, (i: Input) => Promise<unknown>> = { list_products: listProducts, get_product: getProduct, get_affiliate_link: getAffiliateLink }
+export async function POST(request: Request, { params }: { params: Promise<{ tool: string }> }) {
+  const { tool } = await params
+  const handler = TOOLS[tool]
+  if (!handler) return NextResponse.json({ error: `Unknown tool: ${tool}` }, { status: 404 })
+  let input: Input = {}
+  try { input = await request.json() } catch { /* empty */ }
+  try { return NextResponse.json({ tool, data: await handler(input) }) }
+  catch (e) { return NextResponse.json({ tool, error: e instanceof Error ? e.message : 'tool failed' }, { status: 500 }) }
+}

--- a/src/app/api/mcp/tools/__tests__/dispatcher.test.mjs
+++ b/src/app/api/mcp/tools/__tests__/dispatcher.test.mjs
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the MCP tool dispatcher's input-validation layer.
+ *
+ * Runner: Node's built-in test runner (`node --test`). Repo has no
+ * jest/vitest, matching the pattern in src/__smoke__/.
+ *
+ * Invoke directly:
+ *   node --test src/app/api/mcp/tools/__tests__/dispatcher.test.mjs
+ * Or via npm:
+ *   npm test
+ *
+ * We test the validators exported from ./validators.mjs (the single source
+ * of truth that the TS dispatcher re-exports). That keeps the tests
+ * runtime-pure — no Next.js, no TypeScript compile step, no fetchInstance
+ * dependency.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  validateListProducts,
+  validateGetProduct,
+  validateGetAffiliateLink,
+  validateSearchStores,
+  validateGetCategories,
+  KNOWN_TOOL_NAMES,
+} from '../validators.mjs'
+
+// ---------- registry sanity ----------
+
+test('KNOWN_TOOL_NAMES includes the 5 expected tools (3 original + 2 new)', () => {
+  assert.deepEqual(
+    [...KNOWN_TOOL_NAMES].sort(),
+    [
+      'get_affiliate_link',
+      'get_categories',
+      'get_product',
+      'list_products',
+      'search_stores',
+    ],
+  )
+})
+
+// ---------- list_products ----------
+
+test('list_products: empty input applies safe defaults', () => {
+  const r = validateListProducts({})
+  assert.equal(r.ok, true)
+  assert.equal(r.value.page, 1)
+  assert.equal(r.value.limit, 20)
+  assert.equal(r.value.store, undefined)
+})
+
+test('list_products: clamps limit to max 100', () => {
+  const r = validateListProducts({ limit: 9999 })
+  assert.equal(r.ok, true)
+  assert.equal(r.value.limit, 100)
+})
+
+test('list_products: clamps page to min 1 on negative input', () => {
+  const r = validateListProducts({ page: -5 })
+  assert.equal(r.ok, true)
+  assert.equal(r.value.page, 1)
+})
+
+test('list_products: ignores non-string store/category/q', () => {
+  const r = validateListProducts({ store: 42, category: null, q: { evil: true } })
+  assert.equal(r.ok, true)
+  assert.equal(r.value.store, undefined)
+  assert.equal(r.value.category, undefined)
+  assert.equal(r.value.q, undefined)
+})
+
+// ---------- get_product ----------
+
+test('get_product: rejects missing id_or_slug with 400', () => {
+  const r = validateGetProduct({})
+  assert.equal(r.ok, false)
+  assert.equal(r.status, 400)
+  assert.match(r.error, /id_or_slug/)
+})
+
+test('get_product: rejects empty-string id_or_slug', () => {
+  const r = validateGetProduct({ id_or_slug: '   ' })
+  assert.equal(r.ok, false)
+  assert.equal(r.status, 400)
+})
+
+test('get_product: rejects path-traversal characters', () => {
+  for (const bad of ['../etc', 'a/b', 'a?b', 'a#b']) {
+    const r = validateGetProduct({ id_or_slug: bad })
+    assert.equal(r.ok, false, `expected reject for ${bad}`)
+    assert.equal(r.status, 400)
+  }
+})
+
+test('get_product: accepts ObjectId hex and URL slug', () => {
+  for (const good of ['6710abc123def456789012ab', 'hoodie-deluxe']) {
+    const r = validateGetProduct({ id_or_slug: good })
+    assert.equal(r.ok, true, `expected accept for ${good}`)
+    assert.equal(r.value.id_or_slug, good)
+  }
+})
+
+// ---------- get_affiliate_link ----------
+
+test('get_affiliate_link: requires both product_id and affiliate_code', () => {
+  assert.equal(validateGetAffiliateLink({}).ok, false)
+  assert.equal(validateGetAffiliateLink({ product_id: 'p' }).ok, false)
+  assert.equal(validateGetAffiliateLink({ affiliate_code: 'ali_2026' }).ok, false)
+})
+
+test('get_affiliate_link: rejects malformed affiliate_code shapes', () => {
+  for (const bad of ['ab', '!!!', 'a'.repeat(65), 'has space']) {
+    const r = validateGetAffiliateLink({ product_id: 'p1', affiliate_code: bad })
+    assert.equal(r.ok, false, `expected reject for ${bad}`)
+    assert.equal(r.status, 400)
+  }
+})
+
+test('get_affiliate_link: accepts canonical [A-Za-z0-9_-]{3,64} codes', () => {
+  for (const good of ['ali_2026', 'A-1', 'a'.repeat(64)]) {
+    const r = validateGetAffiliateLink({ product_id: 'p1', affiliate_code: good })
+    assert.equal(r.ok, true, `expected accept for ${good}`)
+  }
+})
+
+// ---------- search_stores (NEW) ----------
+
+test('search_stores: requires q', () => {
+  const r = validateSearchStores({})
+  assert.equal(r.ok, false)
+  assert.equal(r.status, 400)
+  assert.match(r.error, /q /)
+})
+
+test('search_stores: rejects q over 128 chars', () => {
+  const r = validateSearchStores({ q: 'x'.repeat(129) })
+  assert.equal(r.ok, false)
+  assert.equal(r.status, 400)
+})
+
+test('search_stores: applies default limit 10 and clamps to 50', () => {
+  const a = validateSearchStores({ q: 'roomours' })
+  assert.equal(a.ok, true)
+  assert.equal(a.value.limit, 10)
+  const b = validateSearchStores({ q: 'roomours', limit: 9999 })
+  assert.equal(b.ok, true)
+  assert.equal(b.value.limit, 50)
+})
+
+// ---------- get_categories (NEW) ----------
+
+test('get_categories: accepts empty input without error', () => {
+  const r = validateGetCategories({})
+  assert.equal(r.ok, true)
+  assert.deepEqual(r.value, {})
+})
+
+test('get_categories: accepts (and ignores) arbitrary input', () => {
+  const r = validateGetCategories({ unexpected: 'field' })
+  assert.equal(r.ok, true)
+})

--- a/src/app/api/mcp/tools/dispatcher.ts
+++ b/src/app/api/mcp/tools/dispatcher.ts
@@ -1,0 +1,196 @@
+/**
+ * MCP tool dispatcher — pure, transport-agnostic logic split out from the
+ * Next.js route handler so it can be unit-tested with `node --test`.
+ *
+ * Each tool has:
+ *   - a `validate(input)` step that returns either `{ ok: true, value }` or
+ *     `{ ok: false, error, status }` — no exceptions for malformed input
+ *     (cheaper for agents to retry against a 4xx body than a 500).
+ *   - an `execute(value)` step that returns the upstream payload. Network /
+ *     upstream errors bubble up as exceptions; the route handler converts
+ *     them to `{ error }` with a 200 status (per spec: "200 + {error} body
+ *     for transient; 4xx for malformed").
+ *
+ * Rate limiting: the real limiter belongs in sidekick's framework. We add a
+ * stub `X-RateLimit-Remaining` header in the route so MCP clients can start
+ * relying on the header now without behavioural change later.
+ */
+
+import { fetchInstance } from '@/lib/fetchInstance'
+// Validators live in a .mjs sibling so `node --test` can unit-test them
+// without a TS toolchain. Single source of truth.
+import {
+  validateListProducts as _validateListProducts,
+  validateGetProduct as _validateGetProduct,
+  validateGetAffiliateLink as _validateGetAffiliateLink,
+  validateSearchStores as _validateSearchStores,
+  validateGetCategories as _validateGetCategories,
+} from './validators.mjs'
+
+export type ToolInput = Record<string, unknown>
+
+export type ValidationOk<T> = { ok: true; value: T }
+export type ValidationErr = { ok: false; error: string; status: number }
+export type ValidationResult<T> = ValidationOk<T> | ValidationErr
+
+// ---------- tool: list_products ----------
+
+export type ListProductsInput = {
+  store?: string
+  category?: string
+  q?: string
+  page: number
+  limit: number
+}
+
+export const validateListProducts = _validateListProducts as (
+  i: ToolInput,
+) => ValidationResult<ListProductsInput>
+
+async function executeListProducts(v: ListProductsInput): Promise<unknown> {
+  const sp = new URLSearchParams({ affiliate: 'true' })
+  if (v.store) sp.set('store', v.store)
+  if (v.category) sp.set('category', v.category)
+  if (v.q) sp.set('q', v.q)
+  sp.set('page', String(v.page))
+  sp.set('limit', String(v.limit))
+  return fetchInstance(`products/public?${sp.toString()}`)
+}
+
+// ---------- tool: get_product ----------
+
+export type GetProductInput = { id_or_slug: string }
+
+export const validateGetProduct = _validateGetProduct as (
+  i: ToolInput,
+) => ValidationResult<GetProductInput>
+
+async function executeGetProduct(v: GetProductInput): Promise<unknown> {
+  return fetchInstance(`products/${encodeURIComponent(v.id_or_slug)}`)
+}
+
+// ---------- tool: get_affiliate_link ----------
+
+export type GetAffiliateLinkInput = { product_id: string; affiliate_code: string }
+
+export const validateGetAffiliateLink = _validateGetAffiliateLink as (
+  i: ToolInput,
+) => ValidationResult<GetAffiliateLinkInput>
+
+async function executeGetAffiliateLink(v: GetAffiliateLinkInput): Promise<unknown> {
+  // Pure URL synthesis — no upstream call. Public-facing storefront URL.
+  return {
+    url: `https://droplinked.com/p/${encodeURIComponent(v.product_id)}?aff=${encodeURIComponent(v.affiliate_code)}`,
+  }
+}
+
+// ---------- tool: search_stores (NEW) ----------
+
+export type SearchStoresInput = { q: string; limit: number }
+
+export const validateSearchStores = _validateSearchStores as (
+  i: ToolInput,
+) => ValidationResult<SearchStoresInput>
+
+async function executeSearchStores(v: SearchStoresInput): Promise<unknown> {
+  // TODO(apiv3): no canonical /stores/search endpoint exists yet. Filed as
+  // operator-decision item. For now we try `/shops/public?q=...` (current
+  // behaviour of the storefront discovery surface) and surface a tagged
+  // response so MCP clients can detect the stub.
+  try {
+    const sp = new URLSearchParams({ q: v.q, limit: String(v.limit), public: 'true' })
+    const data = await fetchInstance(`shops/public?${sp.toString()}`)
+    return { stub: false, data }
+  } catch (e) {
+    return {
+      stub: true,
+      reason: 'apiv3 store-search endpoint not implemented; placeholder response',
+      data: [],
+      detail: e instanceof Error ? e.message : 'fetch failed',
+    }
+  }
+}
+
+// ---------- tool: get_categories (NEW) ----------
+
+export type GetCategoriesInput = Record<string, never>
+
+export const validateGetCategories = _validateGetCategories as (
+  i: ToolInput,
+) => ValidationResult<GetCategoriesInput>
+
+// Mirror of KNOWN_CATEGORIES in the affiliate-products page. Kept duplicated
+// rather than imported because that file is a Server Component (RSC) and we
+// don't want to drag its module graph into the API route.
+const STATIC_CATEGORIES = [
+  'apparel',
+  'accessories',
+  'home',
+  'beauty',
+  'electronics',
+  'collectibles',
+  'digital',
+  'other',
+] as const
+
+async function executeGetCategories(_v: GetCategoriesInput): Promise<unknown> {
+  // Future: fetch from apiv3 once a `/products/categories` endpoint exists.
+  // For now return the static enum so agents can populate filter UIs.
+  return { categories: STATIC_CATEGORIES, source: 'static-enum' }
+}
+
+// ---------- registry ----------
+
+export type ToolName =
+  | 'list_products'
+  | 'get_product'
+  | 'get_affiliate_link'
+  | 'search_stores'
+  | 'get_categories'
+
+type ToolDef<T> = {
+  validate: (i: ToolInput) => ValidationResult<T>
+  execute: (v: T) => Promise<unknown>
+}
+
+export const TOOLS: { [K in ToolName]: ToolDef<unknown> } = {
+  list_products: { validate: validateListProducts as ToolDef<unknown>['validate'], execute: executeListProducts as ToolDef<unknown>['execute'] },
+  get_product: { validate: validateGetProduct as ToolDef<unknown>['validate'], execute: executeGetProduct as ToolDef<unknown>['execute'] },
+  get_affiliate_link: { validate: validateGetAffiliateLink as ToolDef<unknown>['validate'], execute: executeGetAffiliateLink as ToolDef<unknown>['execute'] },
+  search_stores: { validate: validateSearchStores as ToolDef<unknown>['validate'], execute: executeSearchStores as ToolDef<unknown>['execute'] },
+  get_categories: { validate: validateGetCategories as ToolDef<unknown>['validate'], execute: executeGetCategories as ToolDef<unknown>['execute'] },
+}
+
+export function isKnownTool(name: string): name is ToolName {
+  return Object.prototype.hasOwnProperty.call(TOOLS, name)
+}
+
+export type DispatchOutcome =
+  | { kind: 'unknown_tool'; status: 404; body: { error: string } }
+  | { kind: 'invalid_input'; status: number; body: { tool: string; error: string } }
+  | { kind: 'transient_error'; status: 200; body: { tool: string; error: string } }
+  | { kind: 'ok'; status: 200; body: { tool: string; data: unknown } }
+
+/**
+ * Pure dispatch — does the validation step, runs the tool, classifies the
+ * outcome. Route handler just maps this to a NextResponse + headers. Used
+ * directly from unit tests.
+ */
+export async function dispatch(tool: string, input: ToolInput): Promise<DispatchOutcome> {
+  if (!isKnownTool(tool)) {
+    return { kind: 'unknown_tool', status: 404, body: { error: `Unknown tool: ${tool}` } }
+  }
+  const def = TOOLS[tool]
+  const v = def.validate(input)
+  if (!v.ok) {
+    return { kind: 'invalid_input', status: v.status, body: { tool, error: v.error } }
+  }
+  try {
+    const data = await def.execute(v.value)
+    return { kind: 'ok', status: 200, body: { tool, data } }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'tool execution failed'
+    // Transient/upstream errors → 200 + {error} per MCP-friendly contract.
+    return { kind: 'transient_error', status: 200, body: { tool, error: message } }
+  }
+}

--- a/src/app/api/mcp/tools/validators.mjs
+++ b/src/app/api/mcp/tools/validators.mjs
@@ -1,0 +1,84 @@
+/**
+ * Pure input validators for MCP tools — kept as ESM (.mjs) so the Node
+ * built-in test runner (`node --test`) can import them directly without a
+ * TypeScript toolchain.
+ *
+ * The TypeScript dispatcher (./dispatcher.ts) re-exports these so there is
+ * exactly one source of truth for validation logic.
+ */
+
+function isNonEmptyString(v) {
+  return typeof v === 'string' && v.trim().length > 0
+}
+
+function optString(v) {
+  return typeof v === 'string' && v.length > 0 ? v : undefined
+}
+
+function clampInt(v, min, max, fallback) {
+  const n = typeof v === 'number' ? v : typeof v === 'string' ? parseInt(v, 10) : NaN
+  if (!Number.isFinite(n)) return fallback
+  return Math.max(min, Math.min(max, Math.floor(n)))
+}
+
+export function validateListProducts(i) {
+  return {
+    ok: true,
+    value: {
+      store: optString(i.store),
+      category: optString(i.category),
+      q: optString(i.q),
+      page: clampInt(i.page, 1, 1000, 1),
+      limit: clampInt(i.limit, 1, 100, 20),
+    },
+  }
+}
+
+export function validateGetProduct(i) {
+  if (!isNonEmptyString(i.id_or_slug)) {
+    return { ok: false, error: 'id_or_slug (string) is required', status: 400 }
+  }
+  if (/[\/\?#]/.test(i.id_or_slug)) {
+    return { ok: false, error: 'id_or_slug must not contain /, ?, or #', status: 400 }
+  }
+  return { ok: true, value: { id_or_slug: i.id_or_slug } }
+}
+
+export function validateGetAffiliateLink(i) {
+  if (!isNonEmptyString(i.product_id)) {
+    return { ok: false, error: 'product_id (string) is required', status: 400 }
+  }
+  if (!isNonEmptyString(i.affiliate_code)) {
+    return { ok: false, error: 'affiliate_code (string) is required', status: 400 }
+  }
+  if (!/^[A-Za-z0-9_-]{3,64}$/.test(i.affiliate_code)) {
+    return {
+      ok: false,
+      error: 'affiliate_code must be 3-64 chars of [A-Za-z0-9_-]',
+      status: 400,
+    }
+  }
+  return { ok: true, value: { product_id: i.product_id, affiliate_code: i.affiliate_code } }
+}
+
+export function validateSearchStores(i) {
+  if (!isNonEmptyString(i.q)) {
+    return { ok: false, error: 'q (string) is required', status: 400 }
+  }
+  if (i.q.length > 128) {
+    return { ok: false, error: 'q must be 128 chars or fewer', status: 400 }
+  }
+  return { ok: true, value: { q: i.q, limit: clampInt(i.limit, 1, 50, 10) } }
+}
+
+export function validateGetCategories(_i) {
+  return { ok: true, value: {} }
+}
+
+export const KNOWN_TOOL_NAMES = [
+  'list_products',
+  'get_product',
+  'get_affiliate_link',
+  'search_stores',
+  'get_categories',
+]

--- a/src/app/api/public/products/route.ts
+++ b/src/app/api/public/products/route.ts
@@ -1,0 +1,15 @@
+import { fetchInstance } from '@/lib/fetchInstance'
+import { NextResponse } from 'next/server'
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  if (!searchParams.has('limit')) searchParams.set('limit', '20')
+  if (!searchParams.has('page')) searchParams.set('page', '1')
+  const limit = parseInt(searchParams.get('limit') ?? '20', 10)
+  if (limit > 100) searchParams.set('limit', '100')
+  searchParams.set('public', 'true')
+  try {
+    // Backend apiv3 #1278 endpoint: GET /products/public?store=...&limit=...
+    const data = await fetchInstance(`products/public?${searchParams.toString()}`)
+    return NextResponse.json(data, { headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300', 'Access-Control-Allow-Origin': '*' } })
+  } catch (e) { return NextResponse.json({ error: e instanceof Error ? e.message : 'internal error' }, { status: 500 }) }
+}


### PR DESCRIPTION
**DRAFT — HOLD-MERGE until sidekick's /<storename> URL framework lands.**

Per operator 5-20: build infrastructure for D items 1-3 (affiliate products listing / MCP server endpoints / query-friendly public API) WITHOUT binding to the shop.droplinked.com URL framework. These mount under whatever parent route the sidekick's /<storename> framework provides.

## What this adds (path-agnostic)

| File | Purpose |
|---|---|
| `src/app/(routes)/affiliate-products/page.tsx` | Public affiliate-product listing (SSR, no auth, store/category/q search) |
| `src/app/.well-known/mcp/route.ts` | MCP discovery manifest (v0.1, 3 tools, host-derived URLs) |
| `src/app/api/mcp/tools/[tool]/route.ts` | MCP tool dispatcher (list_products / get_product / get_affiliate_link) |
| `src/app/api/public/products/route.ts` | Unauthenticated public products JSON API (CORS *, 60s cache, capped limit 100) |

## Coordination needed
- Sidekick: define the parent /<storename>/ mount point. Once landed, this PR is mergeable.
- Apiv3: confirm `GET /products/public?store=…&affiliate=true` exists with the assumed JSON shape; OR adjust fetchInstance paths in the public route handler.

## Build status
Pre-existing build error on main (`./playwright.config.ts` can't find `@playwright/test`) is unrelated to this PR. Direct tsc on the 4 new files compiles clean. Operator should fix the playwright dep separately (probably `npm install --save-dev @playwright/test`).

## Won't break LIVE
DRAFT prevents auto-merge. shop.droplinked.com (live since path C earlier today) keeps serving current Next-ShopFront /home + /checkout routes.