### PR TITLE
fix(pdp/seo): plain-text description for meta/og/twitter/JSON-LD (GMC quality)

### DIFF
--- a/src/app/(routes)/[productId]/product/[slug]/lib/sanitize-html.ts
+++ b/src/app/(routes)/[productId]/product/[slug]/lib/sanitize-html.ts
@@ -43,3 +43,65 @@ export function sanitizeHtml(input: string | null | undefined): string {
   out = out.replace(JS_URI, "");
   return out.trim();
 }
+
+// Named HTML entities common in imported descriptions (numeric refs handled below).
+const NAMED_ENTITIES: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&apos;": "'",
+  "&nbsp;": " ",
+  "&mdash;": "—",
+  "&ndash;": "–",
+  "&hellip;": "…",
+  "&trade;": "™",
+  "&reg;": "®",
+  "&copy;": "©",
+};
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&#x([0-9a-f]+);/gi, (_m, h) => safeFromCodePoint(parseInt(h, 16)))
+    .replace(/&#(\d+);/g, (_m, d) => safeFromCodePoint(parseInt(d, 10)))
+    .replace(/&[a-z]+;|&#\d+;/gi, (m) => NAMED_ENTITIES[m.toLowerCase()] ?? m);
+}
+
+function safeFromCodePoint(cp: number): string {
+  try {
+    return Number.isFinite(cp) && cp > 0 ? String.fromCodePoint(cp) : "";
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Flatten an HTML description string to clean plain text for crawler-facing
+ * fields (`<meta name="description">`, og/twitter descriptions, JSON-LD
+ * `description`). Those are TEXT fields — leaving HTML markup in them shows up
+ * as literal `<div class="product-description">…` in search/social/GMC and reads
+ * as low-quality/misrepresentation. Strips tags (block tags → spaces so words
+ * don't run together), decodes entities, collapses whitespace, and optionally
+ * truncates on a word boundary with an ellipsis.
+ */
+export function htmlToText(
+  input: string | null | undefined,
+  maxLen?: number,
+): string {
+  if (!input || typeof input !== "string") return "";
+  let out = sanitizeHtml(input);
+  // Block-level boundaries → space so adjacent words don't concatenate.
+  out = out.replace(/<\/(p|div|h[1-6]|li|tr|br|section|article)>/gi, " ");
+  out = out.replace(/<br\s*\/?>/gi, " ");
+  // Drop all remaining tags, decode entities, collapse whitespace.
+  out = out.replace(/<[^>]+>/g, " ");
+  out = decodeEntities(out);
+  out = out.replace(/\s+/g, " ").trim();
+  if (maxLen && out.length > maxLen) {
+    const cut = out.slice(0, maxLen);
+    const lastSpace = cut.lastIndexOf(" ");
+    out = (lastSpace > maxLen * 0.6 ? cut.slice(0, lastSpace) : cut).trim() + "…";
+  }
+  return out;
+}

--- a/src/app/(routes)/[productId]/product/[slug]/page.tsx
+++ b/src/app/(routes)/[productId]/product/[slug]/page.tsx
@@ -38,7 +38,7 @@ import {
   toProductView,
   buildServedUrl,
 } from "./lib/structured-data";
-import { sanitizeHtml } from "./lib/sanitize-html";
+import { sanitizeHtml, htmlToText } from "./lib/sanitize-html";
 import { POLICY } from "@/lib/site";
 import styles from "./description.module.css";
 
@@ -68,8 +68,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const canonicalUrl = buildServedUrl(merchant, slug);
 
   const title = view.name ? `${view.name} | droplinked` : "Product | droplinked";
+  // Meta / og / twitter / JSON-LD descriptions are TEXT fields — the imported
+  // description is HTML, so flatten it to plain text (capped) or the raw markup
+  // leaks into search/social/GMC previews as literal tags.
   const description =
-    view.description ||
+    htmlToText(view.description, 300) ||
     `${view.name}${view.brandName ? ` by ${view.brandName}` : ""} — available on droplinked.`;
   const ogImage = view.images[0];
 
@@ -81,14 +84,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       type: "website",
       url: canonicalUrl,
       title: data.openGraph["og:title"] || title,
-      description: data.openGraph["og:description"] || description,
+      description: htmlToText(data.openGraph["og:description"], 300) || description,
       siteName: data.openGraph["og:site_name"] || "droplinked",
       images: ogImage ? [{ url: ogImage, alt: view.name }] : [],
     },
     twitter: {
       card: "summary_large_image",
       title: data.openGraph["twitter:title"] || title,
-      description: data.openGraph["twitter:description"] || description,
+      description: htmlToText(data.openGraph["twitter:description"], 300) || description,
       images: ogImage ? [ogImage] : [],
     },
     robots: { index: true, follow: true },
@@ -127,7 +130,14 @@ export default async function ProductPage({ params }: PageProps) {
       <script
         type="application/ld+json"
         // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(data.jsonLd) }}
+        dangerouslySetInnerHTML={{
+          // JSON-LD description is a TEXT field — flatten the imported HTML so
+          // GMC/Googlebot reads a clean product description, not raw markup.
+          __html: JSON.stringify({
+            ...data.jsonLd,
+            description: htmlToText(data.jsonLd.description, 5000),
+          }),
+        }}
       />
 
       <main className="container mx-auto px-6 md:px-8 py-12 flex flex-col md:flex-row items-start gap-10 max-w-6xl">


### PR DESCRIPTION
## Problem (confirmed live after #150)
The visible body description now renders as formatted HTML (#150 ✅). But the **crawler-facing** description fields still emit **raw HTML**, verified on the live page source:
- `<meta name="description" content="&lt;div class=&quot;product-description…">`
- `og:description` / `twitter:description` — same escaped HTML
- Schema.org **JSON-LD** `"description":"<div class=\"product-description\"><h3>…"`

These are what **Googlebot / GMC / social** read. Raw markup in a text field is a search/GMC quality + misrepresentation hit (the storefront exists to clear GMC).

## Fix (isolated to the slug route)
- Add `htmlToText()` to the slug's `sanitize-html.ts`: strips tags (block tags → spaces so words don't run together), decodes entities, collapses whitespace, word-boundary truncation.
- Apply to all four sinks in `page.tsx`: meta `description` (cap 300), `og:description` (300), `twitter:description` (300), and JSON-LD `description` (5000).
- The **visible body still renders sanitized HTML** via `sanitizeHtml()` — only text fields are flattened.

Verified output for the reported product: `DIONIES by Dionies Sportswear (US) Dionies is a unique limited edition custom shoe concept… 100% SATISFACTION GUARANTEE Love your shoes or send them back for free.` (clean, 293 chars).

## Scope
SHIPPED — 2 files, slug route only. `tsc` clean for touched files. Base `main` (hotfix; shop.droplinked.com deploys from main). Pairs with #150.

## Closes
Completes the operator-reported 'descriptions not formatted properly across all listings' — body (#150) + crawler/GMC text fields (this PR).