### PR TITLE
chore(ci): npm audit signatures provenance verification

### DIFF
--- a/.github/workflows/audit-signatures.yml
+++ b/.github/workflows/audit-signatures.yml
@@ -1,0 +1,50 @@
+# npm provenance signatures verification
+#
+# Verifies that installed packages have valid npm provenance signatures
+# (npm 8.15+, see https://docs.npmjs.com/generating-provenance-statements).
+# Catches packages where the registry-published artifact does not match
+# the source repo — same failure mode behind the lodash@4.18.x incident.
+#
+# Informational for the first 2 weeks (continue-on-error: true).
+# Operator flips continue-on-error to false after the soak window.
+
+name: audit-signatures
+
+on:
+  pull_request:
+    branches: [main, stage, dev]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: audit-signatures-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: verify provenance
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: install
+        run: npm ci --no-audit --legacy-peer-deps
+
+      - name: Verify npm provenance signatures
+        run: npm audit signatures --omit=dev --no-audit-level || echo "::warning::Some packages lack provenance signatures (informational this rollout)"
+        continue-on-error: true


### PR DESCRIPTION
## Summary

Add `npm audit signatures` provenance verification to CI for **Next-ShopFront** as part of the supply-chain hardening rollout (follow-up to the recent lodash@4.18.x incident).

`npm audit signatures` (npm 8.15+) verifies that installed packages have valid npm provenance signatures (https://docs.npmjs.com/generating-provenance-statements). It catches cases where the registry-published artifact does not match the source repo — exactly the failure mode behind the lodash@4.18.x incident.

## Behaviour

- **Informational mode for the first 2 weeks** (`continue-on-error: true` + `|| echo ::warning::`) — collect signal without breaking CI on packages that have not yet adopted provenance.
- After the 2-week soak window, operator flips `continue-on-error: false` (and drops the `||` fallback) to make the check blocking.
- Adds ~5–15s to the affected workflow.

## Rationale for soft-fail soak

Many widely-used packages do not yet publish provenance attestations. Hard-failing on day 1 would break every PR in the org. Two weeks of observation lets us:

1. Inventory which packages lack provenance.
2. Pin / replace / mirror what we need to.
3. Flip to strict mode with confidence.

## Scope

- CI workflow only. No changes to `package.json` or `package-lock.json`.
- Added once in the canonical install workflow for this repo (avoids duplicate runs across dev + main).

## Test plan

- [ ] CI runs the new step on this PR
- [ ] Step emits either a clean pass or a `::warning::` annotation (never a job failure)
- [ ] No regression in install / build / test step timing beyond ~15s