### PR TITLE
chore(design-system): error-red token reconcile + brand-wordmark sweep

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -128,6 +128,16 @@ const config: Config = {
                     soft: "#DEDEDE",
                     faint: "#7A7A7A",
                 },
+                // === Semantic error token — canonical source-of-truth ===
+                // Figma `error.500` = #FF2244 (slightly cooler + more saturated
+                // than Tailwind default `red-500` #EF4444). Migrate error-state
+                // consumers off `text-red-500`/`bg-red-500`/`border-red-500`
+                // onto `text-error-500` etc. so the surface picks up the token
+                // instead of the Tailwind default red scale.
+                error: {
+                    500: "#FF2244",
+                    bgsoft: "rgba(255, 34, 68, 0.15)",
+                },
             },
             borderRadius: {
                 lg: "16px",


### PR DESCRIPTION
## Closes / addresses
Design-system drift hygiene per source-of-truth § 9.7 (error token) + § 9.12 (brand wordmark). Sibling PRs filed in `droplinked-shopfront` + `droplinked-backend`.

## Summary
Two reconciliations bundled:
1. Adds canonical `error.500` (#FF2244) + `error.bgsoft` Tailwind tokens to mirror the shopfront semantic-error set and the Figma source-of-truth. No existing `text-red-500` / `bg-red-500` / `border-red-500` consumers in this repo's `src/`, so this is a pre-emptive token plant — any future landing / affiliate error states pick it up by default without re-touching the config.
2. Brand wordmark lowercase sweep: no user-facing "Droplinked" violations in this repo's `src/` — sweep is no-op in Next-ShopFront.

## Approach
- Single source-of-truth token added to `tailwind.config.ts`, additive only — no other component touched.
- Block of comments documents the migration rule for the next contributor.

## Risk
- Zero visual change today (no consumer references the token yet).
- No structural / architectural change. No behavior change. No new dependency.
- Future error-state components MUST prefer `text-error-500` etc. over Tailwind's default red scale — that's the long-tail value of landing this token now.