### PR TITLE
chore(security): add execa/tar/axios npm overrides (5th-repo supply-chain cascade)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,9 +73,11 @@
     "@droplinked_inc/web3": {
       "@solana/web3.js": "^1.98.4"
     },
+    "axios": "^1.16.0",
     "base-x": "^5.0.0",
     "braces": "^3.0.3",
     "cross-spawn": "^7.0.6",
+    "execa": "^9.6.1",
     "flatted": "^3.4.2",
     "glob": "^10.5.0",
     "lodash": "4.17.21",
@@ -84,6 +86,7 @@
     "picomatch": "^4.0.4",
     "rollup": "^4.27.0",
     "svgo": "^3.3.3",
+    "tar": "^7.5.0",
     "ws": "^8.18.0"
   }
 }


### PR DESCRIPTION
## Summary

Closes the gap in the **5-20 supply-chain hardening cascade** that landed in 4 sibling repos (droplinked-backend, 3rdp-integration-services, web3-integration-services, droplinked-checkout) and shopfront PR #389. Next-ShopFront was deferred from that round — this PR brings it in line.

## What

Adds three missing entries to the existing \`overrides\` block in \`package.json\`:

| Package | Pin | Rationale |
|---|---|---|
| \`axios\` | \`^1.16.0\` | Matches direct dep; defends transitives from CVE-2024-39338 / SSRF surface |
| \`execa\` | \`^9.6.1\` | ESM pattern (Next.js 15 is ESM-first). Same pin used in shopfront/3rdp/web3. NOT bumped to 9 in backend because NestJS is CJS |
| \`tar\` | \`^7.5.0\` | Closes CVE-2024-28863 transitive surface |

## Audit verdict

\`npm install --legacy-peer-deps\` post-change:
- target packages (axios/execa/braces/ws/tar): **0 HIGH/CRITICAL**
- lodash HIGH = GHSA-r5fr-rjxr-66jc (\`lodash <= 4.17.23\`, fix at 4.18.0) → **ACCEPTED per policy**: lodash 4.18.x is the maintainer-add takeover suspect, must stay exact-pinned at 4.17.21. We do not use \`_.template\` insecurely.

## Non-impact

- No major bumps as a side-effect (none of the three packages currently appear in the resolved tree as direct or near-transitive deps — pins are forward-defense for future Dependabot bumps and transitive churn).
- Lockfile unchanged (no resolution drift).
- No runtime code paths touched → DEV smoke not required.

## Refs

- droplinked-backend #1273 (lodash takeover incident)
- droplinked-backend #1301 (canonical override pattern)
- droplinked-shopfront #389 (sibling cascade PR)
- web3-integration-services #237 (sibling supply-chain hardening)

## Test plan

- [x] \`npm install --legacy-peer-deps --ignore-scripts\` succeeds
- [x] \`npm audit --json\` shows 0 HIGH/CRIT on target packages
- [ ] CI green