### PR TITLE
fix(docker): COPY scripts/ before npm install — prevent preinstall guard miss

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,13 @@ WORKDIR /app
 # If using npm, copy package.json and package-lock.json
 COPY package.json yarn.lock* ./
 
+# Copy scripts/ BEFORE install so the npm `preinstall` supply-chain
+# guard script is present at install time. Without this, install fails
+# with ENOENT on scripts/preinstall-supply-chain-guard.js because the
+# rest of the source tree is not COPYed until the builder stage.
+# Cousin of droplinked-backend#1300.
+COPY scripts ./scripts
+
 # Install dependencies using yarn
 # Use --frozen-lockfile to ensure reproducible installs based on the lock file.
 RUN yarn install --frozen-lockfile


### PR DESCRIPTION
## Summary

Hotfix for Dockerfile build break introduced by the npm `preinstall` supply-chain guard rollout (cousin of droplinked-backend#1300, sibling of Next-ShopFront#67).

The current Dockerfile `deps` stage runs:

```
COPY package.json yarn.lock* ./
RUN yarn install --frozen-lockfile
```

…then later in the `builder` stage does `COPY . .`. The recently added `package.json` `preinstall` hook (`node ./scripts/preinstall-supply-chain-guard.js`) fires during `yarn install`, but `scripts/` is not present yet — so the install fails with `ENOENT` on the guard script and the image never builds.

## Fix

Insert `COPY scripts ./scripts` between the lockfile COPY and the `RUN yarn install` step, so the preinstall guard is on disk when yarn runs the hook. No other Dockerfile changes; runtime stages untouched.

## Scope

- Dockerfile only.
- No application code, no workflow, no package.json touched.

## Test plan

- [ ] CI builds the image successfully.
- [ ] Confirm preinstall guard log line appears in the build output.
- [ ] Standalone runner still boots (`node server.js`).
