### PR TITLE
feat(seo): SSR per-product page at /<merchant>/product/<slug> (GMC landing-page fix)

### DIFF
--- a/src/app/(routes)/[productId]/product/[slug]/lib/structured-data.ts
+++ b/src/app/(routes)/[productId]/product/[slug]/lib/structured-data.ts
@@ -1,0 +1,248 @@
+/**
+ * structured-data.ts
+ *
+ * Fetches and parses the per-product structured-data payload from:
+ *   apiv3.droplinked.com/shop/:shopUrl/product/:productSlug/structured-data
+ *
+ * BE dependency (already live, @Public, no auth):
+ *   droplinked-backend
+ *     src/modules/seo-discoverability/controllers/seo-discoverability.controller.ts
+ *     src/modules/seo-discoverability/services/structured-data.service.ts
+ *
+ * This is the SSR data source for the per-product landing page that the
+ * Google Merchant Center feed links to (`/<merchant>/product/<slug>`).
+ * Googlebot / GMC's landing-page check must see a real product here, or
+ * the feed is suspended for Misrepresentation (content-less apex shell).
+ *
+ * If the endpoint returns 404 / 5xx / an unrecognised payload, the fetch
+ * returns null and the page falls through to notFound() — fully 5xx-safe,
+ * mirroring src/app/m/[slug]/lib/discovery-profile.ts.
+ *
+ * ★ HOST NORMALISATION: the endpoint returns canonical/url/@id/offers.url
+ * on the bare `https://<shopUrl>/...` or `https://droplinked.com/...` host.
+ * We rewrite every served URL to the SERVED host `https://shop.droplinked.com`
+ * so that the page <link rel=canonical>, the JSON-LD `url`/`@id`/`offers.url`,
+ * and the eventual GMC feed-link host are ALL consistent — no mismatch that
+ * would re-trigger a Misrepresentation review.
+ */
+
+const APIV3_BASE = "https://apiv3.droplinked.com";
+
+/** The host the product page is actually served on (matches the GMC feed link host). */
+export const SERVED_HOST = "https://shop.droplinked.com";
+
+// ---- types (shape of the structured-data endpoint response) ----
+
+export interface ProductOfferJsonLd {
+  "@type": "Offer";
+  url?: string;
+  price?: string;
+  priceCurrency?: string;
+  availability?: string;
+  itemCondition?: string;
+  [key: string]: unknown;
+}
+
+export interface ProductJsonLd {
+  "@context": "https://schema.org";
+  "@type": "Product";
+  "@id"?: string;
+  name: string;
+  url?: string;
+  sku?: string;
+  brand?: { "@type": "Brand"; name: string } | unknown;
+  offers?: ProductOfferJsonLd;
+  description?: string;
+  image?: string[];
+  dateCreated?: string;
+  dateModified?: string;
+  [key: string]: unknown;
+}
+
+export interface OpenGraphBlock {
+  "og:type"?: string;
+  "og:title"?: string;
+  "og:url"?: string;
+  "og:site_name"?: string;
+  "og:description"?: string;
+  "og:image"?: string;
+  "twitter:card"?: string;
+  "twitter:title"?: string;
+  "twitter:description"?: string;
+  "twitter:image"?: string;
+  "product:price:amount"?: string;
+  "product:price:currency"?: string;
+  "product:availability"?: string;
+  [key: string]: string | undefined;
+}
+
+export interface StructuredData {
+  productId: string;
+  /** Canonical URL — normalised to the served shop.droplinked.com host. */
+  canonicalUrl: string;
+  jsonLd: ProductJsonLd;
+  openGraph: OpenGraphBlock;
+}
+
+/** A small view model the page renders visible HTML from. */
+export interface ProductView {
+  name: string;
+  description: string;
+  /** Display price string, e.g. "50.00". Empty if unavailable. */
+  price: string;
+  priceCurrency: string;
+  /** true = InStock, false = OutOfStock / unknown. */
+  inStock: boolean;
+  /** Human label, e.g. "In stock" / "Out of stock". */
+  availabilityLabel: string;
+  images: string[];
+  brandName: string;
+  sku: string;
+  /** The canonical/served product URL on shop.droplinked.com. */
+  canonicalUrl: string;
+}
+
+// ---- host normalisation ----
+
+/**
+ * Rewrites a possibly-bare or droplinked.com-hosted product URL to the
+ * served `https://shop.droplinked.com/<merchant>/product/<slug>` form.
+ *
+ * We do NOT trust the endpoint's host — it has been observed to emit a
+ * malformed `https://<shopUrl>/...` (no real host) or `https://droplinked.com/...`.
+ * We always reconstruct from the known (merchant, slug) so the served
+ * canonical is authoritative and host-consistent.
+ */
+export function buildServedUrl(merchant: string, slug: string): string {
+  return `${SERVED_HOST}/${encodeURIComponent(merchant)}/product/${encodeURIComponent(slug)}`;
+}
+
+// ---- runtime validators ----
+
+function isProductJsonLd(v: unknown): v is ProductJsonLd {
+  if (!v || typeof v !== "object") return false;
+  const p = v as Record<string, unknown>;
+  return p["@type"] === "Product" && typeof p.name === "string";
+}
+
+function asStringArray(v: unknown): string[] {
+  if (typeof v === "string") return [v];
+  if (Array.isArray(v)) return v.filter((x): x is string => typeof x === "string");
+  return [];
+}
+
+function parseStructuredData(
+  raw: unknown,
+  merchant: string,
+  slug: string
+): StructuredData | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+
+  if (!isProductJsonLd(r.jsonLd)) return null;
+
+  const servedUrl = buildServedUrl(merchant, slug);
+
+  // Deep-clone + host-normalise the JSON-LD so the served url/@id/offers.url
+  // are all on shop.droplinked.com regardless of what the endpoint returned.
+  const jsonLd: ProductJsonLd = {
+    ...(r.jsonLd as ProductJsonLd),
+    "@id": `${servedUrl}#product`,
+    url: servedUrl,
+  };
+  if (jsonLd.offers && typeof jsonLd.offers === "object") {
+    jsonLd.offers = { ...jsonLd.offers, url: servedUrl };
+  }
+  jsonLd.image = asStringArray((r.jsonLd as ProductJsonLd).image);
+
+  const openGraph: OpenGraphBlock =
+    r.openGraph && typeof r.openGraph === "object"
+      ? { ...(r.openGraph as OpenGraphBlock), "og:url": servedUrl }
+      : { "og:url": servedUrl };
+
+  return {
+    productId: typeof r.productId === "string" ? r.productId : "",
+    canonicalUrl: servedUrl,
+    jsonLd,
+    openGraph,
+  };
+}
+
+/**
+ * Maps a normalised StructuredData payload to the page view model.
+ */
+export function toProductView(data: StructuredData): ProductView {
+  const { jsonLd } = data;
+  const offer =
+    jsonLd.offers && typeof jsonLd.offers === "object"
+      ? (jsonLd.offers as ProductOfferJsonLd)
+      : undefined;
+
+  const availability = offer?.availability || "";
+  const inStock = /InStock/i.test(availability);
+
+  const brand =
+    jsonLd.brand && typeof jsonLd.brand === "object"
+      ? ((jsonLd.brand as { name?: string }).name ?? "")
+      : "";
+
+  return {
+    name: jsonLd.name ?? "",
+    description: typeof jsonLd.description === "string" ? jsonLd.description : "",
+    price: offer?.price ?? "",
+    priceCurrency: offer?.priceCurrency ?? "USD",
+    inStock,
+    availabilityLabel: inStock ? "In stock" : "Out of stock",
+    images: asStringArray(jsonLd.image),
+    brandName: brand,
+    sku: typeof jsonLd.sku === "string" ? jsonLd.sku : "",
+    canonicalUrl: data.canonicalUrl,
+  };
+}
+
+/**
+ * Fetches the structured-data payload for a (merchant, productSlug) pair.
+ * Returns null on network error, 404, 5xx, or an unrecognised payload.
+ * Never throws — callers should fall through to notFound() on null.
+ *
+ * Server fetch, no auth (@Public endpoint), ISR-cached for 5 minutes.
+ */
+export async function fetchStructuredData(
+  merchant: string,
+  productSlug: string
+): Promise<StructuredData | null> {
+  const url = `${APIV3_BASE}/shop/${encodeURIComponent(
+    merchant
+  )}/product/${encodeURIComponent(productSlug)}/structured-data`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      next: { revalidate: 300 },
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "droplinked-shopfront/1.0 (GMC-landing-page)",
+      },
+    });
+  } catch {
+    // Network error (DNS, timeout, etc.) — treat as not-found, never throw.
+    return null;
+  }
+
+  if (!response.ok) {
+    // 404 = unknown shop/slug; 5xx = backend down — notFound() either way.
+    return null;
+  }
+
+  let raw: unknown;
+  try {
+    raw = await response.json();
+  } catch {
+    return null;
+  }
+
+  return parseStructuredData(raw, merchant, productSlug);
+}
+
+// Export internal parser for unit-testing without a real HTTP call.
+export { parseStructuredData };

--- a/src/app/(routes)/[productId]/product/[slug]/page.tsx
+++ b/src/app/(routes)/[productId]/product/[slug]/page.tsx
@@ -1,0 +1,222 @@
+/**
+ * /<merchant>/product/<slug> — per-product SSR landing page.
+ *
+ * THE fix for the Google Merchant Center "Misrepresentation" suspension:
+ * the GMC feed links to `https://shop.droplinked.com/<merchant>/product/<slug>`,
+ * but that path previously fell through to a content-less apex client shell
+ * with NO product — so Googlebot / GMC's landing-page check saw no product
+ * matching the feed item → Misrepresentation.
+ *
+ * This route server-renders the SPECIFIC product (title, price, image,
+ * availability, description) + Schema.org Product JSON-LD + correct metadata,
+ * with canonical = the served `shop.droplinked.com` URL (host-consistent
+ * with the feed link). A crawler now sees a real product.
+ *
+ * ── ROUTE PLACEMENT / COLLISION HANDLING ─────────────────────────────────
+ * The app already has a root single-segment dynamic route:
+ *   src/app/(routes)/[productId]/page.tsx   →  /<productId>   (v1, by ObjectId)
+ * Next.js forbids two DIFFERENT slug names at the same dynamic path position
+ * ("You cannot use different slug names for the same dynamic path"), so we
+ * canNOT add `src/app/[merchant]/...`. Instead this route nests UNDER the
+ * existing first segment, REUSING the `[productId]` slug name:
+ *   src/app/(routes)/[productId]/product/[slug]/page.tsx → /<merchant>/product/<slug>
+ * Here `params.productId` actually carries the MERCHANT handle (aliased to
+ * `merchant` below). The existing single-segment route is untouched and
+ * still resolves `/<productId>`; this 3-segment route resolves the feed path.
+ *
+ * BE dependency (already live, @Public, no auth):
+ *   apiv3.droplinked.com/shop/:shopUrl/product/:productSlug/structured-data
+ *
+ * ISR: 5 minutes (revalidate = 300). Fully 5xx-safe (notFound() on null).
+ */
+
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import {
+  fetchStructuredData,
+  toProductView,
+  buildServedUrl,
+} from "./lib/structured-data";
+
+// ISR — revalidate every 5 minutes.
+export const revalidate = 300;
+
+// ---- types ----
+
+// NOTE: `productId` is the folder/slug name inherited from the parent
+// dynamic segment, but it carries the MERCHANT handle on this route.
+interface PageProps {
+  params: Promise<{ productId: string; slug: string }>;
+}
+
+// ---- metadata ----
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { productId: merchant, slug } = await params;
+  const data = await fetchStructuredData(merchant, slug);
+
+  if (!data) {
+    return { title: "Product not found | droplinked" };
+  }
+
+  const view = toProductView(data);
+  // Canonical = the SERVED url, host-consistent with the GMC feed link.
+  const canonicalUrl = buildServedUrl(merchant, slug);
+
+  const title = view.name ? `${view.name} | droplinked` : "Product | droplinked";
+  const description =
+    view.description ||
+    `${view.name}${view.brandName ? ` by ${view.brandName}` : ""} — available on droplinked.`;
+  const ogImage = view.images[0];
+
+  return {
+    title,
+    description,
+    alternates: { canonical: canonicalUrl },
+    openGraph: {
+      type: "website",
+      url: canonicalUrl,
+      title: data.openGraph["og:title"] || title,
+      description: data.openGraph["og:description"] || description,
+      siteName: data.openGraph["og:site_name"] || "droplinked",
+      images: ogImage ? [{ url: ogImage, alt: view.name }] : [],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: data.openGraph["twitter:title"] || title,
+      description: data.openGraph["twitter:description"] || description,
+      images: ogImage ? [ogImage] : [],
+    },
+    robots: { index: true, follow: true },
+  };
+}
+
+// ---- page ----
+
+export default async function ProductPage({ params }: PageProps) {
+  const { productId: merchant, slug } = await params;
+  const data = await fetchStructuredData(merchant, slug);
+
+  if (!data) {
+    notFound();
+  }
+
+  const view = toProductView(data);
+  const heroImage = view.images[0];
+  const galleryImages = view.images.slice(1, 5);
+  const priceLabel = view.price
+    ? `${view.price} ${view.priceCurrency}`
+    : "Price unavailable";
+
+  return (
+    <>
+      {/* Schema.org Product JSON-LD — host-normalised to shop.droplinked.com.
+          This is what Googlebot / GMC's landing-page check reads to match
+          the feed item. Inline per Next.js App Router convention. */}
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(data.jsonLd) }}
+      />
+
+      <main className="container mx-auto px-6 md:px-8 py-12 flex flex-col md:flex-row items-start gap-10 max-w-6xl">
+        {/* ── media column ── */}
+        <div className="w-full md:w-1/2">
+          {heroImage ? (
+            // Plain <img> (not next/image): product images come from many
+            // hosts (S3, Printful, CDN). A plain tag always server-renders
+            // and never 500s on an unconfigured remote-image host — exactly
+            // what the GMC landing-page crawler must see.
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={heroImage}
+              alt={view.name}
+              width={800}
+              height={800}
+              className="w-full h-auto rounded-lg object-cover bg-surface-1"
+              loading="eager"
+            />
+          ) : (
+            <div className="w-full aspect-square rounded-lg bg-surface-1" />
+          )}
+
+          {galleryImages.length > 0 && (
+            <div className="mt-4 grid grid-cols-4 gap-3">
+              {galleryImages.map((img, i) => (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  key={img + i}
+                  src={img}
+                  alt={`${view.name} — view ${i + 2}`}
+                  width={160}
+                  height={160}
+                  className="w-full h-auto rounded-md object-cover bg-surface-1"
+                  loading="lazy"
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* ── details column ── */}
+        <div className="w-full md:w-1/2 flex flex-col gap-5">
+          {view.brandName && (
+            <p className="text-sm uppercase tracking-wide text-ink-faint">
+              {view.brandName}
+            </p>
+          )}
+
+          <h1 className="text-3xl md:text-4xl font-semibold text-ink">
+            {view.name}
+          </h1>
+
+          <div className="flex items-center gap-4">
+            <span className="text-2xl font-bold text-ink" data-testid="product-price">
+              {priceLabel}
+            </span>
+            <span
+              className={
+                view.inStock
+                  ? "text-sm font-medium text-emerald-600"
+                  : "text-sm font-medium text-red-500"
+              }
+              data-testid="product-availability"
+            >
+              {view.availabilityLabel}
+            </span>
+          </div>
+
+          {view.description && (
+            <p className="text-base leading-relaxed text-ink-muted whitespace-pre-line">
+              {view.description}
+            </p>
+          )}
+
+          {/* Buy / view CTA → the canonical served product URL. */}
+          <a
+            href={view.canonicalUrl}
+            className="inline-flex items-center justify-center rounded-lg bg-mint-500 hover:bg-mint-400 transition-colors px-6 py-3 text-base font-semibold text-black w-full md:w-auto"
+            aria-disabled={!view.inStock}
+          >
+            {view.inStock ? "Buy now" : "View product"}
+          </a>
+
+          {view.sku && (
+            <p className="text-xs text-ink-faint">SKU: {view.sku}</p>
+          )}
+
+          <p className="text-xs text-ink-faint mt-2">
+            Sold on{" "}
+            <a
+              href="https://droplinked.com"
+              className="text-mint-500 hover:text-mint-400 transition-colors"
+            >
+              droplinked
+            </a>{" "}
+            — onchain commerce protocol
+          </p>
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## What

Adds a **server-rendered per-product page** at `/<merchant>/product/<slug>` — the exact path shape the Google Merchant Center product feed links to.

Previously that path fell through to a content-less client shell with no product, so Googlebot / GMC's landing-page check saw no product matching the feed item → **Misrepresentation suspension**. This route makes a crawler see a real product (title, price, image, availability, description) + Schema.org Product JSON-LD + correct canonical.

## Route file
- `src/app/(routes)/[productId]/product/[slug]/page.tsx` — async server component
- `src/app/(routes)/[productId]/product/[slug]/lib/structured-data.ts` — 5xx-safe server-fetch wrapper + host normalisation (cloned from the `m/[slug]` discovery-profile pattern)

## Route-collision handling
The app already has a root single-segment dynamic route `(routes)/[productId]/page.tsx` → `/<productId>`. Next.js forbids two **different** slug names at the same dynamic path position ("You cannot use different slug names for the same dynamic path"), so a sibling `app/[merchant]/...` would break the build. This route instead **nests under the existing first segment, reusing the `[productId]` slug name**: `(routes)/[productId]/product/[slug]`. `params.productId` carries the merchant handle (aliased to `merchant`). The existing single-segment route is untouched.

Build confirms both coexist:
```
├ ƒ /[productId]
├ ƒ /[productId]/product/[slug]
```

## Data source (no new backend)
Server `fetch` (no auth, `{ next: { revalidate: 300 } }`) to the already-live `@Public` endpoint:
`apiv3.droplinked.com/shop/:shopUrl/product/:productSlug/structured-data`
→ `notFound()` on null / 404 / 5xx (never throws).

## Canonical / host consistency ★
The endpoint emits `url`/`@id`/`offers.url`/`canonicalUrl` on a malformed bare host or `droplinked.com`. This route **rewrites all of them — plus the page `<link rel=canonical>` and `og:url` — to the served `https://shop.droplinked.com/<merchant>/product/<slug>`**, so page-canonical, JSON-LD url, and the feed-link host are all consistent (no mismatch that would re-trigger review).

## Verified end-to-end (prod build + live endpoint)
Sample `/blocksurvey/product/sticker-pack-81859` server-renders (in raw HTML, pre-JS):
- `<title>Sticker Pack | droplinked</title>`
- `<link rel="canonical" href="https://shop.droplinked.com/blocksurvey/product/sticker-pack-81859">`
- visible h1 "Sticker Pack", price "50.00 USD", "In stock", product image, description, buy CTA
- inline `<script type="application/ld+json">` Product+Offer with `url`/`@id`/`offers.url` all on `shop.droplinked.com`
- unknown slug → `notFound()`, no JSON-LD / no product content (no phantom product)

`tsc --noEmit` clean · `next lint` clean on new files · `next build` green · `export const revalidate = 300`.

Do not merge yet — for operator review + deploy.