### PR TITLE
[ci] Bump Node 20 to 22 to satisfy @droplinked_inc/* engines (fixes Smoke gate)

### DIFF
--- a/.github/workflows/mobile-test.yml
+++ b/.github/workflows/mobile-test.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci
       - name: Install Playwright browsers
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci
       - name: Install Playwright browsers


### PR DESCRIPTION
Smoke (PR gate) has been failing on every PR for days. CI workflow mobile-test.yml pinned node-version 20 but @droplinked_inc/wallet-connection@0.1.1, @droplinked_inc/web3@1.0.0, @droplinked_inc/web3-kit@0.1.0 all require >=22.0.0. EBADENGINE warnings are non-fatal but modules fail at runtime, Next.js dev server never starts, Playwright sees Connection refused on every smoke spec. This is why #20/#23/#40/#47/#48/#49 all merged with admin override of a failing gate. Fix: bump node-version to 22 in 2 jobs in mobile-test.yml. Unblocks #51 + future NSF PRs. Aligns CI with Dockerfile node bump from PR #32 era. Needs adversarial re-audit before merge per standing rule.