### PR TITLE
chore(security): npm supply-chain hardening (.npmrc + preinstall guard)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry=https://registry.npmjs.org/
+save-exact=false
+audit-level=high

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "next-shopfront",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@droplinked_inc/web3": "^1.0.0",
         "@emotion/react": "^11.11.3",
@@ -7668,6 +7669,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/casper-js-sdk/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/casper-js-sdk/node_modules/node-fetch": {
       "version": "2.6.13",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
@@ -9432,6 +9439,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/formik/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/forwarded-parse": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
@@ -10748,12 +10761,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "preinstall": "node ./scripts/preinstall-supply-chain-guard.js",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
@@ -77,7 +78,7 @@
     "cross-spawn": "^7.0.6",
     "flatted": "^3.4.2",
     "glob": "^10.5.0",
-    "lodash": "^4.17.21",
+    "lodash": "4.17.21",
     "lodash-es": "^4.17.21",
     "minimatch": "^9.0.9",
     "picomatch": "^4.0.4",

--- a/scripts/__tests__/preinstall-supply-chain-guard.spec.js
+++ b/scripts/__tests__/preinstall-supply-chain-guard.spec.js
@@ -1,0 +1,155 @@
+/* eslint-disable */
+'use strict';
+
+// Tests can run two ways:
+//   1) `node --test scripts/__tests__/preinstall-supply-chain-guard.spec.js`
+//      (matches the repo's existing `npm test` runner)
+//   2) `npx jest scripts/__tests__/preinstall-supply-chain-guard.spec.js`
+//      (only if jest is wired up at some later point)
+//
+// To stay runner-agnostic we use plain assertions + a tiny shim that
+// recognises either `node:test`'s `test()` or a globally-injected
+// jest `test()` / `describe()` pair.
+
+const assert = require('node:assert/strict');
+
+let test;
+let describe;
+try {
+  // node:test path (Node 18+).
+  const nodeTest = require('node:test');
+  test = nodeTest.test;
+  describe = nodeTest.describe || ((_label, fn) => fn());
+} catch (_err) {
+  // Jest path.
+  test = global.test;
+  describe = global.describe;
+}
+
+const { scanLockfile } = require('../preinstall-supply-chain-guard');
+
+describe('preinstall-supply-chain-guard scanLockfile', () => {
+  test('clean lockfile passes with no blocks', () => {
+    const lock = {
+      packages: {
+        '': { name: 'next-shopfront', version: '0.1.0' },
+        'node_modules/lodash': { name: 'lodash', version: '4.17.21' },
+        'node_modules/next': { name: 'next', version: '15.5.18' },
+        'node_modules/@droplinked_inc/web3': {
+          name: '@droplinked_inc/web3',
+          version: '1.0.0',
+        },
+      },
+    };
+    assert.deepEqual(scanLockfile(lock), []);
+  });
+
+  test('blocks lodash@4.18.0', () => {
+    const lock = {
+      packages: {
+        'node_modules/lodash': { name: 'lodash', version: '4.18.0' },
+      },
+    };
+    const blocks = scanLockfile(lock);
+    assert.equal(blocks.length, 1);
+    assert.equal(blocks[0].name, 'lodash');
+    assert.equal(blocks[0].version, '4.18.0');
+    assert.match(blocks[0].reason, /lodash@4\.18/);
+  });
+
+  test('blocks lodash@4.18.1 nested under another package', () => {
+    const lock = {
+      packages: {
+        'node_modules/some-pkg/node_modules/lodash': {
+          name: 'lodash',
+          version: '4.18.1',
+        },
+      },
+    };
+    const blocks = scanLockfile(lock);
+    assert.equal(blocks.length, 1);
+    assert.equal(blocks[0].version, '4.18.1');
+  });
+
+  test('blocks bare droplinked-* names (squatters)', () => {
+    const lock = {
+      packages: {
+        'node_modules/droplinked-sdk': {
+          name: 'droplinked-sdk',
+          version: '0.1.0',
+        },
+        'node_modules/droplinked-utils': {
+          name: 'droplinked-utils',
+          version: '9.9.9',
+        },
+      },
+    };
+    const blocks = scanLockfile(lock);
+    assert.equal(blocks.length, 2);
+    assert.deepEqual(
+      blocks.map((b) => b.name).sort(),
+      ['droplinked-sdk', 'droplinked-utils']
+    );
+    for (const b of blocks) {
+      assert.match(b.reason, /@droplinked_inc/);
+    }
+  });
+
+  test('does NOT block scoped @droplinked_inc/* packages', () => {
+    const lock = {
+      packages: {
+        'node_modules/@droplinked_inc/sdk': {
+          name: '@droplinked_inc/sdk',
+          version: '1.0.0',
+        },
+        'node_modules/@droplinked_inc/web3': {
+          name: '@droplinked_inc/web3',
+          version: '2.3.4',
+        },
+      },
+    };
+    assert.deepEqual(scanLockfile(lock), []);
+  });
+
+  test('blocks fs@0.0.1-security typo-squat', () => {
+    const lock = {
+      packages: {
+        'node_modules/fs': { name: 'fs', version: '0.0.1-security' },
+      },
+    };
+    const blocks = scanLockfile(lock);
+    assert.equal(blocks.length, 1);
+    assert.equal(blocks[0].name, 'fs');
+    assert.match(blocks[0].reason, /typo-squat/);
+  });
+
+  test('npm v6 dependencies tree shape is also scanned', () => {
+    const lock = {
+      dependencies: {
+        lodash: { version: '4.18.1' },
+        next: {
+          version: '15.5.18',
+          dependencies: {
+            'droplinked-evil': { version: '1.0.0' },
+          },
+        },
+      },
+    };
+    const blocks = scanLockfile(lock);
+    const names = blocks.map((b) => b.name).sort();
+    assert.deepEqual(names, ['droplinked-evil', 'lodash']);
+  });
+
+  test('allows other lodash 4.17.x versions', () => {
+    const lock = {
+      packages: {
+        'node_modules/lodash': { name: 'lodash', version: '4.17.21' },
+        'node_modules/x/node_modules/lodash': {
+          name: 'lodash',
+          version: '4.17.20',
+        },
+      },
+    };
+    assert.deepEqual(scanLockfile(lock), []);
+  });
+});

--- a/scripts/preinstall-supply-chain-guard.js
+++ b/scripts/preinstall-supply-chain-guard.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/* eslint-disable */
+/**
+ * Preinstall supply-chain guard.
+ *
+ * Reads package-lock.json and refuses to let `npm install` continue if any
+ * dependency resolves to a known-hostile or known-poison-suspect package:
+ *
+ *   - Any package name matching /^droplinked-/
+ *     The legitimate first-party scope is `@droplinked_inc/*` (underscore +
+ *     scope prefix). Bare `droplinked-*` names on the public registry are
+ *     squatters and must never resolve into our dependency graph.
+ *
+ *   - Any lodash@4.18.x
+ *     `lodash` was dormant since 2021. New maintainers were added to the npm
+ *     package in March 2026 and pushed 4.18.0 + 4.18.1. Both are on
+ *     registry.npmjs.org. The maintainer identity has not been independently
+ *     vetted, so we pin to the last known-good 4.17.21 and refuse anything
+ *     in the 4.18.x line until the new maintainers are vetted.
+ *
+ *   - `fs` at `0.0.1-security`
+ *     Typo-squat security-placeholder published by npm to occupy the `fs`
+ *     namespace. Real Node.js `fs` is a built-in and never appears in a lockfile.
+ *
+ * The guard runs cleanly on a fresh checkout where node_modules does not yet
+ * exist: if package-lock.json is missing (e.g. very first `npm install` on a
+ * fresh clone with no lockfile), it exits 0 and lets install proceed.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const LOCKFILE_PATH = path.resolve(__dirname, '..', 'package-lock.json');
+
+const HOSTILE_NAME_PATTERNS = [
+  {
+    pattern: /^droplinked-/,
+    reason:
+      'package name matches /^droplinked-/ — the legitimate first-party scope is @droplinked_inc/* (underscore + scope prefix); bare droplinked-* names on the public registry are squatters',
+  },
+];
+
+const POISON_EXACT = [
+  {
+    name: 'fs',
+    version: '0.0.1-security',
+    reason: 'typo-squat security-placeholder for built-in node:fs',
+  },
+];
+
+const POISON_VERSION_RANGES = [
+  {
+    name: 'lodash',
+    test: (v) => /^4\.18\./.test(v),
+    reason:
+      'lodash@4.18.x was published in March 2026 by a newly-added maintainer after years of dormancy; pinned to 4.17.21 until maintainer identity vetted',
+  },
+];
+
+function scanLockfile(lock) {
+  const blocks = [];
+
+  // npm v7+ lockfile uses "packages" map keyed by install path.
+  if (lock.packages && typeof lock.packages === 'object') {
+    for (const installPath of Object.keys(lock.packages)) {
+      const entry = lock.packages[installPath];
+      if (!entry || typeof entry !== 'object') continue;
+      const name =
+        entry.name ||
+        (installPath.startsWith('node_modules/')
+          ? installPath.slice('node_modules/'.length).replace(/.*\/node_modules\//, '')
+          : '');
+      const version = entry.version || '';
+      checkOne(name, version, installPath, blocks);
+    }
+  }
+
+  // npm v6 fallback: "dependencies" tree.
+  if (lock.dependencies && typeof lock.dependencies === 'object') {
+    const walk = (deps, parentPath) => {
+      for (const name of Object.keys(deps)) {
+        const dep = deps[name];
+        if (!dep || typeof dep !== 'object') continue;
+        const here = parentPath + '/node_modules/' + name;
+        checkOne(name, dep.version || '', here, blocks);
+        if (dep.dependencies) walk(dep.dependencies, here);
+      }
+    };
+    walk(lock.dependencies, '');
+  }
+
+  return blocks;
+}
+
+function checkOne(name, version, installPath, blocks) {
+  if (!name) return;
+
+  for (const p of HOSTILE_NAME_PATTERNS) {
+    if (p.pattern.test(name)) {
+      blocks.push({ name, version, installPath, reason: p.reason });
+    }
+  }
+
+  for (const p of POISON_EXACT) {
+    if (name === p.name && version === p.version) {
+      blocks.push({ name, version, installPath, reason: p.reason });
+    }
+  }
+
+  for (const p of POISON_VERSION_RANGES) {
+    if (name === p.name && p.test(version)) {
+      blocks.push({ name, version, installPath, reason: p.reason });
+    }
+  }
+}
+
+function main() {
+  if (!fs.existsSync(LOCKFILE_PATH)) {
+    // Fresh clone without a lockfile (very rare in CI, but support the case).
+    process.exit(0);
+  }
+
+  let lock;
+  try {
+    lock = JSON.parse(fs.readFileSync(LOCKFILE_PATH, 'utf8'));
+  } catch (err) {
+    console.error('[preinstall-supply-chain-guard] failed to parse package-lock.json:', err.message);
+    process.exit(1);
+  }
+
+  const blocks = scanLockfile(lock);
+  if (blocks.length === 0) {
+    return;
+  }
+
+  console.error('');
+  console.error('========================================================================');
+  console.error(' SUPPLY-CHAIN GUARD: install blocked');
+  console.error('========================================================================');
+  for (const b of blocks) {
+    console.error('');
+    console.error('  package : ' + b.name + '@' + b.version);
+    console.error('  path    : ' + b.installPath);
+    console.error('  reason  : ' + b.reason);
+  }
+  console.error('');
+  console.error(' Resolve the entry in package.json / overrides and regenerate');
+  console.error(' package-lock.json with `npm install --legacy-peer-deps` before retrying.');
+  console.error('========================================================================');
+  console.error('');
+  process.exit(1);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { scanLockfile };


### PR DESCRIPTION
## Summary

Mirrors the npm supply-chain hardening pattern from droplinked-backend PR #1286 and droplinked-shopfront PR #372 into this repo. Two layers:

1. **Static guard at `npm install` time** — `scripts/preinstall-supply-chain-guard.js` parses `package-lock.json` and refuses to let install continue if any dependency resolves to a known-hostile or poison-suspect package.
2. **Override + `.npmrc` hygiene** — `lodash` is now pinned exact to `4.17.21` in `overrides`. Root `.npmrc` pins the registry, sets `audit-level=high`, leaves `save-exact=false` so explicit overrides still drive pins.

## What the guard blocks

- Any package name matching `/^droplinked-/` — the legitimate first-party scope is `@droplinked_inc/*` (underscore + scope prefix); bare `droplinked-*` names on the public registry are squatters.
- Any `lodash@4.18.x` — dormant since 2021, new maintainers added March 2026, pushed `4.18.0` + `4.18.1`. Pinned to last known-good `4.17.21` until maintainer identity is independently vetted.
- `fs@0.0.1-security` — typo-squat security-placeholder for built-in `node:fs`.

No first-party `droplinked-*` (bare-name) deps exist in this repo — only the scoped `@droplinked_inc/web3` — so no allowlist is needed. Adding any bare `droplinked-*` name in the future will block install.

## What this DID find (live incident)

The pre-PR lockfile already pinned **`lodash@4.18.1`** at the top level. The exact-pin override + regenerated lockfile move it back to `4.17.21`.

## What this does NOT cover

- Full SCA / vulnerability scanning (Socket, Snyk, npm audit gating).
- Maintainer-identity checks.
- Post-install script sandboxing.

## Test runner note

The repo's `npm test` runs `node --test`. The spec uses `node:test` if available and falls back to globally-injected `test()` / `describe()` so the same file would also work under jest if it were added later.

## Test plan

- [x] `node scripts/preinstall-supply-chain-guard.js` against current lockfile — exit 0.
- [x] Inject `lodash@4.18.1` into a copy of the lockfile, re-run guard — exits 1 with clear message naming the package + install path.
- [x] `node --test scripts/__tests__/preinstall-supply-chain-guard.spec.js` — 8/8 pass.
- [x] `npm install --legacy-peer-deps --package-lock-only` succeeds with preinstall guard active.
