### PR TITLE
promote(dev→main): dependabot.yml — target-branch: dev (closes loop on dev-first migration)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    target-branch: "dev"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -21,6 +22,7 @@ updates:
         versions: [">4.18.1"]
   - package-ecosystem: github-actions
     directory: /
+    target-branch: "dev"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5


### PR DESCRIPTION
Promote the dependabot.yml update so dependabot reads target-branch: dev from the default branch. Without this, next scheduled dependabot run still PRs against main, which the branch protection blocks (noise + manual close cycle).

Refs: ~/workspace/droplinked/playbooks/droplinked-repo-sync-equilibrium-playbook-2026-06-05.md