### PR TITLE
feat(m-slug): per-merchant SSR landing pages at /m/[slug] (closes #100)

### DIFF
--- a/src/app/m/[slug]/components/MerchantHero.tsx
+++ b/src/app/m/[slug]/components/MerchantHero.tsx
@@ -1,0 +1,104 @@
+/**
+ * MerchantHero — server-rendered merchant branding section.
+ *
+ * Renders differently based on verifiedTier:
+ *   full           → logo + name + description + storefront CTA
+ *   directory_only → minimal name + "View storefront" link only
+ */
+
+import Image from "next/image";
+import type { DiscoveryProfile } from "../lib/discovery-profile";
+
+interface MerchantHeroProps {
+  profile: DiscoveryProfile;
+}
+
+export default function MerchantHero({ profile }: MerchantHeroProps) {
+  const { name, description, logoUrl, storefrontUrl, verifiedTier } = profile;
+  const isFull = verifiedTier === "full";
+
+  return (
+    <section
+      className="bg-surface-1 border-b border-line py-12 px-6 md:px-12"
+      aria-label={`${name} merchant profile header`}
+    >
+      <div className="max-w-4xl mx-auto flex flex-col md:flex-row items-start md:items-center gap-6">
+        {/* Logo — shown for full tier only */}
+        {isFull && logoUrl && (
+          <div className="flex-shrink-0">
+            <Image
+              src={logoUrl}
+              alt={`${name} logo`}
+              width={80}
+              height={80}
+              className="rounded-md object-contain bg-surface-2"
+              unoptimized={logoUrl.startsWith("http")}
+            />
+          </div>
+        )}
+
+        <div className="flex flex-col gap-3 flex-1">
+          {/* Merchant name */}
+          <h1 className="text-2xl md:text-3xl font-semibold text-ink font-display">
+            {name}
+          </h1>
+
+          {/* Description — full tier only */}
+          {isFull && description && (
+            <p className="text-ink-muted text-base leading-relaxed max-w-2xl">
+              {description}
+            </p>
+          )}
+
+          {/* Verified badge */}
+          {isFull && (
+            <span className="inline-flex items-center gap-1.5 text-xs font-medium text-mint-500 bg-mint-50/10 border border-mint-500/20 px-2.5 py-1 rounded-sm w-fit">
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 12 12"
+                fill="none"
+                aria-hidden="true"
+              >
+                <path
+                  d="M10 3L4.75 8.25L2 5.5"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              Verified on droplinked
+            </span>
+          )}
+
+          {/* Storefront CTA */}
+          <a
+            href={storefrontUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 text-sm font-medium text-mint-500 hover:text-mint-400 transition-colors w-fit"
+            aria-label={`Visit ${name} storefront`}
+          >
+            {isFull ? "Shop now" : "View storefront"}
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 14 14"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M2.5 7H11.5M11.5 7L7.5 3M11.5 7L7.5 11"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/m/[slug]/components/MerchantProductGrid.tsx
+++ b/src/app/m/[slug]/components/MerchantProductGrid.tsx
@@ -1,0 +1,87 @@
+/**
+ * MerchantProductGrid — server-rendered top-8 product grid.
+ *
+ * Only rendered for verifiedTier === "full".
+ * directory_only tier: this component is not mounted.
+ *
+ * Products are pre-fetched in page.tsx (SSR) and passed as props,
+ * so there is no client-side data fetch.
+ */
+
+import Image from "next/image";
+import type { DiscoveryProduct } from "../lib/discovery-profile";
+
+interface MerchantProductGridProps {
+  products: DiscoveryProduct[];
+  merchantName: string;
+}
+
+export default function MerchantProductGrid({
+  products,
+  merchantName,
+}: MerchantProductGridProps) {
+  if (products.length === 0) return null;
+
+  return (
+    <section
+      className="py-10 px-6 md:px-12 bg-surface"
+      aria-label={`${merchantName} top products`}
+    >
+      <div className="max-w-4xl mx-auto">
+        <h2 className="text-xl font-semibold text-ink font-display mb-6">
+          Featured Products
+        </h2>
+
+        <ul
+          className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4"
+          role="list"
+        >
+          {products.map((product) => (
+            <li key={product.id} className="group">
+              <a
+                href={product.productUrl || "#"}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex flex-col gap-2 rounded-md overflow-hidden border border-line bg-surface-1 hover:border-mint-500/40 hover:shadow-card-dark transition-all duration-200"
+                aria-label={product.title}
+              >
+                {/* Product image */}
+                <div className="relative w-full aspect-square bg-surface-2">
+                  {product.imageUrl ? (
+                    <Image
+                      src={product.imageUrl}
+                      alt={product.title}
+                      fill
+                      sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 25vw"
+                      className="object-cover group-hover:scale-105 transition-transform duration-300"
+                      unoptimized={product.imageUrl.startsWith("http")}
+                    />
+                  ) : (
+                    <div
+                      className="w-full h-full bg-surface-3"
+                      aria-hidden="true"
+                    />
+                  )}
+                </div>
+
+                {/* Product info */}
+                <div className="px-3 pb-3 flex flex-col gap-1">
+                  <span className="text-sm font-medium text-ink-soft line-clamp-2">
+                    {product.title}
+                  </span>
+                  <span className="text-sm font-semibold text-mint-500">
+                    {product.currency}{" "}
+                    {product.price.toLocaleString("en-US", {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                    })}
+                  </span>
+                </div>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/app/m/[slug]/lib/discovery-profile.ts
+++ b/src/app/m/[slug]/lib/discovery-profile.ts
@@ -1,0 +1,153 @@
+/**
+ * discovery-profile.ts
+ *
+ * Fetches and parses the per-merchant discovery profile from:
+ *   apiv3.droplinked.com/v2/merchants/:slug/discovery-profile
+ *
+ * BE dependency: droplinked-backend#2096 (KYB tier filter).
+ * If the endpoint is not yet live, the fetch returns null and the
+ * page falls through to notFound() — fully 5xx-safe.
+ *
+ * No zod dependency (not in project). TypeScript type guards + runtime
+ * narrowing are used instead for validation.
+ */
+
+export type VerifiedTier = "full" | "directory_only";
+
+export interface DiscoveryProduct {
+  id: string;
+  title: string;
+  description: string;
+  price: number;
+  currency: string;
+  imageUrl: string;
+  productUrl: string;
+}
+
+export interface DiscoveryProfile {
+  slug: string;
+  name: string;
+  description: string;
+  logoUrl: string;
+  websiteUrl: string;
+  storefrontUrl: string;
+  verifiedTier: VerifiedTier;
+  /** Top products — up to 8 for `full` tier, empty for `directory_only` */
+  topProducts: DiscoveryProduct[];
+  /** Social links — optional */
+  social?: {
+    twitter?: string;
+    instagram?: string;
+    linkedin?: string;
+  };
+}
+
+const APIV3_BASE = "https://apiv3.droplinked.com";
+
+// ---- runtime validators ----
+
+function isVerifiedTier(v: unknown): v is VerifiedTier {
+  return v === "full" || v === "directory_only";
+}
+
+function isDiscoveryProduct(v: unknown): v is DiscoveryProduct {
+  if (!v || typeof v !== "object") return false;
+  const p = v as Record<string, unknown>;
+  return (
+    typeof p.id === "string" &&
+    typeof p.title === "string" &&
+    typeof p.price === "number" &&
+    typeof p.currency === "string"
+  );
+}
+
+function parseDiscoveryProfile(raw: unknown): DiscoveryProfile | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+
+  if (
+    typeof r.slug !== "string" ||
+    typeof r.name !== "string" ||
+    typeof r.description !== "string" ||
+    !isVerifiedTier(r.verifiedTier)
+  ) {
+    return null;
+  }
+
+  const topProducts: DiscoveryProduct[] = Array.isArray(r.topProducts)
+    ? (r.topProducts as unknown[]).filter(isDiscoveryProduct).slice(0, 8)
+    : [];
+
+  const social =
+    r.social && typeof r.social === "object"
+      ? (r.social as Record<string, unknown>)
+      : undefined;
+
+  return {
+    slug: r.slug,
+    name: r.name,
+    description: r.description,
+    logoUrl: typeof r.logoUrl === "string" ? r.logoUrl : "",
+    websiteUrl: typeof r.websiteUrl === "string" ? r.websiteUrl : "",
+    storefrontUrl:
+      typeof r.storefrontUrl === "string"
+        ? r.storefrontUrl
+        : `https://droplinked.io/${r.slug}`,
+    verifiedTier: r.verifiedTier,
+    topProducts,
+    social: social
+      ? {
+          twitter:
+            typeof social.twitter === "string" ? social.twitter : undefined,
+          instagram:
+            typeof social.instagram === "string" ? social.instagram : undefined,
+          linkedin:
+            typeof social.linkedin === "string" ? social.linkedin : undefined,
+        }
+      : undefined,
+  };
+}
+
+/**
+ * Fetches the discovery profile for a merchant slug.
+ * Returns null if the endpoint returns 404, 500, or an unrecognised payload.
+ * Never throws — callers should fall through to notFound() on null.
+ */
+export async function fetchDiscoveryProfile(
+  slug: string
+): Promise<DiscoveryProfile | null> {
+  const url = `${APIV3_BASE}/v2/merchants/${encodeURIComponent(slug)}/discovery-profile`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      // ISR revalidation is controlled at the page level (revalidate = 300).
+      // Bypass Next.js fetch cache here so the page-level ISR is authoritative.
+      next: { revalidate: 300 },
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "droplinked-shopfront/1.0 (AEO-crawler-friendly)",
+      },
+    });
+  } catch {
+    // Network error (DNS, timeout, etc.)
+    return null;
+  }
+
+  if (!response.ok) {
+    // 404 = slug not found or not opted-in; 500 = backend not yet live
+    return null;
+  }
+
+  let raw: unknown;
+  try {
+    raw = await response.json();
+  } catch {
+    return null;
+  }
+
+  return parseDiscoveryProfile(raw);
+}
+
+// Export internal parser for unit-testing without a real HTTP call.
+export { parseDiscoveryProfile };

--- a/src/app/m/[slug]/loading.tsx
+++ b/src/app/m/[slug]/loading.tsx
@@ -1,0 +1,50 @@
+/**
+ * loading.tsx — skeleton shown while the SSR page fetches the
+ * discovery profile from apiv3. ISR-cached responses will rarely
+ * trigger this; it fires on first-hit cold start only.
+ */
+
+export default function MerchantPageLoading() {
+  return (
+    <div className="min-h-screen bg-surface animate-pulse" aria-busy="true" aria-label="Loading merchant profile">
+      {/* Hero skeleton */}
+      <div className="bg-surface-1 border-b border-line py-12 px-6 md:px-12">
+        <div className="max-w-4xl mx-auto flex flex-col md:flex-row items-start gap-6">
+          {/* Logo placeholder */}
+          <div className="w-20 h-20 rounded-md bg-surface-3 flex-shrink-0" />
+
+          <div className="flex flex-col gap-3 flex-1">
+            {/* Name */}
+            <div className="h-8 w-48 bg-surface-3 rounded-sm" />
+            {/* Description */}
+            <div className="h-4 w-full max-w-md bg-surface-3 rounded-sm" />
+            <div className="h-4 w-3/4 max-w-sm bg-surface-3 rounded-sm" />
+            {/* Badge + CTA */}
+            <div className="h-6 w-36 bg-surface-3 rounded-sm" />
+          </div>
+        </div>
+      </div>
+
+      {/* Product grid skeleton */}
+      <div className="py-10 px-6 md:px-12">
+        <div className="max-w-4xl mx-auto">
+          <div className="h-6 w-40 bg-surface-3 rounded-sm mb-6" />
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div
+                key={i}
+                className="rounded-md overflow-hidden border border-line bg-surface-1"
+              >
+                <div className="aspect-square bg-surface-3" />
+                <div className="p-3 flex flex-col gap-2">
+                  <div className="h-4 w-full bg-surface-3 rounded-sm" />
+                  <div className="h-4 w-16 bg-surface-3 rounded-sm" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/m/[slug]/not-found.tsx
+++ b/src/app/m/[slug]/not-found.tsx
@@ -1,0 +1,53 @@
+/**
+ * not-found.tsx — rendered when fetchDiscoveryProfile returns null
+ * (404 slug, 500 BE not yet live, or malformed response).
+ *
+ * Intentionally minimal — guides users to the main storefront root
+ * without orphaned dead-end pages.
+ */
+
+import Link from "next/link";
+
+export default function MerchantNotFound() {
+  return (
+    <main
+      className="min-h-screen bg-surface flex flex-col items-center justify-center px-6 text-center"
+      aria-label="Merchant not found"
+    >
+      <span className="text-5xl font-semibold text-ink-muted mb-4 select-none">
+        404
+      </span>
+
+      <h1 className="text-xl font-semibold text-ink mb-2 font-display">
+        Merchant not found
+      </h1>
+
+      <p className="text-ink-muted text-sm max-w-xs mb-8">
+        This merchant page is not available yet. They may not have opted in to
+        the droplinked discovery program.
+      </p>
+
+      <Link
+        href="/"
+        className="inline-flex items-center gap-2 text-sm font-medium text-mint-500 hover:text-mint-400 transition-colors"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 14 14"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M11.5 7H2.5M2.5 7L6.5 3M2.5 7L6.5 11"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+        Back to home
+      </Link>
+    </main>
+  );
+}

--- a/src/app/m/[slug]/page.tsx
+++ b/src/app/m/[slug]/page.tsx
@@ -1,0 +1,200 @@
+/**
+ * /m/[slug] — per-merchant SSR landing page (Phase 1, closes #100).
+ *
+ * AEO/GEO optimization surface: Schema.org JSON-LD + OG + Twitter Card
+ * so LLM crawlers (ChatGPT, Claude, Perplexity) can ingest merchant
+ * catalogs without a separate API fetch.
+ *
+ * BE dependency: apiv3.droplinked.com/v2/merchants/:slug/discovery-profile
+ * (droplinked-backend#2096 — KYB tier filter).
+ * If the endpoint is not live yet, fetchDiscoveryProfile returns null
+ * and this page renders notFound() — fully 5xx-safe.
+ *
+ * Tier gating:
+ *   full           → hero + product grid + storefront CTA + full JSON-LD
+ *   directory_only → minimal hero (name + "View storefront") + sparse JSON-LD
+ *
+ * ISR: 5 minutes (revalidate = 300).
+ */
+
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { fetchDiscoveryProfile, type DiscoveryProfile } from "./lib/discovery-profile";
+import MerchantHero from "./components/MerchantHero";
+import MerchantProductGrid from "./components/MerchantProductGrid";
+
+// ISR — revalidate every 5 minutes
+export const revalidate = 300;
+
+// ---- types ----
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+// ---- metadata ----
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const profile = await fetchDiscoveryProfile(slug);
+
+  if (!profile) {
+    return {
+      title: "Merchant not found | droplinked",
+    };
+  }
+
+  const title = `${profile.name} on droplinked`;
+  const description =
+    profile.verifiedTier === "full"
+      ? profile.description ||
+        `Shop ${profile.name}'s products on droplinked — verified onchain commerce.`
+      : `${profile.name} is listed on droplinked — the onchain commerce protocol.`;
+
+  const canonicalUrl = `https://droplinked.com/m/${slug}`;
+  const ogImage = profile.logoUrl || undefined;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: canonicalUrl,
+    },
+    openGraph: {
+      type: "website",
+      url: canonicalUrl,
+      title,
+      description,
+      siteName: "droplinked",
+      images: ogImage ? [{ url: ogImage, alt: `${profile.name} logo` }] : [],
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
+      images: ogImage ? [ogImage] : [],
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+  };
+}
+
+// ---- JSON-LD helpers ----
+
+function buildOrganizationJsonLd(profile: DiscoveryProfile) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: profile.name,
+    description: profile.description,
+    url: profile.websiteUrl || `https://droplinked.com/m/${profile.slug}`,
+    logo: profile.logoUrl || undefined,
+    sameAs: [
+      profile.storefrontUrl,
+      profile.social?.twitter,
+      profile.social?.instagram,
+      profile.social?.linkedin,
+    ].filter(Boolean) as string[],
+    // Droplinked-specific extension: signals to LLM crawlers that this is
+    // a blockchain-verified commerce entity.
+    additionalType: "https://schema.org/OnlineBusiness",
+    identifier: {
+      "@type": "PropertyValue",
+      name: "droplinked_slug",
+      value: profile.slug,
+    },
+  };
+}
+
+function buildProductListJsonLd(profile: DiscoveryProfile) {
+  if (profile.topProducts.length === 0) return null;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `${profile.name} — Featured Products`,
+    url: `https://droplinked.com/m/${profile.slug}`,
+    numberOfItems: profile.topProducts.length,
+    itemListElement: profile.topProducts.map((p, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      item: {
+        "@type": "Product",
+        name: p.title,
+        description: p.description,
+        url: p.productUrl,
+        image: p.imageUrl,
+        offers: {
+          "@type": "Offer",
+          price: p.price,
+          priceCurrency: p.currency,
+          availability: "https://schema.org/InStock",
+          seller: {
+            "@type": "Organization",
+            name: profile.name,
+          },
+        },
+      },
+    })),
+  };
+}
+
+// ---- page ----
+
+export default async function MerchantPage({ params }: PageProps) {
+  const { slug } = await params;
+  const profile = await fetchDiscoveryProfile(slug);
+
+  if (!profile) {
+    notFound();
+  }
+
+  const orgJsonLd = buildOrganizationJsonLd(profile);
+  const productListJsonLd =
+    profile.verifiedTier === "full" ? buildProductListJsonLd(profile) : null;
+
+  return (
+    <>
+      {/* Schema.org JSON-LD — inline in <body> per Next.js App Router convention */}
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}
+      />
+      {productListJsonLd && (
+        <script
+          type="application/ld+json"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(productListJsonLd) }}
+        />
+      )}
+
+      <main className="min-h-screen bg-surface">
+        <MerchantHero profile={profile} />
+
+        {profile.verifiedTier === "full" && (
+          <MerchantProductGrid
+            products={profile.topProducts}
+            merchantName={profile.name}
+          />
+        )}
+
+        {/* Attribution footer strip */}
+        <div className="py-8 px-6 text-center">
+          <p className="text-xs text-ink-faint">
+            Powered by{" "}
+            <a
+              href="https://droplinked.com"
+              className="text-mint-500 hover:text-mint-400 transition-colors"
+            >
+              droplinked
+            </a>{" "}
+            — onchain commerce protocol
+          </p>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,29 @@
+/**
+ * robots.ts — Next.js App Router robots.txt generator.
+ *
+ * /m/* is explicitly allowed for all crawlers so LLM search engines
+ * (ChatGPT, Claude, Perplexity, Google SGE) can ingest merchant pages.
+ */
+
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: [
+          "/",
+          "/m/",    // per-merchant landing pages — AEO/GEO crawl target
+        ],
+        disallow: [
+          "/api/",
+          "/_next/",
+          "/checkout",
+          "/orders",
+        ],
+      },
+    ],
+    sitemap: "https://droplinked.com/sitemap.xml",
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,68 @@
+/**
+ * sitemap.ts — Next.js App Router sitemap generator.
+ *
+ * Fetches the list of opted-in merchants from the discovery-profile
+ * index endpoint and includes each /m/<slug> route.
+ *
+ * If the index endpoint is not yet live, the sitemap gracefully falls
+ * back to static routes only — never blocks the build.
+ */
+
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://droplinked.com";
+const APIV3_BASE = "https://apiv3.droplinked.com";
+
+/**
+ * Fetches the list of opted-in merchant slugs.
+ * Returns an empty array if the endpoint is not yet live (404/500).
+ */
+async function fetchOptedInMerchantSlugs(): Promise<string[]> {
+  try {
+    const res = await fetch(`${APIV3_BASE}/v2/merchants/discovery-index`, {
+      next: { revalidate: 3600 }, // 1-hour cache for sitemap builds
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "droplinked-sitemap/1.0",
+      },
+    });
+
+    if (!res.ok) return [];
+
+    const data = await res.json();
+    if (!Array.isArray(data?.slugs)) return [];
+
+    return (data.slugs as unknown[])
+      .filter((s): s is string => typeof s === "string" && s.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: `${BASE_URL}/`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 1,
+    },
+    {
+      url: `${BASE_URL}/claim-your-shop`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+  ];
+
+  const merchantSlugs = await fetchOptedInMerchantSlugs();
+
+  const merchantRoutes: MetadataRoute.Sitemap = merchantSlugs.map((slug) => ({
+    url: `${BASE_URL}/m/${encodeURIComponent(slug)}`,
+    lastModified: new Date(),
+    changeFrequency: "daily" as const,
+    priority: 0.7,
+  }));
+
+  return [...staticRoutes, ...merchantRoutes];
+}

--- a/tests/discovery-profile.spec.ts
+++ b/tests/discovery-profile.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * discovery-profile.spec.ts
+ *
+ * Unit tests for the parseDiscoveryProfile runtime validator.
+ * Tests run without a network call — the exported parser is called
+ * directly with fixture payloads.
+ *
+ * These use Playwright's `test`/`expect` which can run without a browser
+ * via `npx playwright test --project=unit` (headless, no browser launch).
+ * The existing playwright.config.ts uses @playwright/test runner, so
+ * these tests slot in with no extra tooling.
+ */
+
+import { test, expect } from "@playwright/test";
+// Path resolves from project root (tests/tsconfig.json sets baseUrl: "..")
+import { parseDiscoveryProfile } from "../src/app/m/[slug]/lib/discovery-profile";
+
+const VALID_FULL_PAYLOAD = {
+  slug: "acme-co",
+  name: "Acme Co",
+  description: "Quality tools since 1952",
+  logoUrl: "https://cdn.example.com/acme-logo.png",
+  websiteUrl: "https://acme.example.com",
+  storefrontUrl: "https://droplinked.io/acme-co",
+  verifiedTier: "full",
+  topProducts: [
+    {
+      id: "prod-1",
+      title: "Super Widget",
+      description: "The best widget",
+      price: 29.99,
+      currency: "USD",
+      imageUrl: "https://cdn.example.com/widget.png",
+      productUrl: "https://droplinked.io/acme-co/super-widget",
+    },
+  ],
+  social: {
+    twitter: "https://twitter.com/acmeco",
+  },
+};
+
+const VALID_DIRECTORY_PAYLOAD = {
+  slug: "small-merchant",
+  name: "Small Merchant LLC",
+  description: "",
+  logoUrl: "",
+  websiteUrl: "",
+  storefrontUrl: "https://droplinked.io/small-merchant",
+  verifiedTier: "directory_only",
+  topProducts: [],
+};
+
+test.describe("parseDiscoveryProfile @unit", () => {
+  test("parses a valid full-tier payload", () => {
+    const result = parseDiscoveryProfile(VALID_FULL_PAYLOAD);
+    expect(result).not.toBeNull();
+    expect(result?.slug).toBe("acme-co");
+    expect(result?.name).toBe("Acme Co");
+    expect(result?.verifiedTier).toBe("full");
+    expect(result?.topProducts).toHaveLength(1);
+    expect(result?.topProducts[0].price).toBe(29.99);
+    expect(result?.social?.twitter).toBe("https://twitter.com/acmeco");
+  });
+
+  test("parses a valid directory_only payload", () => {
+    const result = parseDiscoveryProfile(VALID_DIRECTORY_PAYLOAD);
+    expect(result).not.toBeNull();
+    expect(result?.verifiedTier).toBe("directory_only");
+    expect(result?.topProducts).toHaveLength(0);
+  });
+
+  test("returns null for null input", () => {
+    expect(parseDiscoveryProfile(null)).toBeNull();
+  });
+
+  test("returns null for non-object input", () => {
+    expect(parseDiscoveryProfile("string")).toBeNull();
+    expect(parseDiscoveryProfile(42)).toBeNull();
+    expect(parseDiscoveryProfile([])).toBeNull();
+  });
+
+  test("returns null when slug is missing", () => {
+    const { slug: _slug, ...noSlug } = VALID_FULL_PAYLOAD;
+    expect(parseDiscoveryProfile(noSlug)).toBeNull();
+  });
+
+  test("returns null when name is missing", () => {
+    const { name: _name, ...noName } = VALID_FULL_PAYLOAD;
+    expect(parseDiscoveryProfile(noName)).toBeNull();
+  });
+
+  test("returns null for unknown verifiedTier value", () => {
+    const payload = { ...VALID_FULL_PAYLOAD, verifiedTier: "premium" };
+    expect(parseDiscoveryProfile(payload)).toBeNull();
+  });
+
+  test("filters out malformed products and keeps valid ones", () => {
+    const payload = {
+      ...VALID_FULL_PAYLOAD,
+      topProducts: [
+        VALID_FULL_PAYLOAD.topProducts[0],
+        { id: "bad", title: 123 }, // malformed — missing price, wrong title type
+        null,
+      ],
+    };
+    const result = parseDiscoveryProfile(payload);
+    expect(result?.topProducts).toHaveLength(1);
+  });
+
+  test("caps topProducts at 8 items", () => {
+    const lotsOfProducts = Array.from({ length: 12 }, (_, i) => ({
+      id: `prod-${i}`,
+      title: `Product ${i}`,
+      description: "",
+      price: 10 + i,
+      currency: "USD",
+      imageUrl: "",
+      productUrl: "",
+    }));
+    const payload = { ...VALID_FULL_PAYLOAD, topProducts: lotsOfProducts };
+    const result = parseDiscoveryProfile(payload);
+    expect(result?.topProducts).toHaveLength(8);
+  });
+
+  test("falls back storefrontUrl to droplinked.io/<slug> when missing", () => {
+    const { storefrontUrl: _sf, ...noStorefront } = VALID_FULL_PAYLOAD;
+    const result = parseDiscoveryProfile(noStorefront);
+    expect(result?.storefrontUrl).toBe(`https://droplinked.io/${VALID_FULL_PAYLOAD.slug}`);
+  });
+
+  test("gracefully handles absent social field", () => {
+    const { social: _s, ...noSocial } = VALID_FULL_PAYLOAD;
+    const result = parseDiscoveryProfile(noSocial);
+    expect(result).not.toBeNull();
+    expect(result?.social).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #100

## Why
Phase 1 of decision #6 from droplinked-backend#2091: AEO/GEO-optimized per-merchant landing pages at `droplinked.com/m/<slug>` so LLM crawlers (ChatGPT, Claude, Perplexity, Google SGE) can ingest merchant catalogs with structured data — no separate API call required.

## Route shape

```
GET /m/[slug]   →   src/app/m/[slug]/page.tsx   (SSR, ISR revalidate=300)
```

**JSON-LD schemas emitted:**

```jsonc
// 1. Organization
{ "@context": "https://schema.org", "@type": "Organization",
  "name": "Acme Co", "url": "...", "logo": "...",
  "additionalType": "https://schema.org/OnlineBusiness",
  "identifier": { "@type": "PropertyValue", "name": "droplinked_slug", "value": "acme-co" } }

// 2. ItemList (full tier only, top-8 products)
{ "@context": "https://schema.org", "@type": "ItemList",
  "itemListElement": [ { "@type": "ListItem", "item": { "@type": "Product", ... } } ] }
```

OG + Twitter Card `<meta>` generated in `generateMetadata()`.

## Tier gating
| `verifiedTier` | Renders |
|---|---|
| `full` | Logo + name + description + verified badge + product grid (top 8) + storefront CTA |
| `directory_only` | Name only + "View storefront" link |

## BE dependency
`GET apiv3.droplinked.com/v2/merchants/:slug/discovery-profile` — droplinked-backend#2096 (KYB tier filter).

Sitemap extension uses `GET apiv3.droplinked.com/v2/merchants/discovery-index` (also #2096).

Both endpoints are guarded with graceful fallback: `fetchDiscoveryProfile` returns `null` on any non-2xx or parse error → page calls `notFound()`. Build never fails if BE is not yet live.

## Test plan
- [ ] `npx playwright test tests/discovery-profile.spec.ts` — 10 unit tests on the parser (valid full/directory payloads, null/non-object inputs, malformed products filtered, 8-item cap, storefrontUrl fallback)
- [ ] Manually hit `/m/test-merchant` on dev — expect 404 page (endpoint not live)
- [ ] When BE ships #2096: hit `/m/<real-slug>` — verify JSON-LD in page source via browser DevTools → Application → `<script type="application/ld+json">`
- [ ] Validate JSON-LD at https://validator.schema.org/ for both Organization + ItemList
- [ ] `curl https://droplinked.com/robots.txt` — confirm `Allow: /m/` present
- [ ] `curl https://droplinked.com/sitemap.xml` — confirm merchant URLs present after #2096 ships

## PSP impact
None. This is a marketing surface (`droplinked.com/m/*`) with no payment flows, no checkout, and no PSP routing. Read-only AEO/GEO discovery only.

## Files changed (9)
- `src/app/m/[slug]/page.tsx` — SSR page + `generateMetadata` + JSON-LD
- `src/app/m/[slug]/loading.tsx` — skeleton (pulse animation)
- `src/app/m/[slug]/not-found.tsx` — 404 path
- `src/app/m/[slug]/components/MerchantHero.tsx` — server component, tier-gated hero
- `src/app/m/[slug]/components/MerchantProductGrid.tsx` — server component, top-8 grid
- `src/app/m/[slug]/lib/discovery-profile.ts` — BE fetch + runtime parser (no zod dep)
- `src/app/sitemap.ts` — new; extends static routes with opted-in merchant slugs
- `src/app/robots.ts` — new; `Allow: /m/` for all crawlers
- `tests/discovery-profile.spec.ts` — 10 unit tests on the parser