### PR TITLE
chore(dependabot): manual-review on lodash bumps (#1273-lodash-incident)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: "lodash"
+        versions: ["4.18.x"]
+      - dependency-name: "lodash-es"
+        versions: ["4.18.x"]
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Summary

Adds a Dependabot `ignore` rule for `lodash` and `lodash-es` at the `4.18.x` range as a follow-up to today's supply-chain incident in which new maintainers were silently added to the `lodash@4.18.x` line on npm. Until those maintainers are vetted, Dependabot will skip opening PRs that bump to `4.18.x`, complementing the existing `preinstall` guard and the exact pin in `package.json` `overrides` (defense in depth, three layers).

This is intentionally narrow: it does not block other lodash bumps, does not touch other Dependabot rules, and does not affect manual upgrades. We will revisit and remove this ignore in 2-4 weeks once the new maintainer situation is resolved.

Tracking: droplinked-backend#1273.

## Test plan
- [ ] Dependabot picks up the new config on next scheduled run
- [ ] No PRs opened for `lodash@4.18.x` or `lodash-es@4.18.x` while this rule is in place
- [ ] Existing Dependabot rules (security updates, other ecosystems) continue to function
