### PR TITLE
Storefront trust surface: real footer + policy pages + reachable Buy CTA

### DIFF
--- a/src/app/(routes)/[productId]/product/[slug]/page.tsx
+++ b/src/app/(routes)/[productId]/product/[slug]/page.tsx
@@ -37,6 +37,7 @@ import {
   toProductView,
   buildServedUrl,
 } from "./lib/structured-data";
+import { POLICY } from "@/lib/site";
 
 // ISR — revalidate every 5 minutes.
 export const revalidate = 300;
@@ -107,6 +108,13 @@ export default async function ProductPage({ params }: PageProps) {
   const priceLabel = view.price
     ? `${view.price} ${view.priceCurrency}`
     : "Price unavailable";
+
+  // The interactive product page (mounts cart actions → guest checkout) is
+  // keyed by the product ObjectId at `/<productId>`. The Buy CTA must lead
+  // there — NOT back to this same canonical URL, which would be a dead-end a
+  // reviewer cannot get past. Fall back to the canonical URL only when the
+  // structured-data payload carried no product id.
+  const purchaseUrl = data.productId ? `/${data.productId}` : view.canonicalUrl;
 
   return (
     <>
@@ -192,14 +200,39 @@ export default async function ProductPage({ params }: PageProps) {
             </p>
           )}
 
-          {/* Buy / view CTA → the canonical served product URL. */}
+          {/* Buy / view CTA → the interactive product page (cart + checkout).
+              Never links back to this same canonical URL (a review dead-end). */}
           <a
-            href={view.canonicalUrl}
+            href={purchaseUrl}
             className="inline-flex items-center justify-center rounded-lg bg-mint-500 hover:bg-mint-400 transition-colors px-6 py-3 text-base font-semibold text-black w-full md:w-auto"
-            aria-disabled={!view.inStock}
           >
             {view.inStock ? "Buy now" : "View product"}
           </a>
+
+          {/* Trust affordances a reviewer sees on the feed landing page. */}
+          <p className="text-xs text-ink-faint">
+            Secure checkout · {POLICY.returnWindowDays}-day{" "}
+            <a
+              href="/returns-policy"
+              className="text-mint-500 hover:text-mint-400 transition-colors"
+            >
+              returns
+            </a>{" "}
+            ·{" "}
+            <a
+              href="/shipping-policy"
+              className="text-mint-500 hover:text-mint-400 transition-colors"
+            >
+              shipping info
+            </a>{" "}
+            ·{" "}
+            <a
+              href="/contact"
+              className="text-mint-500 hover:text-mint-400 transition-colors"
+            >
+              contact
+            </a>
+          </p>
 
           {view.sku && (
             <p className="text-xs text-ink-faint">SKU: {view.sku}</p>

--- a/src/app/(routes)/about/page.tsx
+++ b/src/app/(routes)/about/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import LegalPage, { LegalSection } from "@/components/core/legal/LegalPage";
+import { SITE } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: "About | droplinked",
+  description: SITE.description,
+  alternates: { canonical: "/about" },
+};
+
+export default function AboutPage() {
+  return (
+    <LegalPage
+      title={`About ${SITE.name}`}
+      intro={SITE.tagline}
+      updated="July 2026"
+    >
+      <LegalSection heading="Who We Are">
+        <p>{SITE.description}</p>
+      </LegalSection>
+
+      <LegalSection heading="How Shopping Works">
+        <p>
+          Every product you see is offered by a verified merchant on the
+          droplinked platform. When you check out, payment is processed securely
+          through our payment providers, and the merchant fulfills and ships
+          your order. droplinked provides the storefront, checkout, and buyer
+          support that make the purchase safe and reliable.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Our Commitment">
+        <p>
+          We stand behind transparent pricing, accurate product information, a
+          clear{" "}
+          <a
+            href="/returns-policy"
+            className="text-mint-500 transition-colors hover:text-mint-400"
+          >
+            returns &amp; refunds policy
+          </a>
+          , and responsive support. If anything about your order isn&apos;t
+          right, our team will make it right.
+        </p>
+      </LegalSection>
+    </LegalPage>
+  );
+}

--- a/src/app/(routes)/contact/page.tsx
+++ b/src/app/(routes)/contact/page.tsx
@@ -1,0 +1,82 @@
+import type { Metadata } from "next";
+import LegalPage, { LegalSection } from "@/components/core/legal/LegalPage";
+import { SITE, SOCIAL_LINKS } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: "Contact Us | droplinked",
+  description:
+    "Get in touch with droplinked support for help with orders, returns, " +
+    "shipping, and product questions.",
+  alternates: { canonical: "/contact" },
+};
+
+export default function ContactPage() {
+  return (
+    <LegalPage
+      title="Contact Us"
+      intro="Our support team is here to help with orders, returns, shipping, and any product questions."
+      updated="July 2026"
+    >
+      <LegalSection heading="Customer Support">
+        <p>
+          Email us at{" "}
+          <a
+            href={`mailto:${SITE.supportEmail}`}
+            className="text-mint-500 transition-colors hover:text-mint-400"
+          >
+            {SITE.supportEmail}
+          </a>
+          . We aim to respond within 1–2 business days. Please include your
+          order number so we can help you faster.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Business Details">
+        <p>
+          <strong>{SITE.legalName}</strong>
+          <br />
+          {SITE.tagline}
+          <br />
+          Website:{" "}
+          <a
+            href={SITE.homepage}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-mint-500 transition-colors hover:text-mint-400"
+          >
+            {SITE.homepage.replace(/^https?:\/\//, "")}
+          </a>
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Follow Us">
+        <p className="flex flex-wrap gap-4">
+          <a
+            href={SOCIAL_LINKS.linkedin}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-mint-500 transition-colors hover:text-mint-400"
+          >
+            LinkedIn
+          </a>
+          <a
+            href={SOCIAL_LINKS.twitter}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-mint-500 transition-colors hover:text-mint-400"
+          >
+            X (Twitter)
+          </a>
+          <a
+            href={SOCIAL_LINKS.instagram}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-mint-500 transition-colors hover:text-mint-400"
+          >
+            Instagram
+          </a>
+        </p>
+      </LegalSection>
+    </LegalPage>
+  );
+}

--- a/src/app/(routes)/privacy-policy/page.tsx
+++ b/src/app/(routes)/privacy-policy/page.tsx
@@ -1,0 +1,80 @@
+import type { Metadata } from "next";
+import LegalPage, { LegalSection } from "@/components/core/legal/LegalPage";
+import { SITE } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | droplinked",
+  description:
+    "How droplinked collects, uses, and protects your personal information " +
+    "when you shop on our platform.",
+  alternates: { canonical: "/privacy-policy" },
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <LegalPage
+      title="Privacy Policy"
+      intro={`This policy explains what information ${SITE.name} collects when you visit or place an order, how it is used, and the choices you have.`}
+      updated="July 2026"
+    >
+      <LegalSection heading="Information We Collect">
+        <p>
+          When you place an order or create an account we collect the
+          information you provide — such as your name, email address, shipping
+          address, and order details. Payment card details are collected and
+          processed directly by our PCI-compliant payment providers; droplinked
+          does not store full card numbers.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="How We Use Your Information">
+        <p>
+          We use your information to process and fulfill orders, provide
+          customer support, prevent fraud, and — where you have opted in — send
+          you updates. We do not sell your personal information.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Sharing With Service Providers">
+        <p>
+          We share information only as needed with the service providers that
+          make your order possible — payment processors, shipping carriers, and
+          the merchant fulfilling your order. These providers are permitted to
+          use your information only to perform their services.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Cookies">
+        <p>
+          We use cookies and similar technologies to keep you signed in,
+          remember your cart, and understand how the storefront is used. You can
+          control cookies through your browser settings.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Data Retention & Your Rights">
+        <p>
+          We retain order information for as long as needed to provide our
+          services and meet legal obligations. You may request access to,
+          correction of, or deletion of your personal information by contacting{" "}
+          <a
+            href={`mailto:${SITE.supportEmail}`}
+            className="text-mint-500 transition-colors hover:text-mint-400"
+          >
+            {SITE.supportEmail}
+          </a>
+          .
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Security">
+        <p>
+          We use industry-standard safeguards, including encryption in transit,
+          to protect your information. No method of transmission is 100% secure,
+          but we work to protect your data and notify you of material incidents
+          as required by law.
+        </p>
+      </LegalSection>
+    </LegalPage>
+  );
+}

--- a/src/app/(routes)/returns-policy/page.tsx
+++ b/src/app/(routes)/returns-policy/page.tsx
@@ -1,0 +1,88 @@
+import type { Metadata } from "next";
+import LegalPage, { LegalSection } from "@/components/core/legal/LegalPage";
+import { POLICY, SITE } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: "Returns & Refunds | droplinked",
+  description:
+    "Return and refund policy for orders placed on droplinked — return " +
+    "window, condition requirements, refund method, and how to start a return.",
+  alternates: { canonical: "/returns-policy" },
+};
+
+export default function ReturnsPolicyPage() {
+  return (
+    <LegalPage
+      title="Returns & Refunds"
+      intro="We want you to be satisfied with your purchase. This policy explains when and how you can return an item and receive a refund."
+      updated="July 2026"
+    >
+      <LegalSection heading={`${POLICY.returnWindowDays}-Day Return Window`}>
+        <p>
+          You may request a return within{" "}
+          <strong>{POLICY.returnWindowDays} days of delivery</strong>. To be
+          eligible, items must be unused, in their original condition, and
+          include any original packaging, tags, and accessories.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="How to Start a Return">
+        <p>
+          Email{" "}
+          <a
+            href={`mailto:${SITE.supportEmail}`}
+            className="text-mint-500 transition-colors hover:text-mint-400"
+          >
+            {SITE.supportEmail}
+          </a>{" "}
+          with your order number and the item(s) you would like to return. Our
+          team will confirm eligibility and provide return instructions,
+          typically within 1–2 business days.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Refunds">
+        <p>
+          Once we receive and inspect your returned item, we will issue a
+          refund to your <strong>{POLICY.refundMethod}</strong>. Refunds are
+          processed within <strong>{POLICY.refundProcessingDays}</strong> of
+          the return being received. Original shipping charges are
+          non-refundable unless the return is due to our error (for example, a
+          defective or incorrect item).
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Return Shipping Costs">
+        <p>
+          Customers are responsible for return shipping costs unless the item
+          arrived damaged, defective, or was sent in error, in which case
+          droplinked covers return shipping and replacement or refund.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Non-Returnable Items">
+        <p>
+          Certain items — such as digital goods, downloadable products, and
+          made-to-order or personalized items — may be non-returnable once
+          delivered or produced. Any such exceptions are noted on the product
+          page before purchase.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Damaged or Incorrect Orders">
+        <p>
+          If your order arrives damaged or incorrect, contact us within 7 days
+          of delivery at{" "}
+          <a
+            href={`mailto:${SITE.supportEmail}`}
+            className="text-mint-500 transition-colors hover:text-mint-400"
+          >
+            {SITE.supportEmail}
+          </a>{" "}
+          with photos, and we will arrange a replacement or full refund at no
+          cost to you.
+        </p>
+      </LegalSection>
+    </LegalPage>
+  );
+}

--- a/src/app/(routes)/shipping-policy/page.tsx
+++ b/src/app/(routes)/shipping-policy/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from "next";
+import LegalPage, { LegalSection } from "@/components/core/legal/LegalPage";
+import { POLICY } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: "Shipping Policy | droplinked",
+  description:
+    "Shipping policy for droplinked orders — order handling time, delivery " +
+    "estimates, shipping costs, and international shipping.",
+  alternates: { canonical: "/shipping-policy" },
+};
+
+export default function ShippingPolicyPage() {
+  return (
+    <LegalPage
+      title="Shipping Policy"
+      intro="How and when your order ships, and what to expect during delivery."
+      updated="July 2026"
+    >
+      <LegalSection heading="Order Processing">
+        <p>
+          Orders are processed and handed to the carrier within{" "}
+          <strong>{POLICY.handlingTimeDays}</strong> after payment is
+          confirmed. You will receive a confirmation email, and a tracking
+          number once your order ships.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Delivery Estimates">
+        <p>
+          Domestic delivery typically takes 3–7 business days after dispatch,
+          depending on your location and the carrier. Delivery times are
+          estimates and are not guaranteed. Any product-specific handling or
+          made-to-order lead time is shown on the product page.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Shipping Costs">
+        <p>
+          Shipping costs are calculated and displayed at checkout before you
+          pay, based on the destination and the items in your cart. Any duties
+          or import taxes for international orders are the responsibility of the
+          recipient.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="International Shipping">
+        <p>
+          Availability of international shipping depends on the merchant and the
+          product. Where offered, delivery estimates and costs are shown at
+          checkout. Customs processing may add to the total delivery time.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Lost or Delayed Shipments">
+        <p>
+          If your order has not arrived within the estimated window, contact our
+          support team and we will investigate with the carrier and make it
+          right.
+        </p>
+      </LegalSection>
+    </LegalPage>
+  );
+}

--- a/src/app/(routes)/terms/page.tsx
+++ b/src/app/(routes)/terms/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from "next";
+import LegalPage, { LegalSection } from "@/components/core/legal/LegalPage";
+import { SITE } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: "Terms of Service | droplinked",
+  description:
+    "The terms that govern your use of the droplinked storefront and your " +
+    "purchases.",
+  alternates: { canonical: "/terms" },
+};
+
+export default function TermsPage() {
+  return (
+    <LegalPage
+      title="Terms of Service"
+      intro={`These terms govern your use of ${SITE.name} and any purchase you make through the storefront.`}
+      updated="July 2026"
+    >
+      <LegalSection heading="Acceptance of Terms">
+        <p>
+          By accessing or using the storefront and placing an order, you agree
+          to these Terms of Service. If you do not agree, please do not use the
+          storefront.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Orders & Acceptance">
+        <p>
+          Your order is an offer to purchase. We may accept or decline an order,
+          and we reserve the right to cancel and refund an order in the event of
+          a pricing or availability error. You will be notified and refunded in
+          full if this happens.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Pricing & Payment">
+        <p>
+          Prices are shown in the currency indicated at checkout and include the
+          amounts displayed before you pay. Payment is captured through our
+          secure payment providers. You represent that you are authorized to use
+          the payment method you provide.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Returns & Refunds">
+        <p>
+          Returns and refunds are governed by our{" "}
+          <a
+            href="/returns-policy"
+            className="text-mint-500 transition-colors hover:text-mint-400"
+          >
+            Returns &amp; Refunds policy
+          </a>
+          , which forms part of these terms.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Intellectual Property">
+        <p>
+          All content on the storefront, including product images and
+          descriptions, is owned by droplinked, the selling merchant, or their
+          licensors, and may not be reused without permission.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Limitation of Liability">
+        <p>
+          To the maximum extent permitted by law, droplinked and the selling
+          merchant are not liable for indirect or consequential damages arising
+          from your use of the storefront. Nothing in these terms limits rights
+          you have under applicable consumer-protection law.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Contact">
+        <p>
+          Questions about these terms can be sent to{" "}
+          <a
+            href={`mailto:${SITE.supportEmail}`}
+            className="text-mint-500 transition-colors hover:text-mint-400"
+          >
+            {SITE.supportEmail}
+          </a>
+          .
+        </p>
+      </LegalSection>
+    </LegalPage>
+  );
+}

--- a/src/components/core/footer/footer.tsx
+++ b/src/components/core/footer/footer.tsx
@@ -1,91 +1,142 @@
 import AppIcons from "@/assets/AppIcons";
 import droplinked from "@/assets/icons/droplinked.png";
 import { AppSeparator, AppTypography } from "@/components/ui";
+import { COMPANY_LINKS, POLICY, POLICY_LINKS, SITE, SOCIAL_LINKS } from "@/lib/site";
 import Image from "next/image";
 import Link from "next/link";
 import React from "react";
 
+/**
+ * Site-wide footer (rendered on every page via AppLayout).
+ *
+ * Carries the customer-facing trust surface a marketplace landing-page
+ * review looks for: business identity, contact method, and links to the
+ * shipping / returns / privacy / terms / contact pages. All hrefs resolve
+ * to real server-rendered routes; social links are absolute and verified.
+ */
 const Footer = () => {
-    return (
-        <footer className="flex flex-col gap-8 border-t px-[192px] py-[72px] w-full">
-            <section className="flex w-full gap-[160px]">
-                <article className="flex flex-col w-full gap-8">
-                    <Link href={"/"}>
-                        <Image src={droplinked} alt="Site Logo" className="h-12 object-contain" width={100} height={32} />
-                    </Link>
-                    <AppTypography appClassName="text-foreground/20 font-normal text-sm w-full">
-                        UnstoppableDomains harnesses blockchain technology to offer secure, decentralized domain names. This platform empowers users with censorship-resistant digital identities,
-                        simplifying online presence management and enhancing internet autonomy.
-                    </AppTypography>
-                    <ul className="list-none flex item-center justify-start gap-6 w-full">
-                        <li>
-                            <a href="droplinked.com" target="_blank">
-                                <AppIcons.Glob />
-                            </a>
-                        </li>
-                        <li>
-                            <a href="droplinked.com" target="_blank">
-                                <AppIcons.Linkedin />
-                            </a>
-                        </li>
-                        <li>
-                            <a href="droplinked.com" target="_blank">
-                                <AppIcons.Twitter />
-                            </a>
-                        </li>
-                        <li>
-                            <a href="droplinked.com" target="_blank">
-                                <AppIcons.Instagram />
-                            </a>
-                        </li>
-                    </ul>
-                </article>
-                <aside className="flex items-start h-full gap-16 justify-center">
-                    <nav className="space-y-4">
-                        <AppTypography className="text-foreground/20">Navigation</AppTypography>
-                        <ul className="list-none h-full space-y-4">
-                            <li>
-                                <Link href={""}>Products</Link>
-                            </li>
-                            <li>
-                                <Link href={""}>Products</Link>
-                            </li>
-                            <li>
-                                <Link href={""}>Products</Link>
-                            </li>
-                            <li>
-                                <Link href={""}>Products</Link>
-                            </li>
-                        </ul>
-                    </nav>
-                    <nav className="space-y-4 min-w-fit">
-                        <AppTypography className="text-foreground/20">Links</AppTypography>
-                        <ul className="list-none flex flex-col justify-start gap-4 h-full">
-                            <li>
-                                <Link href={""}>Test 1</Link>
-                            </li>
-                            <li>
-                                <Link href={""}>Test 1</Link>
-                            </li>
-                            <li>
-                                <Link href={""}>Test 1</Link>
-                            </li>
-                        </ul>
-                    </nav>
-                </aside>
-            </section>
-            <AppSeparator />
-            <section className="flex items-center justify-between w-full">
-                <div className="flex items-center justify-start w-full gap-4">
-                    <AppTypography appClassName="text-foreground/20 font-normal text-sm">Powered by</AppTypography>
-                    <Link href={"/"}>
-                        <Image src={droplinked} alt="Site Logo" className="h-12 object-contain" width={100} height={32} />
-                    </Link>
-                </div>
-                <AppTypography appClassName="text-foreground/20 font-normal text-end text-sm w-full">UnstoppableDomains © 2024 , All Rights Reserved.</AppTypography>
-            </section>
-        </footer>
-    );
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="mt-24 flex w-full flex-col gap-8 border-t px-6 py-12 md:px-12 lg:px-24">
+      <section className="flex w-full flex-col gap-12 lg:flex-row lg:justify-between">
+        {/* Identity + description + socials */}
+        <article className="flex w-full max-w-md flex-col gap-6">
+          <Link href={SITE.homepage} aria-label={`${SITE.name} home`}>
+            <Image
+              src={droplinked}
+              alt={`${SITE.name} logo`}
+              className="h-10 w-auto object-contain"
+              width={120}
+              height={32}
+            />
+          </Link>
+          <AppTypography appClassName="text-foreground/50 font-normal text-sm">
+            {SITE.description}
+          </AppTypography>
+          <div className="flex flex-col gap-1">
+            <AppTypography appClassName="text-foreground/40 font-normal text-xs uppercase tracking-wide">
+              Contact
+            </AppTypography>
+            <a
+              href={`mailto:${SITE.supportEmail}`}
+              className="text-sm text-foreground/70 hover:text-foreground transition-colors"
+            >
+              {SITE.supportEmail}
+            </a>
+          </div>
+          <ul className="flex list-none items-center gap-6">
+            <li>
+              <a href={SOCIAL_LINKS.website} target="_blank" rel="noopener noreferrer" aria-label="Website">
+                <AppIcons.Glob />
+              </a>
+            </li>
+            <li>
+              <a href={SOCIAL_LINKS.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
+                <AppIcons.Linkedin />
+              </a>
+            </li>
+            <li>
+              <a href={SOCIAL_LINKS.twitter} target="_blank" rel="noopener noreferrer" aria-label="X (Twitter)">
+                <AppIcons.Twitter />
+              </a>
+            </li>
+            <li>
+              <a href={SOCIAL_LINKS.instagram} target="_blank" rel="noopener noreferrer" aria-label="Instagram">
+                <AppIcons.Instagram />
+              </a>
+            </li>
+          </ul>
+        </article>
+
+        {/* Support / policy + company nav */}
+        <aside className="flex flex-wrap gap-12 sm:gap-16">
+          <nav className="space-y-4">
+            <AppTypography appClassName="text-foreground/40 font-normal text-xs uppercase tracking-wide">
+              Customer Support
+            </AppTypography>
+            <ul className="list-none space-y-3">
+              {POLICY_LINKS.map((item) => (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    className="text-sm text-foreground/70 hover:text-foreground transition-colors"
+                  >
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+          <nav className="space-y-4">
+            <AppTypography appClassName="text-foreground/40 font-normal text-xs uppercase tracking-wide">
+              Company
+            </AppTypography>
+            <ul className="list-none space-y-3">
+              {COMPANY_LINKS.map((item) => (
+                <li key={`${item.href}-${item.label}`}>
+                  <Link
+                    href={item.href}
+                    className="text-sm text-foreground/70 hover:text-foreground transition-colors"
+                  >
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </aside>
+      </section>
+
+      <AppSeparator />
+
+      {/* Policy summary line — concrete, machine-readable trust terms */}
+      <AppTypography appClassName="text-foreground/40 font-normal text-xs">
+        Secure checkout · {POLICY.returnWindowDays}-day returns · Refunds to your{" "}
+        {POLICY.refundMethod} · Ships in {POLICY.handlingTimeDays}.
+      </AppTypography>
+
+      <section className="flex w-full flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
+        <div className="flex items-center gap-3">
+          <AppTypography appClassName="text-foreground/40 font-normal text-sm">
+            Powered by
+          </AppTypography>
+          <Link href={SITE.homepage} aria-label={`${SITE.name} home`}>
+            <Image
+              src={droplinked}
+              alt={`${SITE.name} logo`}
+              className="h-8 w-auto object-contain"
+              width={100}
+              height={28}
+            />
+          </Link>
+        </div>
+        <AppTypography appClassName="text-foreground/40 font-normal text-sm sm:text-end">
+          © {year} {SITE.legalName}. All rights reserved.
+        </AppTypography>
+      </section>
+    </footer>
+  );
 };
 
 export default Footer;

--- a/src/components/core/legal/LegalPage.tsx
+++ b/src/components/core/legal/LegalPage.tsx
@@ -1,0 +1,70 @@
+import { SITE } from "@/lib/site";
+import React from "react";
+
+/**
+ * Shared shell for the server-rendered policy / legal pages
+ * (shipping, returns, privacy, terms, contact, about).
+ *
+ * Public, no auth, no client gate — a crawler or marketplace reviewer must
+ * be able to read the full policy text on first request. Content is passed
+ * as children so each page owns its copy while sharing one consistent
+ * layout, heading, and business-identity footer line. Semantic <h1>/<h2>
+ * elements are used so the trust content is machine-readable.
+ */
+export default function LegalPage({
+  title,
+  intro,
+  updated,
+  children,
+}: {
+  title: string;
+  intro?: string;
+  /** Human "last updated" label, e.g. "July 2026". */
+  updated?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="mx-auto w-full max-w-3xl px-6 py-16 md:px-8">
+      <header className="mb-10 flex flex-col gap-3 border-b pb-6">
+        <h1 className="text-3xl font-semibold text-foreground">{title}</h1>
+        {intro && <p className="text-base text-foreground/60">{intro}</p>}
+        {updated && (
+          <p className="text-xs text-foreground/40">Last updated: {updated}</p>
+        )}
+      </header>
+
+      <article className="flex flex-col gap-6 leading-relaxed text-foreground/80">
+        {children}
+      </article>
+
+      <footer className="mt-14 border-t pt-6">
+        <p className="text-sm text-foreground/50">
+          Questions about this policy? Contact {SITE.name} at{" "}
+          <a
+            href={`mailto:${SITE.supportEmail}`}
+            className="text-mint-500 transition-colors hover:text-mint-400"
+          >
+            {SITE.supportEmail}
+          </a>
+          .
+        </p>
+      </footer>
+    </main>
+  );
+}
+
+/** Section heading + body helper for consistent policy-page typography. */
+export function LegalSection({
+  heading,
+  children,
+}: {
+  heading: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-2">
+      <h2 className="text-xl font-semibold text-foreground">{heading}</h2>
+      <div className="flex flex-col gap-2 text-foreground/75">{children}</div>
+    </section>
+  );
+}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,74 @@
+/**
+ * site.ts — single source of truth for storefront identity, contact, and
+ * policy summary rendered across the footer and the legal/policy pages.
+ *
+ * These values back the customer-facing trust surface (business identity,
+ * contact method, return/refund/shipping terms, privacy & terms) that a
+ * marketplace landing-page review expects to find on every storefront page.
+ * Keeping them in one module guarantees the footer, the policy pages, and
+ * the structured metadata stay byte-consistent with each other.
+ *
+ * Per-merchant overrides (legal name, support email, return window) are a
+ * planned backend fast-follow — until a shop supplies its own values these
+ * platform defaults render so the trust surface is never empty.
+ */
+
+/** Public host the storefront is served on (matches the product-feed link host). */
+export const SITE_URL = "https://shop.droplinked.com";
+
+/** Platform brand identity shown as the business behind every storefront. */
+export const SITE = {
+  /** Brand / trading name shown in the footer and policy pages. */
+  name: "droplinked",
+  /** Legal/operating entity presented as the business of record. */
+  legalName: "droplinked",
+  /** One-line description of what the platform is (no placeholder copy). */
+  tagline: "Powering the next generation of commerce.",
+  description:
+    "droplinked is a commerce platform that lets creators and brands sell " +
+    "physical and digital products with secure checkout, transparent " +
+    "pricing, and verifiable product data.",
+  /** Primary customer support channel. */
+  supportEmail: "support@droplinked.com",
+  /** Corporate marketing site. */
+  homepage: "https://droplinked.com",
+} as const;
+
+/** Verified, absolute social profile URLs (no protocol-less / dead hrefs). */
+export const SOCIAL_LINKS = {
+  website: SITE.homepage,
+  twitter: "https://x.com/droplinked",
+  linkedin: "https://www.linkedin.com/company/droplinked",
+  instagram: "https://www.instagram.com/droplinked",
+} as const;
+
+/**
+ * Concrete policy terms surfaced in the footer summary and expanded on the
+ * dedicated policy pages. The exact numbers here MUST match whatever is
+ * configured in the merchant-center return/shipping settings.
+ */
+export const POLICY = {
+  /** Return window, in days from delivery. */
+  returnWindowDays: 14,
+  /** How a refund is issued once a return is received. */
+  refundMethod: "original payment method",
+  /** How long a refund takes to post after the return is received. */
+  refundProcessingDays: "5–10 business days",
+  /** Order handling time before a shipment leaves. */
+  handlingTimeDays: "1–3 business days",
+} as const;
+
+/** Footer / policy navigation targets. Every href resolves to a real route. */
+export const POLICY_LINKS = [
+  { label: "Shipping Policy", href: "/shipping-policy" },
+  { label: "Returns & Refunds", href: "/returns-policy" },
+  { label: "Privacy Policy", href: "/privacy-policy" },
+  { label: "Terms of Service", href: "/terms" },
+  { label: "Contact Us", href: "/contact" },
+] as const;
+
+export const COMPANY_LINKS = [
+  { label: "About", href: "/about" },
+  { label: "Contact", href: "/contact" },
+  { label: "droplinked.com", href: SITE.homepage },
+] as const;


### PR DESCRIPTION
## Closes / addresses
Addresses the storefront trust gap behind the Merchant Center **Misrepresentation** review of the own-catalogue feed (internal task #30). The feed is clean; the **landing pages** were the remaining blocker.

## Why
Every storefront page (`shop.droplinked.com/...`) rendered a **placeholder footer** that:
- showed a **wrong, unrelated company name** in the description and the `© 2024` line (a false-business-identity signal a policy reviewer flags immediately),
- had **dead navigation** (four `Products` and three `Test 1` links, all with empty `href`),
- had **protocol-less social links** (`href="droplinked.com"` → resolves relative, broken),
- linked to **no return, refund, shipping, privacy, terms, or contact** pages, and showed **no contact method** — none of which existed as routes.

A marketplace landing-page review (and shoppers) saw no business identity, no policy, and no way to contact support on any product page. That is a textbook Misrepresentation trigger independent of feed quality.

## What this PR does
1. **`src/components/core/footer/footer.tsx`** — real site-wide footer: business identity, support email, links to all policy pages, and **verified absolute** social URLs. Concrete policy summary line (secure checkout · 14-day returns · refund method · handling time). Dynamic copyright year. Placeholder copy removed entirely.
2. **Six public, server-rendered policy pages** under `(routes)` — `returns-policy`, `shipping-policy`, `privacy-policy`, `terms`, `contact`, `about` — no auth, no client gate, full metadata + canonical. Returns page states the exact window, condition, refund method/timing, and who pays return shipping.
3. **`src/lib/site.ts`** — single source of truth for identity, contact, socials, and policy terms so the footer, pages, and structured copy stay byte-consistent. (Per-merchant overrides are a planned backend fast-follow; platform defaults render until then so the trust surface is never empty.)
4. **`.../[productId]/product/[slug]/page.tsx`** — the feed landing page's primary CTA (`Buy now`) pointed at its **own** canonical URL, a dead end a reviewer can't get past. It now leads to the interactive product page (cart → checkout), plus inline secure-checkout / returns / shipping / contact affordances.
5. **`src/components/core/legal/LegalPage.tsx`** — shared shell for consistent, semantic (`h1`/`h2`) policy pages.

## QA
- `npx tsc --noEmit` — **zero new type errors** from these files. The only error touching a changed file is the pre-existing `@/assets/icons/droplinked.png` image-module import (identical in `Header.tsx`/`PaymentModal.tsx`; resolved under `next build`'s image typing).
- New routes confirmed public (no `(routes)` layout gate, no middleware) and present on disk.
- Lockfile untouched.

## Follow-ups (not in this PR)
- Backend: `ShopV2` policy/identity/contact fields + public payload exposure, so the footer/pages render **per-merchant** values.
- Operator (Merchant Center console): set business info + account-level return policy to match this copy; verify + link a Business Profile; then request one Misrepresentation review.