### PR TITLE
feat(marketplace): consumer-grade SSR PDP for curated external affiliate products

### DIFF
--- a/src/app/(routes)/marketplace/[advertiserId]/[itemId]/[slug]/lib/marketplace-data.ts
+++ b/src/app/(routes)/marketplace/[advertiserId]/[itemId]/[slug]/lib/marketplace-data.ts
@@ -1,0 +1,274 @@
+/**
+ * marketplace-data.ts
+ *
+ * SSR data source for the on-domain affiliate/marketplace PDP served at
+ *   shop.droplinked.com/marketplace/<advertiserId>/<itemId>/<slug>
+ *
+ * Fetches the curated read-model from apiv3 (already live, @Public, no auth):
+ *   GET {APIV3}/v2/marketplace/:advertiserId/:itemId  →  MarketplacePdpDto
+ *
+ * BE dependency (droplinked-backend):
+ *   src/modules/marketplace-pdp/controllers/marketplace-pdp.controller.ts
+ *   src/modules/marketplace-pdp/services/marketplace-pdp.service.ts
+ *
+ * These are EXTERNAL Impact-catalogue products: droplinked curates + hosts the
+ * indexable product page, and the shopper completes the purchase at the retailer
+ * (the attributed `/r` click-out). The page is honest about that — it is NOT a
+ * disguised doorway.
+ *
+ * QUALITY GATE (anti-spam): the endpoint may return a thin row. We render ONLY
+ * items that clear the SAME indexability floor the backend / sitemap use
+ * (`marketplacePdpIsIndexable`): non-empty title, ≥1 image, a real positive
+ * price, and a description that is more than boilerplate. Anything below the
+ * floor → null → the page calls `notFound()` (a real 404, never a shell), so a
+ * crawler never indexes a thin marketplace page.
+ *
+ * If the endpoint 404s / 5xx / returns an unrecognised payload, the fetch
+ * returns null and the page falls through to `notFound()` — fully 5xx-safe,
+ * mirroring the sibling product page's structured-data loader.
+ */
+
+import { SITE, SITE_URL } from "@/lib/site";
+
+/** apiv3 base — overridable for dev/preview; defaults to the prod API host. */
+const APIV3_BASE = (
+  process.env.APIV3_BASE_URL || "https://apiv3.droplinked.com"
+).replace(/\/+$/, "");
+
+/** Mirrors the backend indexability floor (marketplace-indexable.util.ts). */
+const MIN_DESCRIPTION_LENGTH = 50;
+const MIN_DESCRIPTION_WORDS = 8;
+
+// ---- shape of the apiv3 MarketplacePdpDto ----
+
+export type MarketplaceAvailability = "InStock" | "OutOfStock";
+
+export interface MarketplacePdpDto {
+  advertiserId: string;
+  itemId: string;
+  title: string;
+  description: string;
+  images: string[];
+  priceMinor: number | null;
+  currency: string;
+  availability: MarketplaceAvailability;
+  brand: string;
+  retailerName: string;
+  category: string;
+  sku?: string;
+  gtin?: string;
+  canonicalUrl: string | null;
+  buyUrl: string | null;
+}
+
+/** View model the page renders visible HTML from (all display-ready strings). */
+export interface MarketplaceView {
+  advertiserId: string;
+  itemId: string;
+  title: string;
+  description: string;
+  images: string[];
+  /** Display price string, e.g. "89.00". Empty only for a non-renderable row. */
+  price: string;
+  priceCurrency: string;
+  inStock: boolean;
+  availabilityLabel: string;
+  brandName: string;
+  retailerName: string;
+  category: string;
+  sku: string;
+  gtin: string;
+  /** Self-referencing canonical (== the sitemap <loc>, on the served host). */
+  canonicalUrl: string;
+  /** Attributed BUY click-out (the retailer, via /r). Empty if unbuildable. */
+  buyUrl: string;
+}
+
+// ---- validators / helpers ----
+
+function asStringArray(v: unknown): string[] {
+  if (typeof v === "string") return v.trim() ? [v] : [];
+  if (Array.isArray(v))
+    return v.filter((x): x is string => typeof x === "string" && x.trim().length > 0);
+  return [];
+}
+
+function isMarketplacePdpDto(v: unknown): v is MarketplacePdpDto {
+  if (!v || typeof v !== "object") return false;
+  const d = v as Record<string, unknown>;
+  return (
+    typeof d.advertiserId === "string" &&
+    typeof d.itemId === "string" &&
+    typeof d.title === "string"
+  );
+}
+
+/**
+ * The SAME quality floor the backend `marketplacePdpIsIndexable` enforces, so a
+ * page renders iff the item is index-eligible. Below the floor ⇒ notFound().
+ */
+export function isRenderable(dto: MarketplacePdpDto): boolean {
+  const title = (dto.title ?? "").trim();
+  if (title.length === 0) return false;
+
+  const images = asStringArray(dto.images);
+  if (images.length === 0) return false;
+
+  if (
+    dto.priceMinor === null ||
+    dto.priceMinor === undefined ||
+    !Number.isFinite(dto.priceMinor) ||
+    dto.priceMinor <= 0
+  ) {
+    return false;
+  }
+
+  const description = (dto.description ?? "").trim();
+  if (description.length < MIN_DESCRIPTION_LENGTH) return false;
+  const words = description.split(/\s+/).filter((w) => w.length > 0);
+  if (words.length < MIN_DESCRIPTION_WORDS) return false;
+
+  // Description must add info beyond the title (not a verbatim echo).
+  const normDesc = description.toLowerCase();
+  const normTitle = title.toLowerCase();
+  if (normDesc === normTitle) return false;
+  if (normDesc.replace(/[\s.,;:!?-]+$/g, "") === normTitle) return false;
+
+  return true;
+}
+
+/** Build the self-referencing canonical on the SERVED host — equals the sitemap
+ *  <loc> (same shape the backend builder emits). Prefers the DTO's own canonical
+ *  (already host-normalised by the backend); reconstructs from the served host
+ *  only as a fallback so the page is never without a canonical. */
+export function resolveCanonicalUrl(
+  dto: MarketplacePdpDto,
+  advertiserId: string,
+  itemId: string,
+  slug: string
+): string {
+  const fromDto = (dto.canonicalUrl ?? "").trim();
+  if (fromDto.startsWith(`${SITE_URL}/marketplace/`)) return fromDto;
+  const tail = slug ? `/${encodeURIComponent(slug)}` : "";
+  return `${SITE_URL}/marketplace/${encodeURIComponent(
+    advertiserId
+  )}/${encodeURIComponent(itemId)}${tail}`;
+}
+
+/** Integer minor units → "89.00" (fixed 2dp). Empty when no usable price. */
+function formatPrice(priceMinor: number | null): string {
+  if (priceMinor === null || priceMinor === undefined) return "";
+  if (!Number.isFinite(priceMinor)) return "";
+  return (priceMinor / 100).toFixed(2);
+}
+
+/** Map a validated DTO → the page view model. */
+export function toMarketplaceView(
+  dto: MarketplacePdpDto,
+  advertiserId: string,
+  itemId: string,
+  slug: string
+): MarketplaceView {
+  const inStock = dto.availability === "InStock";
+  return {
+    advertiserId: dto.advertiserId,
+    itemId: dto.itemId,
+    title: dto.title.trim(),
+    description: (dto.description ?? "").trim(),
+    images: asStringArray(dto.images),
+    price: formatPrice(dto.priceMinor),
+    priceCurrency: (dto.currency || "USD").toUpperCase(),
+    inStock,
+    availabilityLabel: inStock ? "In stock" : "Out of stock",
+    brandName: (dto.brand ?? "").trim(),
+    retailerName: (dto.retailerName ?? "").trim() || "the retailer",
+    category: (dto.category ?? "").trim(),
+    sku: (dto.sku ?? "").trim(),
+    gtin: (dto.gtin ?? "").trim(),
+    canonicalUrl: resolveCanonicalUrl(dto, advertiserId, itemId, slug),
+    buyUrl: (dto.buyUrl ?? "").trim(),
+  };
+}
+
+/**
+ * schema.org Product + Offer JSON-LD for the marketplace PDP. Seller is the
+ * RETAILER (honest — the retailer is the seller of record); `url` is the
+ * self-referencing canonical. Only-present fields are emitted (no empty keys).
+ */
+export function buildMarketplaceJsonLd(view: MarketplaceView): Record<string, unknown> {
+  const availability = view.inStock
+    ? "https://schema.org/InStock"
+    : "https://schema.org/OutOfStock";
+
+  const jsonLd: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    "@id": `${view.canonicalUrl}#product`,
+    name: view.title,
+    description: view.description,
+    url: view.canonicalUrl,
+  };
+  if (view.images.length > 0) jsonLd.image = view.images;
+  if (view.sku) jsonLd.sku = view.sku;
+  if (view.gtin) jsonLd.gtin = view.gtin;
+  if (view.brandName)
+    jsonLd.brand = { "@type": "Brand", name: view.brandName };
+  if (view.category) jsonLd.category = view.category;
+
+  const offers: Record<string, unknown> = {
+    "@type": "Offer",
+    priceCurrency: view.priceCurrency,
+    availability,
+    url: view.canonicalUrl,
+    seller: { "@type": "Organization", name: view.retailerName },
+  };
+  if (view.price) offers.price = view.price;
+  jsonLd.offers = offers;
+
+  return jsonLd;
+}
+
+/**
+ * Fetch + validate + quality-gate the marketplace item. Returns the view model
+ * (renderable) or null (not-found / 4xx / 5xx / unrecognised / below the quality
+ * floor). Never throws — the page falls through to notFound() on null.
+ *
+ * Server fetch, no auth (@Public endpoint), ISR-cached 5 minutes. Both this and
+ * generateMetadata call it with identical options, so Next dedupes to ONE fetch.
+ */
+export async function fetchMarketplaceItem(
+  advertiserId: string,
+  itemId: string,
+  slug: string
+): Promise<MarketplaceView | null> {
+  const url = `${APIV3_BASE}/v2/marketplace/${encodeURIComponent(
+    advertiserId
+  )}/${encodeURIComponent(itemId)}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      next: { revalidate: 300 },
+      headers: {
+        Accept: "application/json",
+        "User-Agent": `${SITE.name}-shopfront/1.0 (marketplace-pdp)`,
+      },
+    });
+  } catch {
+    return null; // network error → not-found, never throw
+  }
+
+  if (!response.ok) return null; // 404 = unknown/gated; 5xx = backend down
+
+  let raw: unknown;
+  try {
+    raw = await response.json();
+  } catch {
+    return null;
+  }
+
+  if (!isMarketplacePdpDto(raw)) return null;
+  if (!isRenderable(raw)) return null; // anti-spam quality floor
+
+  return toMarketplaceView(raw, advertiserId, itemId, slug);
+}

--- a/src/app/(routes)/marketplace/[advertiserId]/[itemId]/[slug]/page.tsx
+++ b/src/app/(routes)/marketplace/[advertiserId]/[itemId]/[slug]/page.tsx
@@ -1,0 +1,279 @@
+/**
+ * /marketplace/<advertiserId>/<itemId>/<slug> — on-domain SSR PDP for a curated
+ * EXTERNAL (Impact affiliate) product.
+ *
+ * WHY THIS ROUTE EXISTS: apiv3 emits a canonical URL, a marketplace sitemap, and
+ * agentic `canonicalUrl`s all pointing at `shop.droplinked.com/marketplace/...`,
+ * but no storefront route rendered them — so those links resolved to a blank
+ * shell (the thin-doorway / affiliate-spam signal). This route server-renders a
+ * real, trustworthy product page for each curated item so crawlers, shopping
+ * agents, and shoppers all see genuine product content at the canonical URL.
+ *
+ * HONEST BY DESIGN (not a disguised doorway): droplinked curates + hosts the
+ * page; the shopper completes the purchase at the retailer via a disclosed,
+ * attributed "Buy at {retailer}" click-out (`rel="sponsored nofollow"`,
+ * `target="_blank"`). The page states this plainly.
+ *
+ * ROUTE PLACEMENT: `marketplace` is a STATIC first segment, so it coexists with
+ * the sibling dynamic `[productId]` route (Next.js resolves the static segment
+ * first) — no slug-name collision.
+ *
+ * QUALITY GATE: `fetchMarketplaceItem` returns null for a not-found / gated /
+ * 5xx / thin item (same indexability floor as the backend + sitemap), and this
+ * page then calls `notFound()` — a real 404, never a shell.
+ *
+ * Data source (apiv3, @Public, no auth):
+ *   GET /v2/marketplace/:advertiserId/:itemId
+ * ISR: revalidate every 5 minutes. Fully 5xx-safe (notFound() on null).
+ */
+
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SITE } from "@/lib/site";
+import {
+  buildMarketplaceJsonLd,
+  fetchMarketplaceItem,
+  type MarketplaceView,
+} from "./lib/marketplace-data";
+
+// ISR — revalidate every 5 minutes (matches the sibling product page).
+export const revalidate = 300;
+
+interface PageProps {
+  params: Promise<{ advertiserId: string; itemId: string; slug: string }>;
+}
+
+// ---- metadata ----
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { advertiserId, itemId, slug } = await params;
+  const view = await fetchMarketplaceItem(advertiserId, itemId, slug);
+
+  if (!view) {
+    return { title: "Product not found | droplinked" };
+  }
+
+  const soldBy = view.retailerName ? ` — ${view.retailerName}` : "";
+  const title = `${view.title}${soldBy} | droplinked`;
+  const description = metaDescription(view);
+  const ogImage = view.images[0];
+
+  return {
+    title,
+    description,
+    // Self-referencing canonical == the marketplace canonical == sitemap <loc>.
+    alternates: { canonical: view.canonicalUrl },
+    openGraph: {
+      type: "website",
+      url: view.canonicalUrl,
+      title,
+      description,
+      siteName: SITE.name,
+      images: ogImage ? [{ url: ogImage, alt: view.title }] : [],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: ogImage ? [ogImage] : [],
+    },
+    robots: { index: true, follow: true },
+  };
+}
+
+/** Clean, ~160-char meta description from the sanitized product copy. */
+function metaDescription(view: MarketplaceView): string {
+  const base =
+    view.description ||
+    `${view.title}${view.brandName ? ` by ${view.brandName}` : ""}.`;
+  const trimmed = base.length > 157 ? `${base.slice(0, 157).trimEnd()}…` : base;
+  return trimmed;
+}
+
+// ---- page ----
+
+export default async function MarketplaceProductPage({ params }: PageProps) {
+  const { advertiserId, itemId, slug } = await params;
+  const view = await fetchMarketplaceItem(advertiserId, itemId, slug);
+
+  if (!view) {
+    notFound();
+  }
+
+  const heroImage = view.images[0];
+  const galleryImages = view.images.slice(1, 5);
+  const priceLabel = view.price
+    ? `${view.price} ${view.priceCurrency}`
+    : "Price unavailable";
+  const jsonLd = buildMarketplaceJsonLd(view);
+
+  return (
+    <>
+      {/* Product + Offer JSON-LD — what Googlebot / shopping agents read. */}
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+
+      <main className="container mx-auto px-6 md:px-8 py-8 md:py-12 max-w-6xl">
+        {/* ── breadcrumb (internal — not an orphan doorway) ── */}
+        <nav
+          aria-label="Breadcrumb"
+          className="mb-8 text-sm text-ink-faint flex flex-wrap items-center gap-2"
+        >
+          <Link href="/" className="hover:text-mint-500 transition-colors">
+            droplinked
+          </Link>
+          <span aria-hidden>/</span>
+          <span className="text-ink-faint">Marketplace</span>
+          {view.category && (
+            <>
+              <span aria-hidden>/</span>
+              <span className="capitalize text-ink-faint">{view.category}</span>
+            </>
+          )}
+          <span aria-hidden>/</span>
+          <span className="text-ink-muted line-clamp-1">{view.title}</span>
+        </nav>
+
+        <div className="flex flex-col md:flex-row items-start gap-10">
+          {/* ── media column ── */}
+          <div className="w-full md:w-1/2">
+            {heroImage ? (
+              // Plain <img> (not next/image): product images come from many
+              // remote hosts; a plain tag always server-renders and never 500s
+              // on an unconfigured image host — what the crawler must see.
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={heroImage}
+                alt={view.title}
+                width={800}
+                height={800}
+                className="w-full h-auto rounded-lg object-cover bg-surface-1"
+                loading="eager"
+              />
+            ) : (
+              <div className="w-full aspect-square rounded-lg bg-surface-1" />
+            )}
+
+            {galleryImages.length > 0 && (
+              <div className="mt-4 grid grid-cols-4 gap-3">
+                {galleryImages.map((img, i) => (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    key={img + i}
+                    src={img}
+                    alt={`${view.title} — view ${i + 2}`}
+                    width={160}
+                    height={160}
+                    className="w-full h-auto rounded-md object-cover bg-surface-1"
+                    loading="lazy"
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* ── details column ── */}
+          <div className="w-full md:w-1/2 flex flex-col gap-5">
+            <p className="text-sm uppercase tracking-wide text-ink-faint">
+              Sold by {view.retailerName}
+            </p>
+
+            <h1 className="text-3xl md:text-4xl font-semibold text-ink leading-tight">
+              {view.title}
+            </h1>
+
+            <div className="flex items-center gap-4">
+              <span
+                className="text-2xl font-bold text-ink"
+                data-testid="marketplace-price"
+              >
+                {priceLabel}
+              </span>
+              <span
+                className={
+                  view.inStock
+                    ? "text-sm font-medium text-emerald-600"
+                    : "text-sm font-medium text-error-500"
+                }
+                data-testid="marketplace-availability"
+              >
+                {view.availabilityLabel}
+              </span>
+            </div>
+
+            {view.description && (
+              <p className="text-base leading-relaxed text-ink-muted whitespace-pre-line">
+                {view.description}
+              </p>
+            )}
+
+            {/* Primary CTA — attributed, disclosed click-out to the retailer. */}
+            {view.buyUrl && (
+              <a
+                href={view.buyUrl}
+                rel="sponsored nofollow"
+                target="_blank"
+                data-testid="marketplace-buy-cta"
+                className="inline-flex items-center justify-center rounded-lg bg-mint-500 hover:bg-mint-400 transition-colors px-6 py-3 text-base font-semibold text-black w-full md:w-auto"
+              >
+                Buy at {view.retailerName} &rarr;
+              </a>
+            )}
+
+            {/* Honest disclosure — curated here, purchased at the retailer. */}
+            <p className="text-sm text-ink-faint leading-relaxed">
+              droplinked curates this product from{" "}
+              <span className="text-ink-muted">{view.retailerName}</span>. You&apos;ll
+              complete your purchase securely on {view.retailerName}&apos;s site, and
+              it is fulfilled and shipped by {view.retailerName} under their own
+              shipping &amp; returns policies. droplinked may earn a commission.
+            </p>
+
+            {(view.sku || view.gtin || view.category) && (
+              <dl className="text-xs text-ink-faint flex flex-col gap-1 border-t border-line pt-4">
+                {view.category && (
+                  <div className="flex gap-2">
+                    <dt className="text-ink-faint">Category</dt>
+                    <dd className="capitalize text-ink-muted">{view.category}</dd>
+                  </div>
+                )}
+                {view.sku && (
+                  <div className="flex gap-2">
+                    <dt className="text-ink-faint">SKU</dt>
+                    <dd className="text-ink-muted">{view.sku}</dd>
+                  </div>
+                )}
+                {view.gtin && (
+                  <div className="flex gap-2">
+                    <dt className="text-ink-faint">GTIN</dt>
+                    <dd className="text-ink-muted">{view.gtin}</dd>
+                  </div>
+                )}
+              </dl>
+            )}
+
+            {/* Trust row + internal links back into the storefront. */}
+            <p className="text-xs text-ink-faint mt-1">
+              Curated on{" "}
+              <Link href="/" className="text-mint-500 hover:text-mint-400 transition-colors">
+                droplinked
+              </Link>{" "}
+              ·{" "}
+              <Link href="/about" className="text-mint-500 hover:text-mint-400 transition-colors">
+                About
+              </Link>{" "}
+              ·{" "}
+              <Link href="/contact" className="text-mint-500 hover:text-mint-400 transition-colors">
+                Contact
+              </Link>
+            </p>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Why
apiv3 emits a canonical URL, a marketplace sitemap (~673 URLs), and agentic `findInventory`/`getProductDetail` `canonicalUrl`s all pointing at `shop.droplinked.com/marketplace/{adv}/{item}/{slug}` — but **no storefront route rendered them**, so every one resolved to a blank SPA shell. Canonical/sitemap/agent links pointing at a non-rendering page is exactly the **thin-doorway / affiliate-spam** signal that makes crawlers and feeds distrust the corpus. This PR adds the missing route so each curated item renders a real, trustworthy product page at its canonical URL.

## What
New SSR route `src/app/(routes)/marketplace/[advertiserId]/[itemId]/[slug]/page.tsx` (+ `lib/marketplace-data.ts`). `marketplace` is a **static** first segment, so it coexists with the sibling dynamic `[productId]` route (no slug-name collision).

- Server-fetches apiv3 `GET /v2/marketplace/:advertiserId/:itemId` (@Public, ISR 5 min). Not-found / gated / 5xx / **thin** item → `notFound()` — a real 404, never a shell. The FE re-applies the SAME indexability floor the backend + sitemap use, so a thin page is never rendered or indexed.
- Clean, consumer-grade layout reusing the storefront design tokens (matches the shipped GMC `[productId]/product/[slug]` page): image gallery, "Sold by {retailer}" eyebrow, title, price + availability, sanitized description, category breadcrumb.
- Prominent, **disclosed** "Buy at {retailer}" CTA → the attributed `buyUrl` with `rel="sponsored nofollow"` + `target="_blank"`.
- Honest, not a disguised doorway: states plainly that droplinked curates the page and the purchase completes / ships at the retailer under their policies ("droplinked may earn a commission"); internal links back into the storefront (home / about / contact) so it is not an orphan.
- `generateMetadata`: unique title, clean meta description, og/twitter tags, `robots: index,follow`, and a **self-referencing canonical == the marketplace canonical == the sitemap `<loc>`** (served host `shop.droplinked.com`).
- **Product + Offer JSON-LD** (name, image, description, sku, gtin, brand, category, `offers{price, priceCurrency, availability, url, seller=retailer}`) — mirrors the sibling `structured-data.ts`.

## SSR proof (built app against a local mock of the endpoint)
```
$ curl -s .../marketplace/2873502/810005850704/land-before-tula-mesh-toddler-carrier
<title>Land Before Tula Mesh Toddler Carrier — Baby Tula | droplinked</title>
<link rel="canonical" href="https://shop.droplinked.com/marketplace/2873502/810005850704/land-before-tula-mesh-toddler-carrier"/>
<meta name="robots" content="index, follow"/>
<script type="application/ld+json">{"@context":"https://schema.org","@type":"Product", … "offers":{"@type":"Offer","price":"189.00","priceCurrency":"USD","availability":"https://schema.org/InStock","seller":{"@type":"Organization","name":"Baby Tula"}}}</script>
<h1 …>Land Before Tula Mesh Toddler Carrier</h1>   189.00 USD   In stock
<a href="https://droplinked.io/r/2873502/810005850704?src=marketplace_pdp" rel="sponsored nofollow" target="_blank">Buy at Baby Tula →</a>
```
- HTTP **200** with real content for a valid item; HTTP **404** (never a 200 shell) for unknown/gated/thin items.

## Gates
- ✅ `npm ci && npm run build` passes; route builds as `ƒ (Dynamic) server-rendered on demand`.
- ✅ Internal nav uses `next/link` — ESLint `@next/next/no-html-link-for-pages` clean (no errors on new files).

## Companion
Pairs with **droplinked-backend #2857** (sanitized consumer descriptions + `sku`/`gtin` on the DTO + canonical host = the render host `shop.droplinked.com`).

**Do not merge** — review train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)