### PR TITLE
feat(identity): add customer-service phone to storefront

### DIFF
--- a/src/app/(routes)/contact/page.tsx
+++ b/src/app/(routes)/contact/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import LegalPage, { LegalSection } from "@/components/core/legal/LegalPage";
-import { SITE, SITE_ADDRESS_LINE, SOCIAL_LINKS } from "@/lib/site";
+import { SITE, SITE_ADDRESS_LINE, SITE_PHONE_TEL, SOCIAL_LINKS } from "@/lib/site";
 
 export const metadata: Metadata = {
   title: "Contact Us | droplinked",
@@ -25,6 +25,13 @@ export default function ContactPage() {
             className="text-mint-500 transition-colors hover:text-mint-400"
           >
             {SITE.supportEmail}
+          </a>{" "}
+          or call{" "}
+          <a
+            href={SITE_PHONE_TEL}
+            className="text-mint-500 transition-colors hover:text-mint-400"
+          >
+            {SITE.supportPhone}
           </a>
           . We aim to respond within 1–2 business days. Please include your
           order number so we can help you faster.

--- a/src/components/core/footer/footer.tsx
+++ b/src/components/core/footer/footer.tsx
@@ -1,7 +1,7 @@
 import AppIcons from "@/assets/AppIcons";
 import droplinked from "@/assets/icons/droplinked.png";
 import { AppSeparator, AppTypography } from "@/components/ui";
-import { COMPANY_LINKS, POLICY, POLICY_LINKS, SITE, SITE_ADDRESS_LINE, SOCIAL_LINKS } from "@/lib/site";
+import { COMPANY_LINKS, POLICY, POLICY_LINKS, SITE, SITE_ADDRESS_LINE, SITE_PHONE_TEL, SOCIAL_LINKS } from "@/lib/site";
 import Image from "next/image";
 import Link from "next/link";
 import React from "react";
@@ -43,6 +43,12 @@ const Footer = () => {
               className="text-sm text-foreground/70 hover:text-foreground transition-colors"
             >
               {SITE.supportEmail}
+            </a>
+            <a
+              href={SITE_PHONE_TEL}
+              className="text-sm text-foreground/70 hover:text-foreground transition-colors"
+            >
+              {SITE.supportPhone}
             </a>
             <address className="text-sm not-italic text-foreground/70">
               {SITE_ADDRESS_LINE}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -31,6 +31,8 @@ export const SITE = {
     "checkout and payment providers you already trust.",
   /** Primary customer support channel. */
   supportEmail: "support@droplinked.com",
+  /** Customer-service phone (matches Merchant Center → Business info contact). */
+  supportPhone: "+1 (929) 266-7624",
   /**
    * Registered business address of the platform (business of record).
    * MUST match the address configured in Merchant Center → Business info so
@@ -49,6 +51,9 @@ export const SITE = {
 
 /** One-line, human-readable rendering of {@link SITE.address}. */
 export const SITE_ADDRESS_LINE = `${SITE.address.line1}, ${SITE.address.city}, ${SITE.address.region} ${SITE.address.postalCode}, ${SITE.address.country}`;
+
+/** `tel:` href derived from {@link SITE.supportPhone} (digits + leading +). */
+export const SITE_PHONE_TEL = `tel:${SITE.supportPhone.replace(/[^+\d]/g, "")}`;
 
 /** Verified, absolute social profile URLs (no protocol-less / dead hrefs). */
 export const SOCIAL_LINKS = {


### PR DESCRIPTION
## Closes / addresses

Merchant Center Misrepresentation review (account 5814803688), Jul-10 window. A findable customer-service phone is a named Misrepresentation trust signal + a Google Business Profile requirement.

## Change

Adds `SITE.supportPhone` = `+1 (929) 266-7624` (operator-provided) as a `tel:` link in:
- the site-wide **footer** contact block, and
- the **/contact** page Customer Support section.

Derived `SITE_PHONE_TEL` normalises to `tel:+19292667624`. Matches the phone to be configured in Merchant Center → Business info so site ↔ GMC contact is consistent.

## Scope

Copy/identity constants only (`src/lib/site.ts` + footer + contact). `tsc` clean on touched files. No behavior change.

## Sequencing

feature → base `dev` → CI → GTFU dev→main.