### PR TITLE
promote(dev→main): bootstrap PR Source Branch Policy + post-GTFU reconcile

### DIFF
--- a/.github/workflows/enforce-pr-source-branch.yml
+++ b/.github/workflows/enforce-pr-source-branch.yml
@@ -1,0 +1,23 @@
+name: PR Source Branch Policy
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches: [main]
+jobs:
+  enforce-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR head branch
+        run: |
+          HEAD="${{ github.head_ref }}"
+          if [[ "$HEAD" == "dev" || "$HEAD" == hotfix/* ]]; then
+            echo "PR source '$HEAD' satisfies the dev-first policy"
+            exit 0
+          fi
+          echo "::error::PR head '$HEAD' violates the dev-first policy."
+          echo "Required head branch for PRs targeting main: 'dev' OR 'hotfix/*'"
+          echo "Exception path 'hotfix/*' is for active integration debugging with external partners"
+          echo "where dev parity does not exist (e.g. Telr E0x partner bisect). Operator merges still required."
+          echo "Reference: workspace playbook droplinked-repo-sync-equilibrium-playbook-2026-06-05.md"
+          echo "          memory feedback-dev-first-no-direct-to-main"
+          exit 1


### PR DESCRIPTION
Bootstrap the **PR Source Branch Policy** workflow on main, completing the structural enforcement of the dev-first equilibrium playbook for this repo.

After this merges, all PRs targeting main must have head: `dev` OR `hotfix/*` — anything else fails the `enforce-source-branch` status check and cannot merge.

The `hotfix/*` exception path is for active integration debugging with external partners where dev parity does not exist (codified in [[feedback-dev-first-no-direct-to-main]] memory + the equilibrium playbook).

Refs:
- `~/workspace/droplinked/scripts/enforce-pr-source-branch.yml` (template)
- `~/workspace/droplinked/playbooks/droplinked-repo-sync-equilibrium-playbook-2026-06-05.md`
- droplinked-backend reference: this same setup landed on main 2026-06-06T11:28Z