### PR TITLE
storefront: next/link for internal policy links (build fix)

### DIFF
--- a/src/app/(routes)/[productId]/product/[slug]/page.tsx
+++ b/src/app/(routes)/[productId]/product/[slug]/page.tsx
@@ -32,6 +32,7 @@
 
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
+import Link from "next/link";
 import {
   fetchStructuredData,
   toProductView,
@@ -202,36 +203,36 @@ export default async function ProductPage({ params }: PageProps) {
 
           {/* Buy / view CTA → the interactive product page (cart + checkout).
               Never links back to this same canonical URL (a review dead-end). */}
-          <a
+          <Link
             href={purchaseUrl}
             className="inline-flex items-center justify-center rounded-lg bg-mint-500 hover:bg-mint-400 transition-colors px-6 py-3 text-base font-semibold text-black w-full md:w-auto"
           >
             {view.inStock ? "Buy now" : "View product"}
-          </a>
+          </Link>
 
           {/* Trust affordances a reviewer sees on the feed landing page. */}
           <p className="text-xs text-ink-faint">
             Secure checkout · {POLICY.returnWindowDays}-day{" "}
-            <a
+            <Link
               href="/returns-policy"
               className="text-mint-500 hover:text-mint-400 transition-colors"
             >
               returns
-            </a>{" "}
+            </Link>{" "}
             ·{" "}
-            <a
+            <Link
               href="/shipping-policy"
               className="text-mint-500 hover:text-mint-400 transition-colors"
             >
               shipping info
-            </a>{" "}
+            </Link>{" "}
             ·{" "}
-            <a
+            <Link
               href="/contact"
               className="text-mint-500 hover:text-mint-400 transition-colors"
             >
               contact
-            </a>
+            </Link>
           </p>
 
           {view.sku && (

--- a/src/app/(routes)/about/page.tsx
+++ b/src/app/(routes)/about/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import LegalPage, { LegalSection } from "@/components/core/legal/LegalPage";
 import { SITE } from "@/lib/site";
 
@@ -33,12 +34,12 @@ export default function AboutPage() {
         <p>
           We stand behind transparent pricing, accurate product information, a
           clear{" "}
-          <a
+          <Link
             href="/returns-policy"
             className="text-mint-500 transition-colors hover:text-mint-400"
           >
             returns &amp; refunds policy
-          </a>
+          </Link>
           , and responsive support. If anything about your order isn&apos;t
           right, our team will make it right.
         </p>

--- a/src/app/(routes)/terms/page.tsx
+++ b/src/app/(routes)/terms/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import LegalPage, { LegalSection } from "@/components/core/legal/LegalPage";
 import { SITE } from "@/lib/site";
 
@@ -46,12 +47,12 @@ export default function TermsPage() {
       <LegalSection heading="Returns & Refunds">
         <p>
           Returns and refunds are governed by our{" "}
-          <a
+          <Link
             href="/returns-policy"
             className="text-mint-500 transition-colors hover:text-mint-400"
           >
             Returns &amp; Refunds policy
-          </a>
+          </Link>
           , which forms part of these terms.
         </p>
       </LegalSection>


### PR DESCRIPTION
Follow-up to #128. The production build fails ESLint `@next/next/no-html-link-for-pages` because the policy-page links were added as `<a>` elements pointing at internal routes. Converts them to `next/link` `<Link>` (external `mailto:`/`https://` links unchanged).

Verified: local `next build` exits 0; all six policy routes prerender static. Unblocks the dev→main deploy.

Addresses task #30 (GMC Misrepresentation storefront trust surface).