### PR TITLE
fix(pdp): disable next/image optimizer so merchant product images render

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -42,12 +42,17 @@ const nextConfig = {
     images: {
         // Aggregate storefront serves product images from ARBITRARY merchant
         // CDNs (Shopify custom domains like theshoecircle.com, cdn.shopify.com,
-        // retailer CDNs). next/image REJECTS any host not listed here, which
-        // rendered every imported product image as a broken placeholder. Allow
-        // any https host so merchant images resolve; the droplinked S3 hosts are
-        // implicitly covered but kept explicit for intent.
+        // retailer CDNs). The Next image OPTIMIZER rejects any host not in
+        // `remotePatterns` with HTTP 400 — and a bare `hostname: '**'` does NOT
+        // match apex merchant domains in Next 15, so every imported product image
+        // (main via AppMagnifier + thumbnails, both `next/image`) rendered as a
+        // broken placeholder. Disable the optimizer so `next/image` emits the raw
+        // <img> with the original merchant URL — the source CDNs (Shopify etc.)
+        // already serve optimized images, so we lose little and unblock all hosts.
+        // (Follow-up option: a custom loader / SSRF-guarded /img proxy to
+        // re-enable optimization for third-party hosts.)
+        unoptimized: true,
         remotePatterns: [
-            { protocol: 'https', hostname: '**' },
             {
                 protocol: 'https',
                 hostname: 'upload-file-flatlay.s3.us-west-2.amazonaws.com',


### PR DESCRIPTION
## Problem
After #153 deployed, imported product images STILL render broken. Verified against the live optimizer:
`GET /_next/image?url=<theshoecircle.com img>` → **HTTP 400** (host rejected), while the allowed S3 host returns 403 (allowed, fetch-failed). So next/image still refuses merchant hosts.

## Why #153 wasn't enough
#153 added `remotePatterns: [{ hostname: '**' }]`, but in **Next 15.5 a bare `'**'` does not match apex domains** (theshoecircle.com, cdn.shopify.com). Both product-image call sites use `next/image` — the main image (`AppMagnifier` → `NextImage`) and the 4 thumbnails — so every image 400s.

## Fix
`images.unoptimized: true` — `next/image` emits the raw `<img>` with the original merchant URL, no optimizer round-trip, no host allowlist. The source CDNs (Shopify etc.) already serve optimized images, so the trade-off is minimal. CSP `img-src` is already `https:` + Report-Only (#153), so nothing blocks the load. Images verified reachable (theshoecircle JPEGs = 200).

## Scope
SHIPPED — 1 file (`next.config.mjs`). Base `main` (hotfix). Follow-up option: a custom next/image `loader` or the SSRF-guarded `/img` proxy to re-enable optimization for third-party hosts.

## Closes
Completes the 'product images broken / formatting completely broken' fix (supersedes the #153 remotePatterns approach).