### PR TITLE
fix(pdp): allow arbitrary merchant image hosts (imported product images render broken)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,7 +15,12 @@ const cspReportOnly = [
     "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://js.stripe.com",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.cdnfonts.com",
     "font-src 'self' https://fonts.gstatic.com https://fonts.cdnfonts.com data:",
-    "img-src 'self' data: blob: https://upload-file-droplinked.s3.amazonaws.com https://upload-file-flatlay.s3.us-west-2.amazonaws.com https://files.cdn.printful.com https://*.cloudfront.net https://www.google-analytics.com",
+    // Aggregate storefront: product images come from ARBITRARY merchant CDNs
+    // (Shopify custom domains, retailer CDNs, etc.), so `img-src` must allow any
+    // https image host or imported products render as broken placeholders. Kept
+    // scheme-restricted to https (+ data:/blob: for inline). Non-image directives
+    // stay tight.
+    "img-src 'self' data: blob: https:",
     "connect-src 'self' https://apiv3.droplinked.com https://apiv3dev.droplinked.com https://tools.droplinked.com https://ipapi.co https://accept.paymob.com https://*.ingest.sentry.io https://www.google-analytics.com https://api.stripe.com",
     "frame-src 'self' https://accept.paymob.com https://js.stripe.com https://hooks.stripe.com",
     "frame-ancestors 'none'",
@@ -35,7 +40,14 @@ const nextConfig = {
     // fails at `COPY --from=builder /app/.next/standalone ./` (issue #38).
     output: 'standalone',
     images: {
+        // Aggregate storefront serves product images from ARBITRARY merchant
+        // CDNs (Shopify custom domains like theshoecircle.com, cdn.shopify.com,
+        // retailer CDNs). next/image REJECTS any host not listed here, which
+        // rendered every imported product image as a broken placeholder. Allow
+        // any https host so merchant images resolve; the droplinked S3 hosts are
+        // implicitly covered but kept explicit for intent.
         remotePatterns: [
+            { protocol: 'https', hostname: '**' },
             {
                 protocol: 'https',
                 hostname: 'upload-file-flatlay.s3.us-west-2.amazonaws.com',


### PR DESCRIPTION
## Problem (prod)
On the interactive PDP (e.g. `shop.droplinked.com/6899d5f61c35d3043863bbfe`, DIONIES) every imported product image renders as a broken 'product image' placeholder — 'formatting completely broken'.

## Root cause (NOT dead images)
The images are **valid + reachable** — `https://theshoecircle.com/cdn/shop/products/Dionies_ID802689_01.jpg` returns `HTTP 200 image/jpeg`. The block is the FE host allowlist:
- `ProductSlider.tsx` uses **`next/image`**, and `next.config.mjs` `remotePatterns` only permitted two droplinked S3 hosts → next/image **rejects** arbitrary merchant CDNs (theshoecircle.com, cdn.shopify.com, s0.as-img.com) → broken placeholders.
- CSP `img-src` (currently `Report-Only`, so not the active blocker, but enforcing is planned) only listed a few hosts.

## Fix
- `remotePatterns`: add `{ protocol: 'https', hostname: '**' }` — an aggregate storefront serves arbitrary merchant product images, so any https host must be allowed (kept the explicit S3 hosts for intent).
- CSP `img-src`: broaden to `'self' data: blob: https:` so promoting CSP to enforcing later won't re-break merchant images. Non-image directives stay tight.

## Scope / safety
SHIPPED — 1 file (`next.config.mjs`), config only. Base `main` (hotfix; shop.droplinked.com deploys from main). Follow-up option (noted, not blocking): route third-party images through the SSRF-guarded `/img` proxy for tighter control + optimization cost management, instead of letting next/image optimize arbitrary hosts.

## Closes
Addresses the operator-reported 'formatting completely broken / product images broken' on imported PDPs.