### PR TITLE
fix(dockerfile): CMD node server.js (closes #50)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,4 +81,4 @@ ENV PORT 80
 
 # Command to run the application using the Node.js server included in the standalone output.
 # This will run as the root user.
-CMD ["npm", "run", "prod"]
+CMD ["node", "server.js"]


### PR DESCRIPTION
Next.js standalone has no package.json at /app → npm run prod exits 127. Use node server.js directly. Removes need for shop_droplinked_com task-def command override.