### PR TITLE
storefront identity: sharpen value-prop copy + show business address (GMC consistency)

### DIFF
--- a/src/app/(routes)/contact/page.tsx
+++ b/src/app/(routes)/contact/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import LegalPage, { LegalSection } from "@/components/core/legal/LegalPage";
-import { SITE, SOCIAL_LINKS } from "@/lib/site";
+import { SITE, SITE_ADDRESS_LINE, SOCIAL_LINKS } from "@/lib/site";
 
 export const metadata: Metadata = {
   title: "Contact Us | droplinked",
@@ -35,6 +35,7 @@ export default function ContactPage() {
         <p>
           <strong>{SITE.legalName}</strong>
           <br />
+          <span className="block">{SITE_ADDRESS_LINE}</span>
           {SITE.tagline}
           <br />
           Website:{" "}

--- a/src/components/core/footer/footer.tsx
+++ b/src/components/core/footer/footer.tsx
@@ -1,7 +1,7 @@
 import AppIcons from "@/assets/AppIcons";
 import droplinked from "@/assets/icons/droplinked.png";
 import { AppSeparator, AppTypography } from "@/components/ui";
-import { COMPANY_LINKS, POLICY, POLICY_LINKS, SITE, SOCIAL_LINKS } from "@/lib/site";
+import { COMPANY_LINKS, POLICY, POLICY_LINKS, SITE, SITE_ADDRESS_LINE, SOCIAL_LINKS } from "@/lib/site";
 import Image from "next/image";
 import Link from "next/link";
 import React from "react";
@@ -44,6 +44,9 @@ const Footer = () => {
             >
               {SITE.supportEmail}
             </a>
+            <address className="text-sm not-italic text-foreground/70">
+              {SITE_ADDRESS_LINE}
+            </address>
           </div>
           <ul className="flex list-none items-center gap-6">
             <li>

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -31,9 +31,24 @@ export const SITE = {
     "checkout and payment providers you already trust.",
   /** Primary customer support channel. */
   supportEmail: "support@droplinked.com",
+  /**
+   * Registered business address of the platform (business of record).
+   * MUST match the address configured in Merchant Center → Business info so
+   * the storefront the reviewer visits shows the same identity Google holds.
+   */
+  address: {
+    line1: "555 West 5th St",
+    city: "Los Angeles",
+    region: "California",
+    postalCode: "90013",
+    country: "United States",
+  },
   /** Corporate marketing site. */
   homepage: "https://droplinked.com",
 } as const;
+
+/** One-line, human-readable rendering of {@link SITE.address}. */
+export const SITE_ADDRESS_LINE = `${SITE.address.line1}, ${SITE.address.city}, ${SITE.address.region} ${SITE.address.postalCode}, ${SITE.address.country}`;
 
 /** Verified, absolute social profile URLs (no protocol-less / dead hrefs). */
 export const SOCIAL_LINKS = {

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -25,9 +25,10 @@ export const SITE = {
   /** One-line description of what the platform is (no placeholder copy). */
   tagline: "Powering the next generation of commerce.",
   description:
-    "droplinked is a commerce platform that lets creators and brands sell " +
-    "physical and digital products with secure checkout, transparent " +
-    "pricing, and verifiable product data.",
+    "droplinked is the commerce platform for modern brands and retailers — " +
+    "sell physical and digital products, reach new customers across AI " +
+    "shopping agents and affiliate networks, and get paid through the " +
+    "checkout and payment providers you already trust.",
   /** Primary customer support channel. */
   supportEmail: "support@droplinked.com",
   /** Corporate marketing site. */


### PR DESCRIPTION
## Closes / addresses

Two operator requests on the storefront identity/trust surface:
1. Footer copy "comes off strange" — make it commercially appealing to brands/retailers.
2. Merchant Center Misrepresentation review (account 5814803688): the storefront must show the **same** business identity Google holds in Business info.

## Changes

**1. Value-prop copy (footer + /about)** — `SITE.description`

Was passive and jargon-heavy ("lets creators and brands sell … verifiable product data"). Now leads with the commercial value to brands/retailers: multi-channel reach (AI shopping agents + affiliate networks) and getting paid through the checkout/PSP they already use.

**2. Registered business address on the storefront** — `SITE.address` + `SITE_ADDRESS_LINE`

Merchant Center lists the platform's registered address (555 West 5th St, Los Angeles, CA 90013), but a live cross-check found it showed **nowhere** on the storefront (contact, returns, product pages). A Misrepresentation reviewer cross-checks the GMC address against the site. This adds it (single source of truth) to:
- the site-wide **footer** Contact block (semantic `<address>`), and
- the **/contact** page Business Details section.

## Why safe / honest

- Copy is accurate to the product; no invented claims.
- Address is the **same** one already registered in Merchant Center — publishing it on-site removes an inconsistency, adds no new claim.
- No fake reviews/ratings anywhere.

## Scope

Copy + identity constants in `src/lib/site.ts`, rendered by `footer.tsx` and `contact/page.tsx`. No behavior/route/dependency changes. `tsc` clean on all touched files (pre-existing `.png` module artifacts unrelated).

## Sequencing

feature → base `dev` → CI → GTFU dev→main.