### PR TITLE
hotfix(marketplace): professional empty-cart + no-products copy

### DIFF
--- a/src/app/(routes)/home/components/product-browser/components/product-list/ProductList.tsx
+++ b/src/app/(routes)/home/components/product-browser/components/product-list/ProductList.tsx
@@ -81,7 +81,7 @@ const ProductList = () => {
       </InfiniteScroll>
     ) : (
       <AppTypography>
-        Oops, looks like the product doesn&apos;t exist.
+        No products found.
       </AppTypography>
     )
   ) : (

--- a/src/components/core/header/triggers/cart/parts/empty/empty-cart.tsx
+++ b/src/components/core/header/triggers/cart/parts/empty/empty-cart.tsx
@@ -9,9 +9,9 @@ const EmptyCart = () => {
     return (
         <article className={cn(app_vertical, "w-full gap-10 py-6")}>
             <Image src={emptycart} width={144} height={166} alt="Your cart is empty" />
-            <AppTypography appClassName="text-center font-normal">Your cart is emptier than our Monday morning meetings...</AppTypography>
+            <AppTypography appClassName="text-center font-normal">Your cart is empty</AppTypography>
             <Link href={"/"} className={cn(app_link, "text-center text-base font-thin")}>
-                Go back to shopping
+                Continue shopping
             </Link>
         </article>
     );


### PR DESCRIPTION
## Why
Operator flagged jokey placeholder copy on a live marketplace PDP that undercuts platform credibility with merchants/lenders/partners. Hotfix path (copy-only, no logic).

## Changes
- Empty cart: `Your cart is emptier than our Monday morning meetings...` → **`Your cart is empty`**
- Link: `Go back to shopping` → **`Continue shopping`**
- Product list empty: `Oops, looks like the product doesn't exist.` → **`No products found.`**

Swept the repo — these were the only two casual strings.