### PR TITLE
feat: scaffold Cloudflare Pages ($0 alt to PR #43)

### DIFF
--- a/.github/workflows/cf-pages.yml
+++ b/.github/workflows/cf-pages.yml
@@ -1,0 +1,37 @@
+name: Cloudflare Pages
+
+on:
+  push:
+    branches: [main, dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      # Operator must set in repo secrets before enabling:
+      #   CLOUDFLARE_API_TOKEN  (scope: Account / Cloudflare Pages: Edit)
+      #   CLOUDFLARE_ACCOUNT_ID
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+      NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci --legacy-peer-deps
+      - run: npx @opennextjs/cloudflare build
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy .open-next/dist --project-name=next-shopfront --branch=${{ github.ref_name }}

--- a/docs/CLOUDFLARE_PAGES_MIGRATION.md
+++ b/docs/CLOUDFLARE_PAGES_MIGRATION.md
@@ -1,0 +1,58 @@
+# Cloudflare Pages migration (PR #43 alternative)
+
+## Why
+Original PR #43 proposes a dedicated ECS Fargate service (~$36/mo) to remove the
+collision risk between Next-ShopFront and the shared `shop_droplinked_com_service`.
+This document describes the **$0 alternative**: deploy to Cloudflare Pages via
+`@opennextjs/cloudflare`.
+
+## Cost
+- Free tier: 500 builds/mo, 100K req/day, unlimited bandwidth.
+- Commercial use permitted on free tier.
+- Bypasses ECS entirely; the shared `shop_droplinked_com_service` keeps serving
+  shop.droplinked.com without contention.
+
+## Operator activation checklist
+
+1. **Create CF Pages project** (one-time)
+   - Cloudflare Dashboard → Workers & Pages → Create → Pages → Direct Upload
+   - Project name: `next-shopfront`
+   - Skip wizard; we deploy via GitHub Actions.
+
+2. **Mint CF API token**
+   - https://dash.cloudflare.com/profile/api-tokens → Create
+   - Template: "Edit Cloudflare Workers" (covers Pages)
+   - Permissions: Account → Cloudflare Pages → Edit
+   - Save token value.
+
+3. **Push GitHub secrets** (run locally):
+   ```bash
+   gh secret set CLOUDFLARE_API_TOKEN -R droplinked/Next-ShopFront -b "<token>"
+   gh secret set CLOUDFLARE_ACCOUNT_ID -R droplinked/Next-ShopFront -b "<account-id>"
+   ```
+
+4. **Bind runtime env vars** (CF dashboard → Settings → Environment variables)
+   - `NEXT_PUBLIC_API_URL`
+   - `NEXT_PUBLIC_SENTRY_DSN`
+   - Set on both Production + Preview.
+
+5. **First deploy**
+   ```bash
+   gh workflow run cf-pages.yml -R droplinked/Next-ShopFront --ref main
+   ```
+
+6. **Wire custom domain** (after first green deploy)
+   - CF Pages → next-shopfront → Custom domains → Add `shop.droplinked.com`
+   - Update Route 53 CNAME or move zone to CF.
+
+7. **Decommission ECS path** (after 48h soak)
+   - Set `shop_droplinked_com_service` desiredCount=0
+   - Delete ECR repo + task-def revisions (keep last 3 for rollback)
+
+## Rollback
+If CF deploy breaks: re-scale `shop_droplinked_com_service` to 1; CNAME flips back
+in <60s via DNS update. Original ECS Dockerfile + task-def unchanged in this PR.
+
+## Local dev
+Unchanged: `npm run dev` → `next dev` (no CF emulation needed for app code).
+Optional CF runtime emulation: `npx wrangler pages dev .open-next/dist`.

--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -1,0 +1,6 @@
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+
+export default defineCloudflareConfig({
+  // Use in-memory incremental cache; swap to KV/R2 when traffic warrants
+  // (see docs/CLOUDFLARE_PAGES_MIGRATION.md for cache-binding recipe).
+});

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "test:mobile:debug": "playwright test --config=playwright.config.ts --debug",
     "test:mobile:update-snapshots": "playwright test --config=playwright.config.ts --update-snapshots",
     "test:mobile:report": "playwright show-report",
-    "test:mobile:install": "playwright install --with-deps chromium webkit"
+    "test:mobile:install": "playwright install --with-deps chromium webkit",
+    "cf:build": "opennextjs-cloudflare build",
+    "cf:preview": "opennextjs-cloudflare preview",
+    "cf:deploy": "opennextjs-cloudflare deploy"
   },
   "dependencies": {
     "@droplinked_inc/web3": "^1.0.0",
@@ -65,7 +68,9 @@
     "eslint-config-next": "15.3.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@opennextjs/cloudflare": "^1.0.0",
+    "wrangler": "^3.95.0"
   },
   "overrides": {
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,12 @@
+name = "next-shopfront"
+compatibility_date = "2026-05-20"
+compatibility_flags = ["nodejs_compat"]
+pages_build_output_dir = ".open-next/dist"
+
+# Operator: bind production secrets in CF dashboard or `wrangler pages secret put <NAME>`
+# Required at runtime:
+#   NEXT_PUBLIC_API_URL, NEXT_PUBLIC_SENTRY_DSN, SENTRY_AUTH_TOKEN
+#
+# Environments use the same Pages project with branch-based deploys:
+#   main → production (shop.droplinked.com via custom domain)
+#   dev  → preview (auto preview URL)


### PR DESCRIPTION
## Summary
$0 alternative to PR #43's ~$36/mo Fargate-split. Scaffolds Cloudflare Pages deploy via `@opennextjs/cloudflare` while leaving the existing ECS path untouched for trivial rollback.

## Why now
`shop_droplinked_com_service` is shared between Next-ShopFront and the legacy shop.droplinked.com codebase → race-overwrite risk on simultaneous deploys. PR #43 solves it with dedicated ECS ($36/mo). This PR removes Next-ShopFront from ECS entirely ($0).

## Files
- `wrangler.toml` — CF Pages project config
- `open-next.config.ts` — OpenNext adapter
- `.github/workflows/cf-pages.yml` — deploy on push to main/dev
- `docs/CLOUDFLARE_PAGES_MIGRATION.md` — 7-step operator activation checklist
- `package.json` — adds cf:build/preview/deploy scripts + @opennextjs/cloudflare + wrangler devDeps

## Operator activation (blocks activation, not merge)
1. Create CF Pages project `next-shopfront`
2. Mint CF API token (Pages:Edit)
3. `gh secret set CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID`
4. Bind `NEXT_PUBLIC_API_URL` + `NEXT_PUBLIC_SENTRY_DSN` in CF dashboard
5. `gh workflow run cf-pages.yml`
6. After 48h soak: CNAME shop.droplinked.com → CF, decom ECS path

## Test plan
- [ ] CF Pages project + token + secrets
- [ ] First deploy green
- [ ] Mobile UX smoke per storefront standing rule
- [ ] Sentry ingest
- [ ] CNAME live + cert
- [ ] 48h zero-incident → decom ECS

## Decision-fork
Pick this OR PR #43. Close the other.