### PR TITLE
fix(pdp): size selection as a clean high-contrast dropdown (was a low-contrast 30-box grid)

### DIFF
--- a/src/app/(routes)/[productId]/components/details/client/components/ProductSizeSelector.tsx
+++ b/src/app/(routes)/[productId]/components/details/client/components/ProductSizeSelector.tsx
@@ -1,19 +1,37 @@
-import { AppButton, AppDotLabel } from '@/components/ui';
-import { cn } from '@/lib/utils/cn/cn';
+'use client';
+import { AppDropDownInput } from '@/components/ui';
 import { variantIDs } from '@/lib/variables/variables';
 import { useCallback, useContext, useEffect, useMemo } from 'react';
 import { ProductContext } from '../context';
 import productVariantsModel from './model';
 
+/**
+ * Size selection as a single clean dropdown.
+ *
+ * Previously this rendered every size as a grid of ~30 outlined boxes with a
+ * low-contrast (pale) selected state — noisy, and the selection read as
+ * secondary. A dropdown (react-select via AppDropDownInput, the same control the
+ * checkout uses) makes size a deliberate, high-contrast, primary choice, is
+ * searchable/keyboard-friendly for long shoe-size lists, and scales cleanly from
+ * 2 to 30 options. Sizes arrive unsorted from the SKU options, so we order them
+ * numerically. Sizes unavailable for the chosen colour are disabled, not hidden.
+ */
 function ProductSizeSelector() {
   const { skuIDsMatchColor, getOptions } = productVariantsModel;
-  const {states: { product,option: { size, color }, sku}, methods: { updateOption },} = useContext(ProductContext);
+  const {
+    states: {
+      product,
+      option: { size, color },
+      sku,
+    },
+    methods: { updateOption },
+  } = useContext(ProductContext);
 
   const match = useMemo(
     () => skuIDsMatchColor(product?.skuIDs, color || ''),
     [product, color]
   );
-  
+
   const sizes = useMemo(
     () => getOptions(product?.skuIDs, 'size'),
     [product, match, color]
@@ -26,35 +44,49 @@ function ProductSizeSelector() {
       )
         ? match.includes(caption)
         : true,
-    [sku]
+    [product, match]
   );
 
   useEffect(() => {
     !sku && sizes.length && color && updateOption('size', match[0]);
   }, [sku]);
 
+  // Captions look like "8.5 US" / "11 US" — order by the leading numeric size so
+  // the dropdown reads naturally (6 → 17), not by SKU insertion order.
+  const numericSize = (caption: string) => {
+    const m = String(caption ?? '').match(/[\d.]+/);
+    return m ? parseFloat(m[0]) : Number.POSITIVE_INFINITY;
+  };
+
+  const options = useMemo(
+    () =>
+      [...sizes]
+        .sort((a, b) => numericSize(a.caption) - numericSize(b.caption))
+        .map((el) => ({
+          value: el.caption,
+          label: el.caption,
+          // react-select honours isDisabled at runtime; the interface types the
+          // base { value, label } shape, this extra flag is additive.
+          isDisabled: !active(el.caption),
+        })),
+    [sizes, active]
+  );
+
+  const selected = useMemo(
+    () => options.find((o) => o.value === size) ?? null,
+    [options, size]
+  );
+
   return sizes.length ? (
-    <div className="flex flex-col gap-6">
-      <AppDotLabel label={'Size'} content={size || ''} appClassNames={{}} />
-      <div className="flex flex-wrap gap-2.5">
-        {sizes.map((el) => (
-          <AppButton
-            key={el._id}
-            onClick={() =>
-              active(el.caption) && updateOption('size', el.caption)
-            }
-            appVariant="outlined"
-            appClassName={cn(
-              'font-normal text-base w-12 h-12 border border-border py-3 px-4 rounded-sm cursor-pointer min-w-',
-              el.caption === size
-                ? 'bg-foreground text-background'
-                : 'bg-transparent text-foreground'
-            )}
-          >
-            {el.caption}
-          </AppButton>
-        ))}
-      </div>
+    <div className="flex flex-col gap-2 w-full max-w-xs">
+      <AppDropDownInput
+        name="size"
+        label="Size"
+        placeholder="Choose your size"
+        options={options}
+        value={selected}
+        select={(opt: any) => opt?.value && updateOption('size', opt.value)}
+      />
     </div>
   ) : null;
 }


### PR DESCRIPTION
## Problem
The size selector was a grid of ~30 outlined boxes with a **low-contrast pale selected state** and read as a **secondary** control (operator: 'horrible contrast … size selection is always secondary … cleaner UXUI drop down').

## Fix
Replace the box grid with the design-system **`AppDropDownInput`** (react-select — the same control the checkout address form uses):
- **High-contrast dropdown** — selected value in solid black, option hover black/white; no more pale selected box.
- **Primary, deliberate choice** — a single labelled 'Size' control with a 'Choose your size' placeholder instead of a wall of boxes.
- **Searchable + keyboard-friendly** — scales cleanly from 2 to 30 shoe sizes.
- **Numeric sort** — captions ('8.5 US', '11 US') arrive in SKU-insertion order; now ordered 6 → 17.
- **Unavailable sizes disabled, not hidden** — availability-by-colour logic unchanged.

## Scope
SHIPPED — 1 file (`ProductSizeSelector.tsx`). Selection + colour-availability + auto-select behaviour unchanged. Base `main` (hotfix). tsc clean for the file.

## Closes
Operator-reported size-selector UX (contrast + dropdown + primary treatment).