### PR TITLE
fix(root): make root-catalog flag survive to runtime (NEXT_PUBLIC_ inline)

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -64,7 +64,7 @@ jobs:
         # marketplace endpoint is deployed. Prod (main.yml) leaves both unset →
         # ROOT_CATALOG_ENABLED absent = OFF, so the prod root keeps redirecting
         # to /home until an explicit prod enablement.
-        echo "ROOT_CATALOG_ENABLED=true" >> .env
+        echo "NEXT_PUBLIC_ROOT_CATALOG_ENABLED=true" >> .env
         echo "APIV3_BASE_URL=https://apiv3dev.droplinked.com" >> .env
     
     - name: Build, tag, and push image to Amazon ECR

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
         # prod. APIV3_BASE_URL is intentionally left unset so it defaults to the
         # prod API host. Revert this single line to fall back to the previous
         # behaviour (root redirects to /home).
-        echo "ROOT_CATALOG_ENABLED=true" >> .env
+        echo "NEXT_PUBLIC_ROOT_CATALOG_ENABLED=true" >> .env
 
     - name: Build, tag, and push image to Amazon ECR
       id: build-image

--- a/src/lib/variables/variables.ts
+++ b/src/lib/variables/variables.ts
@@ -5,12 +5,14 @@ export const API_KEY = process.env.NEXT_PUBLIC_API_KEY;
 export const APP_DEVELOPMENT = process.env.NEXT_PUBLIC_APP_DEVELOPMENT === "true";
 /**
  * Aggregate product catalog at the platform root (shop.droplinked.com/).
- * Server-only flag (NOT NEXT_PUBLIC_) so it defaults OFF simply by being absent
- * from an environment's ENV_FILE. Set ROOT_CATALOG_ENABLED=true in the dev
- * ENV_FILE (shopdev) for preview; leave it unset on prod until sign-off, then
- * flip it on via a one-line env change (reversible, no code revert).
+ * Uses a NEXT_PUBLIC_ name so Next INLINES the value at build time — the
+ * standalone runner does not carry .env, so a plain (non-public) server var
+ * reads as undefined at runtime and the root would wrongly redirect to /home.
+ * Defaults OFF by being absent from an environment's ENV_FILE; set
+ * NEXT_PUBLIC_ROOT_CATALOG_ENABLED=true to enable (reversible, no code revert).
  */
-export const ROOT_CATALOG_ENABLED = process.env.ROOT_CATALOG_ENABLED === "true";
+export const ROOT_CATALOG_ENABLED =
+  process.env.NEXT_PUBLIC_ROOT_CATALOG_ENABLED === "true";
 export const variantIDs = { color: { _id: "62a989ab1f2c2bbc5b1e7153" }, size: { _id: "62a989e21f2c2bbc5b1e7154" } };
 export const app_vertical = "flex flex-col items-center justify-center";
 export const app_center = "flex items-center justify-center";


### PR DESCRIPTION
## Summary
The aggregate-root catalog flag was a plain (non-public) server env written to `.env` at build. But the `output: standalone` runner doesn't copy `.env`, and the task definition has no such var, so at **runtime** `process.env.ROOT_CATALOG_ENABLED` was `undefined` and the root redirected to `/home` even though the build had it set. (The client-inlined `NEXT_PUBLIC_BASE_API_URL` works precisely because it's `NEXT_PUBLIC_`.)

## Fix
Rename to `NEXT_PUBLIC_ROOT_CATALOG_ENABLED` so Next **inlines the build-time value** into the bundle (same pattern as `NEXT_PUBLIC_APP_DEVELOPMENT`), surviving to runtime. Workflows updated to echo the new name.

## QA
Verified locally: a clean build with the flag set prerenders the catalog (`<title>Shop all products | droplinked</title>`, H1, subtitle), not a `/home` redirect. `tsc` clean.