### PR TITLE
fix(pdp): guard interactive product page against missing variant/option/shop data (Buy Now crash)

### DIFF
--- a/src/app/(routes)/[productId]/components/details/ProductDetails.tsx
+++ b/src/app/(routes)/[productId]/components/details/ProductDetails.tsx
@@ -5,7 +5,7 @@ import ProductClient from "./client/ProductClient";
 const ProductDetails = ({ product }: { product: any }) => {
     return (
         <section className="w-full flex flex-col gap-9">
-            <h1 className={cn("text-3xl font-medium", roboto.className)}>{product.title}</h1>
+            <h1 className={cn("text-3xl font-medium", roboto.className)}>{product?.title}</h1>
             <ProductClient product={product} />
         </section>
     );

--- a/src/app/(routes)/[productId]/components/details/client/ProductClient.tsx
+++ b/src/app/(routes)/[productId]/components/details/client/ProductClient.tsx
@@ -28,7 +28,7 @@ const ProductClient = ({ product }: { product: IProduct }) => {
         product: product,
         option: {
           quantity: prev.option.quantity,
-          ...getFirstOption(data?.skuIDs[0]),
+          ...getFirstOption(data?.skuIDs?.[0]),
         },
       })),
     [product]
@@ -38,7 +38,7 @@ const ProductClient = ({ product }: { product: IProduct }) => {
       updateState(
         'sku',
         States?.product?.product_type === 'DIGITAL'
-          ? States?.product?.skuIDs[0]
+          ? States?.product?.skuIDs?.[0]
           : findSkuAsOption({
               color: States.option.color,
               size: States.option.size,

--- a/src/app/(routes)/[productId]/components/details/client/components/ProductSizeSelector.tsx
+++ b/src/app/(routes)/[productId]/components/details/client/components/ProductSizeSelector.tsx
@@ -21,8 +21,8 @@ function ProductSizeSelector() {
 
   const active = useCallback(
     (caption: string) =>
-      product?.skuIDs.find((el: any) =>
-        el.options.find((item: any) => item.variantID === variantIDs.color._id)
+      product?.skuIDs?.find((el: any) =>
+        el?.options?.find((item: any) => item.variantID === variantIDs.color._id)
       )
         ? match.includes(caption)
         : true,

--- a/src/app/(routes)/[productId]/components/details/client/components/model.ts
+++ b/src/app/(routes)/[productId]/components/details/client/components/model.ts
@@ -3,11 +3,12 @@ import { variantIDs } from "@/lib/variables/variables";
 
 namespace productVariantsModel{
     export const getOptions = ( skuIDs: any, type: 'color' | 'size'): {_id: any, value: any, caption: any}[] => {
-        if (!skuIDs || !skuIDs.length) return []
+        if (!Array.isArray(skuIDs) || !skuIDs.length) return []
         let results: any = {}
         const variantID = variantIDs[type]._id
-        skuIDs.filter((el: any) => el.options.find((item: any) => item.variantID === variantID)).forEach((element: any) => {
-            const target = element.options.find((color: any) => color.variantID === variantID)
+        skuIDs.filter((el: any) => el?.options?.find((item: any) => item.variantID === variantID)).forEach((element: any) => {
+            const target = element?.options?.find((color: any) => color.variantID === variantID)
+            if (!target) return
             results[target.caption] = {
                 _id: target?._id,
                 value: target?.value,
@@ -16,6 +17,6 @@ namespace productVariantsModel{
         });
         return Object.keys(results).length ? Object.values(results) : []
     }
-    export const skuIDsMatchColor = (skuIDs: ISku[], color: string) => skuIDs.filter((sku: any) => sku?.options.find((options: any) => options.caption === color)).map((el: any) => el?.options.find((opt: any) => opt.variantID === variantIDs.size._id)).map((el: any) => el?.caption)
+    export const skuIDsMatchColor = (skuIDs: ISku[], color: string) => (Array.isArray(skuIDs) ? skuIDs : []).filter((sku: any) => sku?.options?.find((options: any) => options.caption === color)).map((el: any) => el?.options?.find((opt: any) => opt.variantID === variantIDs.size._id)).map((el: any) => el?.caption)
 }
 export default productVariantsModel

--- a/src/app/(routes)/[productId]/components/details/client/context/ProductOptionsModel.ts
+++ b/src/app/(routes)/[productId]/components/details/client/context/ProductOptionsModel.ts
@@ -8,14 +8,14 @@ interface IFindSkuAsOption {
 
 namespace productClientModel {
     export const getFirstOption = (sku: any) => {
-        const option = (variantID: string) => sku?.options.find((el: any) => el.variantID === variantID)?.caption;
+        const option = (variantID: string) => sku?.options?.find((el: any) => el.variantID === variantID)?.caption;
         return { color: option(variantIDs.color._id) || null, size: option(variantIDs.size._id) || null };
     };
 
     export const findSkuAsOption = ({ color, size, skuIDs }: IFindSkuAsOption) => {
-        if (!(skuIDs && (color || size))) return null;
-        const findOption = (options: any, value: string) => options.find((item: any) => item.caption === value);
-        return skuIDs.find((el: any) => (color ? findOption(el.options, color) : true) && (size ? findOption(el.options, size) : true));
+        if (!(Array.isArray(skuIDs) && (color || size))) return null;
+        const findOption = (options: any, value: string) => (options ?? []).find((item: any) => item.caption === value);
+        return skuIDs.find((el: any) => (color ? findOption(el?.options, color) : true) && (size ? findOption(el?.options, size) : true));
     };
 }
 

--- a/src/app/(routes)/[productId]/lib/product-data.ts
+++ b/src/app/(routes)/[productId]/lib/product-data.ts
@@ -1,0 +1,233 @@
+/**
+ * product-data.ts
+ *
+ * SSR data source for the INTERACTIVE product page served at
+ *   shop.droplinked.com/<productId>
+ *
+ * WHY THIS EXISTS (the "Buy Now" black-screen fix)
+ * ------------------------------------------------
+ * The interactive PDP was written for a SINGLE-SHOP storefront: page.tsx called
+ * `fetchInstance('products/:id')`, which requires a per-shop x-shop-id
+ * (NEXT_PUBLIC_API_KEY). The aggregate root storefront (shop.droplinked.com) is
+ * CROSS-SHOP and has no single shop identity, so NEXT_PUBLIC_API_KEY is unset
+ * and `fetchInstance` throws "Unauthorized!" *before it even makes a request*
+ * (see fetchInstance.ts: `if (!API_KEY) throw`). page.tsx is a Server Component
+ * with no try/catch, so that throw took down the whole route → Next's default
+ * error page ("Application error: a client-side exception has occurred").
+ *
+ * On top of that, imported/aggregate products (e.g. from the Shopify merchant
+ * "theshoecircle") only exist behind the PUBLIC product-v2 endpoint, whose
+ * payload is the V2 shape (`skuIds` / `skus` / `type` / `isPurchasable` /
+ * `images` / `shop`), NOT the legacy V1 shape (`skuIDs` / `product_type` /
+ * `purchaseAvailable` / `media`) the interactive client subtree consumes — so
+ * even a successful fetch would null-deref during hydration.
+ *
+ * This loader is FAIL-OPEN and NEVER throws:
+ *   1. Try the legacy shop-scoped endpoint — unchanged behavior on single-shop
+ *      deployments where NEXT_PUBLIC_API_KEY IS set.
+ *   2. Fall back to the PUBLIC product-v2 endpoint (no auth, cross-shop) and
+ *      adapt the V2 payload into the legacy `IProduct` shape the page renders.
+ *   3. Return null on total failure → the page falls through to `notFound()`
+ *      (a real 404 page, never a black screen).
+ *
+ * BE dependency (droplinked-backend):
+ *   GET {APIV3}/product-v2/public/:id  (@Public, no x-shop-id)
+ *   — wrapped by the class-level TransformInterceptor: { statusCode, message, data }.
+ */
+
+import { fetchInstance } from '@/lib/fetchInstance';
+import { SITE } from '@/lib/site';
+import { variantIDs } from '@/lib/variables/variables';
+import {
+  IProduct,
+  IProductMedia,
+  ISku,
+  initialProductProps,
+  initialSkuProps,
+} from '@/types/interfaces/product/product';
+
+/** apiv3 base — overridable for dev/preview; defaults to the prod API host. */
+const APIV3_BASE = (
+  process.env.APIV3_BASE_URL || 'https://apiv3.droplinked.com'
+).replace(/\/+$/, '');
+
+// ---- subset of the apiv3 product-v2 payload we consume -------------------
+
+interface V2Image {
+  original?: string | null;
+  thumbnail?: string | null;
+  alt?: string | null;
+}
+interface V2Attribute {
+  key?: string | null;
+  value?: string | null;
+  caption?: string | null;
+}
+interface V2Sku {
+  id?: string;
+  price?: number | null;
+  inventory?: { quantity?: number | null } | null;
+  attributes?: V2Attribute[] | null;
+  externalId?: string | null;
+}
+interface V2Product {
+  id?: string;
+  title?: string;
+  description?: string | null;
+  type?: string | null;
+  shopId?: string | null;
+  shop?: { id?: string } | null;
+  isPurchasable?: boolean | null;
+  defaultImageIndex?: number | null;
+  images?: V2Image[] | null;
+  skus?: V2Sku[] | null;
+  tags?: string[] | null;
+}
+
+// ---- V2 → legacy IProduct adapter (pure) ---------------------------------
+
+/**
+ * Only `color` and `size` drive the legacy variant selectors; every other V2
+ * attribute (e.g. "Gender") has no legacy variantID and is intentionally
+ * dropped so it never renders a broken selector. Keyed case-insensitively.
+ */
+const VARIANT_KEY_TO_ID: Record<string, string> = {
+  color: variantIDs.color._id,
+  colour: variantIDs.color._id,
+  size: variantIDs.size._id,
+};
+
+function attributesToOptions(attributes: V2Attribute[] | null | undefined) {
+  const options: Array<{ variantID: string; caption: string; value: string; _id: string }> = [];
+  for (const attr of attributes ?? []) {
+    const key = String(attr?.key ?? '').trim().toLowerCase();
+    const variantID = VARIANT_KEY_TO_ID[key];
+    if (!variantID) continue;
+    const caption = String(attr?.caption ?? attr?.value ?? '').trim();
+    if (!caption) continue;
+    options.push({
+      variantID,
+      caption,
+      value: String(attr?.value ?? caption),
+      _id: `${variantID}:${caption}`,
+    });
+  }
+  return options;
+}
+
+function skuV2ToLegacy(sku: V2Sku): ISku {
+  return {
+    ...initialSkuProps,
+    _id: String(sku?.id ?? ''),
+    price: typeof sku?.price === 'number' ? sku.price : 0,
+    quantity: typeof sku?.inventory?.quantity === 'number' ? sku.inventory.quantity : 0,
+    externalID: String(sku?.externalId ?? ''),
+    options: attributesToOptions(sku?.attributes),
+  };
+}
+
+function imagesToMedia(
+  images: V2Image[] | null | undefined,
+  defaultImageIndex: number | null | undefined,
+): IProductMedia[] {
+  const arr = Array.isArray(images) ? images : [];
+  const mainIdx =
+    typeof defaultImageIndex === 'number' && defaultImageIndex >= 0 && defaultImageIndex < arr.length
+      ? defaultImageIndex
+      : 0;
+  const media: IProductMedia[] = [];
+  arr.forEach((img, i) => {
+    const url = img?.original || img?.thumbnail;
+    if (!url) return;
+    media.push({
+      url,
+      thumbnail: img?.thumbnail || url,
+      isMain: i === mainIdx ? 'true' : 'false',
+      _id: `img-${i}`,
+    });
+  });
+  // Guarantee exactly one "main" so ms(media) always resolves a hero image.
+  if (media.length && !media.some((m) => m.isMain === 'true')) media[0].isMain = 'true';
+  return media;
+}
+
+/** Map a product-v2 payload onto the legacy IProduct shape the page renders. */
+export function adaptProductV2ToLegacy(v2: V2Product): IProduct {
+  const productType = String(v2?.type ?? '').toUpperCase(); // 'PHYSICAL' | 'DIGITAL' | …
+  const skus = Array.isArray(v2?.skus) ? v2.skus : [];
+  return {
+    ...initialProductProps,
+    _id: String(v2?.id ?? ''),
+    ownerID: String(v2?.shopId ?? v2?.shop?.id ?? ''),
+    title: String(v2?.title ?? ''),
+    description: typeof v2?.description === 'string' ? v2.description : '',
+    type: productType,
+    product_type: productType,
+    skuIDs: skus.map(skuV2ToLegacy),
+    media: imagesToMedia(v2?.images, v2?.defaultImageIndex),
+    purchaseAvailable: v2?.isPurchasable !== false,
+    tags: Array.isArray(v2?.tags) ? v2.tags : [],
+    ruleSet: null,
+  };
+}
+
+// ---- fetch (never throws) ------------------------------------------------
+
+async function fetchPublicProductV2(productId: string): Promise<V2Product | null> {
+  const url = `${APIV3_BASE}/product-v2/public/${encodeURIComponent(productId)}`;
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      next: { revalidate: 300 },
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': `${SITE.name}-shopfront/1.0 (interactive-pdp)`,
+      },
+    });
+  } catch {
+    return null; // network error → not-found, never throw
+  }
+  if (!response.ok) return null; // 404 = unknown/gated, 5xx = backend down
+
+  let raw: unknown;
+  try {
+    raw = await response.json();
+  } catch {
+    return null;
+  }
+
+  // Unwrap the TransformInterceptor envelope { statusCode, message, data } when
+  // present; otherwise treat the payload as the product itself.
+  const outer = raw as { data?: unknown };
+  const payload =
+    outer && typeof outer === 'object' && outer.data && typeof outer.data === 'object'
+      ? outer.data
+      : raw;
+  return payload && typeof payload === 'object' ? (payload as V2Product) : null;
+}
+
+/**
+ * Resolve the interactive PDP product, fail-open. Tries the legacy shop-scoped
+ * endpoint first (single-shop deployments), then the public cross-shop
+ * product-v2 endpoint (aggregate root). Returns a legacy-shaped IProduct, or
+ * null when the product cannot be resolved anywhere → page calls notFound().
+ * NEVER throws.
+ */
+export async function getInteractiveProduct(productId: string): Promise<IProduct | null> {
+  // 1. Legacy shop-scoped endpoint. On the aggregate root this throws
+  //    "Unauthorized!" (no x-shop-id) — swallow and fall through.
+  try {
+    const legacy = await fetchInstance(`products/${productId}`);
+    if (legacy && typeof legacy === 'object' && Array.isArray((legacy as IProduct).skuIDs)) {
+      return legacy as IProduct;
+    }
+  } catch {
+    /* no shop identity on the aggregate root, or route/product missing */
+  }
+
+  // 2. Public cross-shop product-v2 endpoint (no auth), adapted to legacy shape.
+  const v2 = await fetchPublicProductV2(productId);
+  if (v2) return adaptProductV2ToLegacy(v2);
+
+  return null;
+}

--- a/src/app/(routes)/[productId]/page.tsx
+++ b/src/app/(routes)/[productId]/page.tsx
@@ -1,19 +1,23 @@
 'use server';
 
-import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import ProductDescription from './components/ProductDescription';
 import ProductDetails from './components/details/ProductDetails';
 
 import { AppSeparator } from '@/components/ui';
-import { fetchInstance } from '@/lib/fetchInstance';
 import ProductSlider from './components/ProductSlider';
+import { getInteractiveProduct } from './lib/product-data';
 
 // type IProps = { params: { productId: string } };
 
 export default async function Page({ params } : { params: Promise<{ productId: string }>}) {
   const { productId } = await params
-  const data = await fetchInstance(`products/${productId}`);
-  
+  // Fail-open loader: resolves the product across single-shop + aggregate
+  // storefronts and never throws. `null` = genuinely unresolvable → a real 404
+  // page, never the "Application error" black screen (see lib/product-data.ts).
+  const data = await getInteractiveProduct(productId);
+  if (!data) notFound();
+
   return (
     <main className="container px-8 flex items-start md:flex-row flex-col justify-center w-full gap-12 mt-20">
       <div className="min-w-full md:min-w-[40%] md:sticky left-0 top-24">

--- a/src/lib/utils/ms/ms.ts
+++ b/src/lib/utils/ms/ms.ts
@@ -1,6 +1,8 @@
 import { IProductMedia } from "@/types/interfaces/product/product";
 
 export function ms(medias: IProductMedia[]) {
-    return medias.find((el: any) => el.isMain === "true")?.url || ""
+    // Null-safe: the interactive PDP can render products with no/undefined media
+    // (sparse aggregate items) — never throw on `.find` of undefined.
+    return medias?.find((el: any) => el.isMain === "true")?.url || ""
 }
   


### PR DESCRIPTION
## Summary — SHIPPED

Fixes the urgent prod crash: clicking **Buy Now** on an aggregate/imported product landing page navigates to the interactive PDP `https://shop.droplinked.com/<productId>` and the page black-screens with **"Application error: a client-side exception has occurred."**

Reproduced live on `https://shop.droplinked.com/6899d5f61c35d3043863bbfe` ("DIONIES by Dionies Sportswear", Shopify merchant *theshoecircle*). Server HTML returns HTTP 200 carrying a **server error digest `3988620222`** with zero product content — the route threw during render.

## Root cause (exact)

**Primary — SSR fetch throws `"Unauthorized!"`:** `src/app/(routes)/[productId]/page.tsx:15` called `fetchInstance('products/:id')`. `fetchInstance` (`src/lib/fetchInstance.ts:5`) does `if (!API_KEY) throw new Error("Unauthorized!")`, where `API_KEY = process.env.NEXT_PUBLIC_API_KEY` (the `x-shop-id`). The **aggregate root storefront is cross-shop and has no single shop identity**, so `NEXT_PUBLIC_API_KEY` is unset — the throw happens *before any request*. `page.tsx` is a Server Component with no try/catch, so the throw takes down the whole route → Next's default error page.

> Proof: the app's own proxy `GET https://shop.droplinked.com/api/products?id=6899d5f61c35d3043863bbfe` returns `500 {"error":"Unauthorized!"}` — that exact string can only originate from the `!API_KEY` guard.

**Secondary — V1/V2 shape mismatch:** aggregate products only exist behind the public `GET {APIV3}/product-v2/public/:id` endpoint. Its payload is the **product-v2 shape** (`skuIds` / `skus` / `type` / `isPurchasable` / `images` / `shop`), NOT the **legacy V1 shape** (`skuIDs` / `product_type` / `purchaseAvailable` / `media`) the interactive client subtree consumes. So even a successful fetch would null-deref during hydration. Concrete unguarded accesses that throw on a product missing `skuIDs`:
- `ProductClient.tsx:31` — `getFirstOption(data?.skuIDs[0])` → `undefined[0]` (optional chain guarded `data`, not `skuIDs`)
- `ProductClient.tsx:41` — `States?.product?.skuIDs[0]` (DIGITAL branch)
- `model.ts:19` `skuIDsMatchColor` — `skuIDs.filter(...)` on `undefined`
- `ProductSizeSelector.tsx:24` — `product?.skuIDs.find(...)`; `ms.ts` — `medias.find(...)` on undefined media

## The fix (fail-open — mirrors the house `marketplace-data.ts` never-throw + `notFound()` pattern)

- **New `src/app/(routes)/[productId]/lib/product-data.ts`** — `getInteractiveProduct(productId)`:
  1. Try the legacy shop-scoped endpoint (**unchanged behavior** on single-shop deployments where `NEXT_PUBLIC_API_KEY` IS set).
  2. Fall back to the **public cross-shop** `product-v2/public/:id` (no auth) and **adapt** it into the legacy `IProduct` shape (pure `adaptProductV2ToLegacy`: `images→media`, `skus→skuIDs` with `attributes→options` mapping only `color`/`size` to their variantIDs, `type→product_type`, `isPurchasable→purchaseAvailable`).
  3. Return `null` on total failure → page calls `notFound()` (a real 404, never a black screen). **Never throws.**
- **`page.tsx`** — use the loader + `notFound()` instead of a bare throwing fetch.
- **Defense-in-depth null-safety** across the client subtree (`ProductClient`, `ProductOptionsModel`, `model`, `ProductSizeSelector`, `ProductDetails`) and the shared `ms()` helper, so a product with missing `skuIDs`/`options`/`media` can never crash during hydration.

Verified against the real V2 payload: adapter yields title, 6 images (hero set), 39 SKUs, price $189, and 12 size options → the PDP now renders title/image/price + size selector + quantity + Add-to-cart instead of black-screening.

## Quality gates
- `npm ci` — OK
- **`npm run build` (next build, standalone, production) — OK, exit 0** — `/[productId]` builds as a dynamic route. `npx tsc --noEmit` shows **8 pre-existing errors** in checkout/footer/header/cart files (image-module + MUI `IntrinsicAttributes`), **none in touched files** and all present on stock `main`; they don't block `next build`.

## Checkout implications (diagnosis only — NOT changed in this PR)

Per the task, this PR does **not** modify any money-path code — this section only documents what a separate workaround would need.

How Buy/checkout is wired on the interactive PDP:
- `ProductCartActions.tsx` → `useAppCart().addItemToCart({ skuID, quantity })` → the `/api/cart*` routes → `fetchInstance('cart/...')`, which is **shop-scoped and requires the same `x-shop-id` (`NEXT_PUBLIC_API_KEY`)** whose absence caused the crash.
- On the aggregate root, Add-to-cart therefore cannot complete; it now **fails open via `toast.promise` error** ("Something went wrong") rather than crashing. No payment provider is reachable from this route because there is no shop context.

What the imported aggregate products lack:
- No `x-shop-id` on the root storefront (cross-shop), so **no shop → no payment-provider connection → no provider-readiness signal**. The product's true owner is the merchant shop (e.g. `theshoecircle`, shopId `688776fb2f570f1c9cc5fb87`); the V2 payload carries `shop { id, name }` / `shopId`, but no payment wiring is surfaced to this route.

What a workaround to route these products' checkout through a **specific merchant's Stripe account** would need to touch (for a **separate** money-path PR — not implemented here):
- Resolve the **owning merchant shop** from the product (`shop.id` / `shopId` in the V2 payload) and drive checkout with **that shop's** `x-shop-id` (cart create → payment-methods → `checkout/stripe/:cartId`), rather than the root's absent key.
- The cart/checkout API routes (`src/app/api/cart/**`, `src/app/api/checkout/**`) currently read `x-shop-id` from the ambient `NEXT_PUBLIC_API_KEY`; they would need to accept/propagate a **per-product merchant shop id**.
- Backend: the payment-intent resolver and the provider-eligibility / account-readiness gates must resolve against the **merchant's** connected Stripe account, and the aggregate product's SKUs must map to that merchant's catalog for capture.
- Cleaner alternative worth considering: the aggregate PDP's Buy affordance could instead route to the merchant's own shop PDP (`/{shopSlug}/product/{slug}`) where shop/payment context already exists — but that link lives in the SEO PDP, outside this PR's lane.

## Scope
- Lane: `[productId]/page.tsx`, `[productId]/lib/**` (new), the `components/details/**` client subtree, and the shared null-safe `ms()` helper.
- **Did NOT touch** `src/app/(routes)/[productId]/product/[slug]/**` or `ProductDescription.tsx` (parallel task's lane).

Base: `main` (deploys `shop_droplinked_com`). Head `hotfix/*` per the dev-first policy exception path (`enforce-pr-source-branch.yml`) — chosen over a `dev` base because `main` is currently 3 commits ahead of `dev` and a `dev→main` GTFU would revert live hotfixes.
