### PR TITLE
feat(root): enable SSR aggregate product catalog at the platform root

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -58,6 +58,14 @@ jobs:
         # + deploy correlation.
         echo "SENTRY_RELEASE=${{ github.sha }}" >> .env
         echo "NEXT_PUBLIC_SENTRY_RELEASE=${{ github.sha }}" >> .env
+        # --- Aggregate root catalog: dev/shopdev preview 2026-07-11 ---
+        # Enable the SSR aggregate product catalog at the platform root on the
+        # dev environment only, pointed at the dev API host where the public
+        # marketplace endpoint is deployed. Prod (main.yml) leaves both unset →
+        # ROOT_CATALOG_ENABLED absent = OFF, so the prod root keeps redirecting
+        # to /home until an explicit prod enablement.
+        echo "ROOT_CATALOG_ENABLED=true" >> .env
+        echo "APIV3_BASE_URL=https://apiv3dev.droplinked.com" >> .env
     
     - name: Build, tag, and push image to Amazon ECR
       id: build-image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,12 @@ jobs:
         # + deploy correlation.
         echo "SENTRY_RELEASE=${{ github.sha }}" >> .env
         echo "NEXT_PUBLIC_SENTRY_RELEASE=${{ github.sha }}" >> .env
+        # --- Aggregate root catalog: PROD enablement 2026-07-11 ---
+        # Serve the SSR aggregate product catalog at the platform root (/) on
+        # prod. APIV3_BASE_URL is intentionally left unset so it defaults to the
+        # prod API host. Revert this single line to fall back to the previous
+        # behaviour (root redirects to /home).
+        echo "ROOT_CATALOG_ENABLED=true" >> .env
 
     - name: Build, tag, and push image to Amazon ECR
       id: build-image

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,48 @@
-import { redirect } from 'next/navigation';
+import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+import { ROOT_CATALOG_ENABLED } from "@/lib/variables/variables";
+import { SITE, SITE_URL } from "@/lib/site";
+import { fetchMarketplaceCatalog } from "@/lib/catalog/marketplace-catalog-data";
+import MarketplaceCatalog from "@/components/catalog/MarketplaceCatalog";
 
-export default function RootPage() {
-  redirect('/home');
+// ISR — revalidate every 5 minutes (shared by generateMetadata + the page).
+export const revalidate = 300;
+
+export async function generateMetadata(): Promise<Metadata> {
+  // Flag OFF: the page redirects to /home, so no special metadata is needed.
+  if (!ROOT_CATALOG_ENABLED) return {};
+
+  const canonical = `${SITE_URL}/`;
+  const title = `Shop all products | ${SITE.name}`;
+  const description = SITE.description;
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      type: "website",
+      url: canonical,
+      title,
+      description,
+      siteName: SITE.name,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default async function RootPage() {
+  // Default-OFF on prod: until the catalog flag is enabled for an environment,
+  // the root keeps its existing behaviour (redirect to the single-shop /home).
+  if (!ROOT_CATALOG_ENABLED) {
+    redirect("/home");
+  }
+
+  const catalog = await fetchMarketplaceCatalog({ page: 1, limit: 48, type: "physical" });
+  return <MarketplaceCatalog products={catalog.products} total={catalog.total} />;
 }

--- a/src/components/catalog/MarketplaceCatalog.tsx
+++ b/src/components/catalog/MarketplaceCatalog.tsx
@@ -1,0 +1,89 @@
+/**
+ * MarketplaceCatalog — server-rendered aggregate product grid for the platform
+ * root (shop.droplinked.com/). Products are pre-fetched in page.tsx (SSR) and
+ * passed as props, so there is no client-side data fetch and the full grid is
+ * in the initial HTML (crawlable by GMC / Googlebot without JS execution).
+ *
+ * Each card links to the existing per-shop PDP `/{shopSlug}/product/{slug}`
+ * (the same route the GMC feed g:link points at), so clicking a product enters
+ * the normal per-shop checkout flow with full shop context.
+ *
+ * Uses a plain <img> (not next/image) for product thumbnails so arbitrary
+ * per-shop CDN hosts don't need next.config remotePatterns entries — matching
+ * how the other SSR routes render remote product images.
+ */
+
+import Link from "next/link";
+import type { CatalogProduct } from "@/lib/catalog/marketplace-catalog-data";
+import { SITE } from "@/lib/site";
+
+interface MarketplaceCatalogProps {
+  products: CatalogProduct[];
+  total: number;
+}
+
+export default function MarketplaceCatalog({ products }: MarketplaceCatalogProps) {
+  return (
+    <main className="min-h-[60vh] w-full px-4 py-10 md:px-8 lg:px-12 text-gray-900">
+      <div className="mx-auto max-w-7xl">
+        <header className="mb-8">
+          <h1 className="text-2xl font-semibold md:text-3xl">Shop all products</h1>
+          <p className="mt-2 max-w-2xl text-sm text-gray-600 md:text-base">
+            Discover physical products from brands and retailers across {SITE.name}.
+          </p>
+        </header>
+
+        {products.length === 0 ? (
+          <div className="rounded-lg border border-gray-200 bg-gray-50 py-20 text-center">
+            <p className="text-base font-medium text-gray-700">No products to show yet</p>
+            <p className="mt-1 text-sm text-gray-500">Please check back soon.</p>
+          </div>
+        ) : (
+          <ul
+            className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
+            role="list"
+          >
+            {products.map((product) => (
+              <li key={product.id} className="group">
+                <Link
+                  href={product.href}
+                  className="flex h-full flex-col gap-2 overflow-hidden rounded-lg border border-gray-200 bg-white transition-all duration-200 hover:border-gray-300 hover:shadow-md"
+                  aria-label={product.title}
+                >
+                  <div className="relative aspect-square w-full bg-gray-100">
+                    {product.imageUrl ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={product.imageUrl}
+                        alt={product.title}
+                        loading="lazy"
+                        className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                      />
+                    ) : (
+                      <div className="h-full w-full bg-gray-200" aria-hidden="true" />
+                    )}
+                  </div>
+                  <div className="flex flex-col gap-1 px-3 pb-3">
+                    <span className="line-clamp-2 text-sm font-medium text-gray-900">
+                      {product.title}
+                    </span>
+                    {product.shopName ? (
+                      <span className="line-clamp-1 text-xs text-gray-500">{product.shopName}</span>
+                    ) : null}
+                    <span className="text-sm font-semibold text-gray-900">
+                      $
+                      {product.price.toLocaleString("en-US", {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}
+                    </span>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/components/catalog/MarketplaceCatalog.tsx
+++ b/src/components/catalog/MarketplaceCatalog.tsx
@@ -29,7 +29,7 @@ export default function MarketplaceCatalog({ products }: MarketplaceCatalogProps
         <header className="mb-8">
           <h1 className="text-2xl font-semibold md:text-3xl">Shop all products</h1>
           <p className="mt-2 max-w-2xl text-sm text-gray-600 md:text-base">
-            Discover physical products from brands and retailers across {SITE.name}.
+            Discover products from brands and retailers on {SITE.name}.
           </p>
         </header>
 

--- a/src/lib/catalog/marketplace-catalog-data.ts
+++ b/src/lib/catalog/marketplace-catalog-data.ts
@@ -1,0 +1,161 @@
+/**
+ * marketplace-catalog-data.ts
+ *
+ * SSR data source for the aggregate product catalog served at the platform
+ * root (shop.droplinked.com/). Fetches the cross-shop public marketplace grid
+ * from apiv3 (@Public, no auth, no x-shop-id — the identifier-in-path pattern
+ * used by the other SSR routes):
+ *
+ *   GET {APIV3}/product-v2/public/marketplace?page&limit&type  →  PaginationResult<MarketplaceGridProduct>
+ *
+ * BE dependency (droplinked-backend):
+ *   src/modules/product-v2/controllers/product-v2.controller.ts  (@Get('public/marketplace'))
+ *   src/modules/product-v2/repositories/product-v2.repository.ts (getPublicMarketplaceProducts)
+ *
+ * The endpoint already gates OUT non-shoppable shops (disabled/archived/test)
+ * and products (draft/hidden/unpublished), so this loader only shapes the rows
+ * into a render view model and drops any item that can't build a valid card
+ * link. Never throws: on 4xx/5xx/network/unrecognised payload it returns an
+ * empty catalog so the root page still renders (a real page, never a 404), and
+ * the flag can be flipped off if the backend is unavailable.
+ */
+
+import { SITE } from "@/lib/site";
+
+/** apiv3 base — overridable for dev/preview; defaults to the prod API host. */
+const APIV3_BASE = (
+  process.env.APIV3_BASE_URL || "https://apiv3.droplinked.com"
+).replace(/\/+$/, "");
+
+// ---- shape of the apiv3 MarketplaceGridProduct row (subset we consume) ----
+
+interface RawImage {
+  original?: string | null;
+  thumbnail?: string | null;
+  alt?: string | null;
+}
+
+interface RawMarketplaceProduct {
+  id?: string;
+  title?: string;
+  slug?: string | null;
+  thumbnail?: string | null;
+  images?: RawImage[] | null;
+  defaultImageIndex?: number | null;
+  lowestPrice?: number | null;
+  shopSlug?: string | null;
+  shopName?: string | null;
+}
+
+// ---- render view model ----
+
+export interface CatalogProduct {
+  id: string;
+  title: string;
+  /** Same-origin PDP link `/{shopSlug}/product/{productSlug}` (GMC g:link shape). */
+  href: string;
+  imageUrl: string | null;
+  /** Lowest SKU price in major units (dollars) — SkuV2.price is a Float. */
+  price: number;
+  shopName: string;
+}
+
+export interface MarketplaceCatalog {
+  products: CatalogProduct[];
+  total: number;
+}
+
+function resolveImage(p: RawMarketplaceProduct): string | null {
+  if (p.thumbnail) return p.thumbnail;
+  const images = p.images ?? [];
+  if (images.length === 0) return null;
+  const idx =
+    typeof p.defaultImageIndex === "number" &&
+    p.defaultImageIndex >= 0 &&
+    p.defaultImageIndex < images.length
+      ? p.defaultImageIndex
+      : 0;
+  const img = images[idx] || images[0];
+  return img?.thumbnail || img?.original || null;
+}
+
+function toCatalogProduct(p: RawMarketplaceProduct): CatalogProduct | null {
+  const shopSlug = (p.shopSlug || "").trim();
+  const productSlug = (p.slug || "").trim();
+  // Both are required to build a resolvable `/{shop}/product/{slug}` link; the
+  // backend already excludes shops with no slug/url, this guards the edge.
+  if (!shopSlug || !productSlug || !p.id || !p.title) return null;
+  return {
+    id: p.id,
+    title: p.title,
+    href: `/${shopSlug}/product/${productSlug}`,
+    imageUrl: resolveImage(p),
+    price: typeof p.lowestPrice === "number" && p.lowestPrice >= 0 ? p.lowestPrice : 0,
+    shopName: p.shopName || "",
+  };
+}
+
+const EMPTY: MarketplaceCatalog = { products: [], total: 0 };
+
+/**
+ * Fetch + shape the cross-shop marketplace grid. Returns an empty catalog on
+ * any failure (never throws) so the root page renders regardless. Server fetch,
+ * no auth, ISR-cached 5 minutes; generateMetadata + the page share one fetch.
+ */
+export async function fetchMarketplaceCatalog(params?: {
+  page?: number;
+  limit?: number;
+  type?: "physical" | "digital" | "pod";
+}): Promise<MarketplaceCatalog> {
+  const page = params?.page ?? 1;
+  const limit = params?.limit ?? 48;
+  const type = params?.type ?? "physical";
+  const url = `${APIV3_BASE}/product-v2/public/marketplace?page=${page}&limit=${limit}&type=${encodeURIComponent(
+    type,
+  )}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      next: { revalidate: 300 },
+      headers: {
+        Accept: "application/json",
+        "User-Agent": `${SITE.name}-shopfront/1.0 (marketplace-root)`,
+      },
+    });
+  } catch {
+    return EMPTY; // network error → empty catalog, never throw
+  }
+
+  if (!response.ok) return EMPTY;
+
+  let raw: unknown;
+  try {
+    raw = await response.json();
+  } catch {
+    return EMPTY;
+  }
+
+  // product-v2 routes are wrapped by the class-level TransformInterceptor:
+  //   { statusCode, message, data: { data: [...], currentPage, totalDocuments } }
+  // So unwrap the interceptor envelope (when present), then read the inner
+  // PaginationResult. The `!Array.isArray` check keeps this correct even if the
+  // wrapper is ever removed (payload would then be the PaginationResult itself).
+  const outer = raw as { data?: unknown; totalDocuments?: unknown; total?: unknown };
+  const payload =
+    (outer?.data && !Array.isArray(outer.data)
+      ? (outer.data as { data?: unknown; totalDocuments?: unknown; total?: unknown })
+      : outer) ?? {};
+  const rows = Array.isArray(payload.data) ? (payload.data as RawMarketplaceProduct[]) : [];
+  const products = rows
+    .map(toCatalogProduct)
+    .filter((p): p is CatalogProduct => p !== null);
+  const total =
+    typeof payload.totalDocuments === "number"
+      ? payload.totalDocuments
+      : typeof payload.total === "number"
+        ? payload.total
+        : products.length;
+
+  return { products, total };
+}

--- a/src/lib/variables/variables.ts
+++ b/src/lib/variables/variables.ts
@@ -3,6 +3,14 @@ import { roboto } from "@/styles/fonts";
 export const BASE_API_URL = process.env.NEXT_PUBLIC_BASE_API_URL;
 export const API_KEY = process.env.NEXT_PUBLIC_API_KEY;
 export const APP_DEVELOPMENT = process.env.NEXT_PUBLIC_APP_DEVELOPMENT === "true";
+/**
+ * Aggregate product catalog at the platform root (shop.droplinked.com/).
+ * Server-only flag (NOT NEXT_PUBLIC_) so it defaults OFF simply by being absent
+ * from an environment's ENV_FILE. Set ROOT_CATALOG_ENABLED=true in the dev
+ * ENV_FILE (shopdev) for preview; leave it unset on prod until sign-off, then
+ * flip it on via a one-line env change (reversible, no code revert).
+ */
+export const ROOT_CATALOG_ENABLED = process.env.ROOT_CATALOG_ENABLED === "true";
 export const variantIDs = { color: { _id: "62a989ab1f2c2bbc5b1e7153" }, size: { _id: "62a989e21f2c2bbc5b1e7154" } };
 export const app_vertical = "flex flex-col items-center justify-center";
 export const app_center = "flex items-center justify-center";


### PR DESCRIPTION
## Summary
Brings the server-rendered aggregate product catalog (already on `dev`, #147) to `main` and **enables it** at the platform root `/`. The root currently redirects to the single-shop home; this serves a real SSR catalog so the initial HTML contains a populated, crawlable product grid. Each card links to the existing per-shop product page `/{shopSlug}/product/{slug}`, handing off to the normal per-shop checkout.

## Changes
- Catalog code cherry-picked from #147 (server component root + SSR data loader + grid, `generateMetadata`).
- `main.yml`: `ROOT_CATALOG_ENABLED=true` (single line; revert to fall back to the `/home` redirect). API base defaults to the prod API host.
- Subtitle copy: "Discover products from brands and retailers on droplinked."

## QA
Same code verified end-to-end on the dev environment (renders SSR, crawlable, correct per-shop links). `tsc --noEmit` clean. `hotfix/* → main` per source-branch policy. Idempotent read-only SSR GET.