### PR TITLE
chore(sync): back-sync main→dev — platform Stripe pk pin (#143)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,11 @@ jobs:
     - name: Create env file
       id: create-env
       run: |
-        echo "${{ secrets.ENV_FILE }}" > .env
+        # Strip any rolled/stale platform Stripe pk from the bundle and pin the valid
+        # one (public Elements key). Sole source so a stale ENV_FILE can't serve
+        # an invalid key again.
+        echo "${{ secrets.ENV_FILE }}" | grep -vE '^NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=' > .env
+        echo "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_51Odtp1JYpy7bkFtu9G6zuNFyomWtE68JSvne9IEyYI43d7REBoAX98zQdRM7s4UOhpEYb4qcFBlggo0XRB36O9im006NzLBc7e" >> .env
         # --- Sentry release tagging 2026-05-19 ---
         # Source: sentry.server.config.ts:7 + sentry.edge.config.ts:7 read
         # process.env.SENTRY_RELEASE; instrumentation-client.ts:6 reads


### PR DESCRIPTION
## Back-sync main→dev

Reconciles `dev` with `main` so the dev→main GTFU (#136 Sentry+sharp bumps) is clean.

`main` carried one hotfix stranded off `dev`:
- **#143** `385d54a` — `fix(deploy): pin valid platform Stripe pk (strip rolled key from ENV_FILE)`

This merges `origin/main` into `dev`, bringing #143's `.github/workflows/main.yml` change (the Stripe `pk_live` strip+pin) onto `dev`. Merge is clean (no conflicts); reconciled tree is deterministic in both directions.

### Verification
- `dev` was `diverged` (ahead 1 / behind 1). After this merges, `compare/main...dev .behind_by` → **0**.
- The `pk_live` strip+pin lines are **preserved** in `dev`'s `main.yml` (main's hotfix side kept).
- No source/product behavior change — CI-workflow file only.

Do not squash — this is a reconciling merge; a merge commit keeps `behind_by == 0`.
