### PR TITLE
fix(theme): repair next-themes type import — unblocks dev-deploy workflow (broken since 2026-05-21)

### DIFF
--- a/src/components/providers/theme/AppThemeProvider.tsx
+++ b/src/components/providers/theme/AppThemeProvider.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { ThemeProvider as NextThemesProvider } from "next-themes";
-import { type ThemeProviderProps } from "next-themes/dist/types";
+import { ThemeProvider as NextThemesProvider, type ThemeProviderProps } from "next-themes";
 
 export function AppThemeProvider({ children }: ThemeProviderProps) {
     return (


### PR DESCRIPTION
## The chokepoint

\`Deploy ECS - dev\` has been failing on **every push to \`dev\`** since at least **2026-05-21** with:

\`\`\`
Failed to compile.
Type error: Cannot find module 'next-themes/dist/types' or its corresponding type declarations.
Next.js build worker exited with code: 1 and signal: null
\`\`\`

Latent consequence: dev environment has been serving a stale image from before 2026-05-21. The recent feed-auth landing PR #83 (\`/claim-your-shop\`) returns **404** on \`dev.droplinked.com\` because its build artifact never made it past the type-check gate.

## Root cause

\`next-themes@0.4.6\` (current installed version per \`package-lock.json\`) does **not** ship a \`dist/types\` subpath. Its package exports map only exposes \`.\` with \`./dist/index.d.ts\` as the types entry, and \`ThemeProviderProps\` is re-exported from the package root:

\`\`\`ts
// node_modules/next-themes/dist/index.d.ts
export { type Attribute, ThemeProvider, type ThemeProviderProps, type UseThemeProps, useTheme };
\`\`\`

The \`dist/types\` subpath was a vestige of an older \`next-themes\` major. When the dependency was bumped (likely in the 2026-05-21 minor-group bump), the deep import broke and \`tsc\` started rejecting the build.

## The one-line fix

\`src/components/providers/theme/AppThemeProvider.tsx\`:

\`\`\`diff
-import { ThemeProvider as NextThemesProvider } from "next-themes";
-import { type ThemeProviderProps } from "next-themes/dist/types";
+import { ThemeProvider as NextThemesProvider, type ThemeProviderProps } from "next-themes";
\`\`\`

No dependency change. No new packages. Same type, sourced from the now-canonical root export.

## Why this is the structural fix

\`AppThemeProvider\` is mounted at the application root and is the **only consumer** of \`ThemeProviderProps\`. Every downstream component renders through it. This single import was the chokepoint blocking the entire dev-deploy pipeline — fixing it unblocks every previously-merged PR (including #83's \`/claim-your-shop\` landing) **and** every future PR's build.

The temptation to re-architect the theme provider, swap \`next-themes\` for another package, or scaffold a wrapping abstraction would be scope creep. The bug is one import. We fix one import.

## Test plan

- [x] \`npm install\` clean (resolves \`next-themes@0.4.6\`)
- [x] \`tsc --noEmit\` clean for the touched file (no errors mentioning \`AppThemeProvider\` or \`next-themes\`)
- [x] \`npm run build\` succeeds locally; \`/claim-your-shop\` static route compiles
- [ ] After merge → next push to \`dev\` should successfully run \`Deploy ECS - dev\` end-to-end
- [ ] After ECS rollout → \`https://dev.droplinked.com/claim-your-shop\` should return 200 instead of 404 (i.e. the feed-auth landing from PR #83 finally goes live)

## Audit trail

- Installed \`next-themes\` version: \`^0.4.6\` (lockfile: \`0.4.6\`)
- File touched: \`src/components/providers/theme/AppThemeProvider.tsx\` (+1 / -2)
- Base: \`dev\` (per operator: dev-first, no direct-to-main)
- Draft — operator merges