### PR TITLE
fix(deploy): pin valid platform Stripe pk (ENV_FILE held rolled key)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,11 @@ jobs:
     - name: Create env file
       id: create-env
       run: |
-        echo "${{ secrets.ENV_FILE }}" > .env
+        # Strip any rolled/stale platform Stripe pk from the bundle and pin the valid
+        # one (public Elements key). Sole source so a stale ENV_FILE can't serve
+        # an invalid key again.
+        echo "${{ secrets.ENV_FILE }}" | grep -vE '^NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=' > .env
+        echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_51Odtp1JYpy7bkFtu9G6zuNFyomWtE68JSvne9IEyYI43d7REBoAX98zQdRM7s4UOhpEYb4qcFBlggo0XRB36O9im006NzLBc7e" >> .env
         # --- Sentry release tagging 2026-05-19 ---
         # Source: sentry.server.config.ts:7 + sentry.edge.config.ts:7 read
         # process.env.SENTRY_RELEASE; instrumentation-client.ts:6 reads


### PR DESCRIPTION
`NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` (baked from the ENV_FILE secret bundle) held the rolled pk → Elements 401 on marketplace checkout. Strip it from the bundle + pin the valid public pk as sole source. Rebuilds main.