### PR TITLE
[ci] Lockfile sanity guard — prevent out-of-tree path commits

### DIFF
--- a/.github/workflows/lockfile-sanity.yml
+++ b/.github/workflows/lockfile-sanity.yml
@@ -1,0 +1,24 @@
+name: Lockfile sanity
+
+on:
+  pull_request:
+    paths:
+      - 'package-lock.json'
+      - '.github/workflows/lockfile-sanity.yml'
+
+jobs:
+  sanity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Guard against out-of-tree paths in package-lock.json
+        run: |
+          if grep -q '"\.\./' package-lock.json; then
+            echo "::error::package-lock.json contains relative paths to outside the repo (../)."
+            echo "Likely cause: someone ran 'npm install' inside an out-of-tree worktree"
+            echo "(e.g. ../../security-sprint/...) and committed the resulting lockfile."
+            echo "Fix: re-run 'npm install' from the repo root and commit the clean lockfile."
+            grep -n '"\.\./' package-lock.json | head -10
+            exit 1
+          fi
+          echo "OK — no out-of-tree paths found."


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/lockfile-sanity.yml`: PR-gated single-step grep that fails the build if `package-lock.json` contains relative paths escaping the repo.
- Refs PR #47 incident: 845 orphan entries pointed at `../../security-sprint/oidc-migration-work/Next-ShopFront/node_modules/*` — leftover from `npm install` run inside an out-of-tree worktree and then committed.
- Belt-and-suspenders: cheap (~5s, single grep + exit), only runs on PRs touching `package-lock.json` or this workflow.

## Why a CI guard (not .gitignore)
`package-lock.json` is tracked, so `.gitignore` cannot prevent the bad content from landing — only a content check can. This is the minimal viable guard.

## Test plan
- [ ] Workflow appears as a PR check on this PR (no lockfile change, should be skipped by path filter — expected)
- [ ] Manually verified the grep pattern matches the orphan signature found in PR #47

## Re-audit
Per standing rule (feedback-pre-merge-reaudit-required) — needs independent re-audit before merge. Do not auto-merge.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
