### PR TITLE
feat(checkout): flag-gated MoR shop context for aggregate root (default OFF) — shopsadiq MoR scaffold

### DIFF
--- a/src/lib/fetchInstance.ts
+++ b/src/lib/fetchInstance.ts
@@ -1,14 +1,42 @@
-import { API_KEY, BASE_API_URL } from "./variables/variables";
+import {
+  API_KEY,
+  BASE_API_URL,
+  MOR_CHECKOUT_ENABLED,
+  MOR_SHOP_ID,
+} from "./variables/variables";
 
+/**
+ * Resolve the shop context sent as the `x-shop-id` header for this request.
+ *
+ * Default behavior (unchanged): use the deployment's ambient shop identity
+ * (NEXT_PUBLIC_API_KEY). A per-shop deployment always has this set, so the
+ * `||` short-circuits before the MoR branch is ever evaluated — behavior is
+ * byte-identical to before this change on every real shop.
+ *
+ * MoR aggregate-root fallback (flag-gated, DEFAULT OFF): ONLY when this
+ * deployment has NO ambient shop identity (API_KEY unset — i.e. the
+ * shop.droplinked.com aggregate root) AND `NEXT_PUBLIC_MOR_CHECKOUT_ENABLED`
+ * is explicitly "true" AND a MoR shop id is configured, fall back to the
+ * Merchant-of-Record shop so all aggregate-root cart/checkout traffic runs
+ * under ONE MoR shop's PSP. When the flag is off/unset, or no MoR shop id is
+ * set, we resolve to `undefined` and throw "Unauthorized!" exactly as before
+ * (fail-open: no new code path is taken).
+ */
+function resolveShopId(): string | undefined {
+  if (API_KEY) return API_KEY;
+  if (MOR_CHECKOUT_ENABLED && MOR_SHOP_ID) return MOR_SHOP_ID;
+  return undefined;
+}
 
 export async function fetchInstance(url: string, options?: RequestInit) {
-  if (!API_KEY) throw new Error("Unauthorized!");
+  const shopId = resolveShopId();
+  if (!shopId) throw new Error("Unauthorized!");
 
   const response = await fetch(`${BASE_API_URL}${url}`, {
     credentials: 'include',
-    headers: { 
-      "Content-Type": "application/json", 
-      "x-shop-id": API_KEY,
+    headers: {
+      "Content-Type": "application/json",
+      "x-shop-id": shopId,
       "Accept": "application/json",
       ...(options?.headers || {}),
     },

--- a/src/lib/variables/variables.ts
+++ b/src/lib/variables/variables.ts
@@ -13,6 +13,35 @@ export const APP_DEVELOPMENT = process.env.NEXT_PUBLIC_APP_DEVELOPMENT === "true
  */
 export const ROOT_CATALOG_ENABLED =
   process.env.NEXT_PUBLIC_ROOT_CATALOG_ENABLED === "true";
+/**
+ * Merchant-of-Record (MoR) checkout context for the aggregate root
+ * (shop.droplinked.com). The aggregate root is CROSS-SHOP and carries no single
+ * shop identity — NEXT_PUBLIC_API_KEY (the `x-shop-id`) is unset — so cart /
+ * checkout requests have no shop to run under and `fetchInstance` throws
+ * "Unauthorized!". These two vars let ALL aggregate-root sales run under ONE
+ * MoR shop's PSP (e.g. "shopsadiq ltd") without giving the root a per-shop
+ * identity.
+ *
+ * `NEXT_PUBLIC_MOR_SHOP_ID`  — the MoR shop's ObjectId; used as the `x-shop-id`
+ *                              for cart/checkout ONLY on the aggregate root
+ *                              (i.e. only when NEXT_PUBLIC_API_KEY is unset).
+ * `NEXT_PUBLIC_MOR_CHECKOUT_ENABLED` — master flag. Default OFF: absent / any
+ *                              value other than the string "true" ⇒ EXACTLY
+ *                              today's behavior (no regression on any per-shop
+ *                              deployment, where API_KEY is set and this branch
+ *                              is never reached). NEXT_PUBLIC_ so Next inlines
+ *                              it at build time (the standalone runner does not
+ *                              carry .env at runtime — same reasoning as
+ *                              ROOT_CATALOG_ENABLED above).
+ *
+ * NOTE: the FE wiring alone is necessary but NOT sufficient — the backend
+ * cart still enforces per-item shop ownership (add-product rejects a product
+ * whose shopId !== cart.shopId unless the MoR shop's agent holds an ACTIVE
+ * affiliate link for it). See the activation runbook in the PR body.
+ */
+export const MOR_SHOP_ID = process.env.NEXT_PUBLIC_MOR_SHOP_ID;
+export const MOR_CHECKOUT_ENABLED =
+  process.env.NEXT_PUBLIC_MOR_CHECKOUT_ENABLED === "true";
 export const variantIDs = { color: { _id: "62a989ab1f2c2bbc5b1e7153" }, size: { _id: "62a989e21f2c2bbc5b1e7154" } };
 export const app_vertical = "flex flex-col items-center justify-center";
 export const app_center = "flex items-center justify-center";


### PR DESCRIPTION
## What & why

`shop.droplinked.com` (this repo, Next-ShopFront) is the **cross-shop aggregate root**. It carries **no single shop identity** — `NEXT_PUBLIC_API_KEY` (the `x-shop-id`) is unset — so `fetchInstance` throws `"Unauthorized!"` and **Add-to-cart / checkout do nothing** on the root. The owning merchant lives in each product payload (`shop.id`, e.g. `theshoecircle`=`688776fb2f570f1c9cc5fb87`) but those merchants have no PSP; all aggregate sales must run under **ONE Merchant-of-Record (MoR) shop** — "shopsadiq ltd".

This PR ships the **safe, flag-gated, default-OFF FE scaffold** for that: a MoR shop context at the single `x-shop-id` choke point. **No payment behavior changes when the flag is off.** It does **not** ship any backend change and does **not** connect any Stripe account (shopsadiq's creds don't exist yet, so this is untestable end-to-end — deliberately left dark).

---

## Cross-shop-MoR feasibility verdict (the crux)

**Can shop B (MoR) hold + checkout shop A's product with JUST a MoR shop-id? → NO, not by itself.** The active backend (`droplinked-backend`, `dev`) enforces per-item shop ownership on add-to-cart, with **exactly one escape hatch: an ACTIVE affiliate link.**

**Evidence — `src/modules/cart-v2/use-cases/add-product-to-cart.use-case.ts:181-191`:**
```ts
// Ensure the product belongs to the same shop as the cart,
// OR the cart's shop has an active affiliate link for this product
if (product.shopId !== cart.shopId) {
  const isAffiliate = await this.isAffiliateProduct(product.id, cart.shopId);
  if (!isAffiliate) {
    throw new BadRequestException('Product does not belong to this shop');
  }
}
```
`isAffiliateProduct` (same file, `:346-363`): `shopV2(cart.shopId).merchantId` → `agentProfile(agentUserId=merchantId)` → `affiliateLink.findFirst({ agentId, productId, status: 'ACTIVE' })`. So a MoR cart can hold another shop's product **only when the MoR shop's merchant is an agent with an ACTIVE affiliate link to that specific product.**

**The rest of the money path already routes to the cart's shop automatically (this part IS feasible with just a shop-id):**
- Cart is bound to ONE shop at creation — `CreateCartDto.shopId` (`src/modules/cart-v2/dtos/create-cart.dto.ts:12-18`). The add-product DTO has **no** `shopId` (`.../dtos/add-product-to-cart.dto.ts`), so the shop is fixed by the cart.
- Order inherits the cart's shop — `src/modules/order-v2/use-cases/init-order.use-case.ts:293` `shop: { connect: { id: cart.shopId } }`.
- PSP / distribution resolve off the cart's shop — `src/modules/order-v2/use-cases/calculate-payment-distribution.use-case.ts:123` `getShopWithPaymentMethod(cart.shopId)`.
- Stripe account selection — `src/modules/checkout-intent-resolver/use-cases/resolve-payment-intent.use-case.ts`: reads the shop's `PaymentMethod` (`shopPaymentMethodsV2`). `accountId` set ⇒ Connect **destination** charges (requires `shop.stripeConnectChargesEnabled === true`, `:770-791`); `accountId` null ⇒ **platform-direct** mode to droplinked's platform account. Publishable key = `gateway.publishableKey` per-shop override → else env `STRIPE_PUBLIC_KEY` (`:893-948`).

**Net:** point the cart at the MoR shop (this PR does that via `x-shop-id`) and the order + Stripe automatically settle under the MoR shop. The **only** blocker is the per-item ownership gate — cleared by affiliate links (data, no code) **or** a new MoR cart mode (backend code).

### Important caveats surfaced during investigation
1. **Endpoint-version mismatch.** This FE calls the **legacy v1** surface — `NEXT_PUBLIC_BASE_API_URL=https://apiv3.droplinked.com/v1/` (README:41) + paths `cart`, `cart/:cartId`, `checkout/stripe/:cartId`. The maintained backend cart is **cart-v2** at `v2/carts` (`crt_`-encrypted cart tokens, `checkout/prepare`). In the current `dev` branch **both** the legacy `cart` module (`src/modules/cart/cart.module.ts`) **and** the legacy `public-api` module (`src/modules/public-api/public-api.module.ts`) are **fully commented out**. So `apiv3.droplinked.com/v1/cart*` is served either by a separate legacy deployment or is dead. **The operator must `curl` the v1 cart endpoint to confirm it resolves before activation** — and consider migrating Next-ShopFront's cart layer to cart-v2. The verdict above is cited against cart-v2 (the maintained source of truth); the ownership constraint existed in the legacy path too.
2. **"Shopsadiq-MoR" already exists as a PSP-cohort concept** for Telr/Bonum settlement (`resolve-payment-intent.use-case.ts:122-124`). That is a PSP-settlement mode, **distinct** from the cart cross-shop ownership gate that is the actual blocker here.

---

## Flag / env design

Both are `NEXT_PUBLIC_` so Next inlines them at build time (the standalone runner carries no `.env` at runtime — same reasoning as the existing `ROOT_CATALOG_ENABLED`).

| Env | Meaning | Default |
| --- | --- | --- |
| `NEXT_PUBLIC_MOR_CHECKOUT_ENABLED` | master flag | **OFF** (absent / anything ≠ `"true"`) |
| `NEXT_PUBLIC_MOR_SHOP_ID` | MoR shop ObjectId used as `x-shop-id` on the aggregate root | unset |

**Resolution logic** (`src/lib/fetchInstance.ts`, single choke point for ALL cart + checkout requests):
```ts
function resolveShopId(): string | undefined {
  if (API_KEY) return API_KEY;                                 // per-shop deploy: unchanged
  if (MOR_CHECKOUT_ENABLED && MOR_SHOP_ID) return MOR_SHOP_ID; // aggregate root + flag ON
  return undefined;                                            // → throw "Unauthorized!" (as before)
}
```

**Money-path discipline:**
- **Default OFF / no regression:** on any per-shop deployment `API_KEY` is set, so the `||` short-circuits and the MoR branch is never evaluated — byte-identical to today.
- **Fail-open:** flag off/unset with `API_KEY` unset still throws `"Unauthorized!"` exactly as before — no new code path taken.
- **Idempotency:** pure header resolution, no state, no extra requests; add-to-cart de-dup is already handled backend-side (existing-item quantity merge in `add-product-to-cart.use-case.ts`). No double-add introduced.
- **Isolation:** only `fetchInstance.ts` + `variables.ts`. Does **not** touch the just-merged PDP/display files (`next.config.mjs`, `ProductSizeSelector.tsx`, `ProductSlider.tsx`, `[productId]/product/[slug]/**`, `ProductDescription.tsx`) and does **not** touch `fetchConfig.ts` (user/auth only, not the cart/checkout path).

---

## Activation runbook (operator — once shopsadiq's Stripe exists)

1. **Connect shopsadiq's Stripe to a droplinked shop.** Create/confirm the "shopsadiq ltd" shop and add a Stripe `PaymentMethod` (`shopPaymentMethodsV2`, `type=GATEWAY`, `gateway.provider=STRIPE`, `isEnabled=true`). For Connect destination charges set `gateway.accountId` + ensure `shop.stripeConnectChargesEnabled=true`; for platform-direct leave `accountId` null.
2. **Get the MoR shop-id** (the shopsadiq shop's ObjectId).
3. **Clear the backend ownership gate** (pick ONE):
   - **(a) Affiliate/consignment path — no code, ships today:** make the shopsadiq merchant an **agent** (`agentProfile`) and create an **ACTIVE `affiliateLink`** from that agent to every aggregate product to be sold. Then cross-shop add-to-cart passes `isAffiliateProduct` and the whole flow works with just the MoR shop-id. Distribution/merchant-share is already handled by `order-v2/use-cases/distribution/*`.
   - **(b) MoR cart mode — backend change (checklist below), NOT in this PR.**
4. **Set the FE env on the `shop.droplinked.com` deployment** (main.yml / dev-deploy.yml ENV_FILE, mirroring how `ROOT_CATALOG_ENABLED` is set): `NEXT_PUBLIC_MOR_SHOP_ID=<mor shop id>` + `NEXT_PUBLIC_MOR_CHECKOUT_ENABLED=true`. Redeploy (build-time inline).
5. **Verify the v1 endpoint first** (see caveat #1): `curl -H 'x-shop-id: <mor shop id>' https://apiv3.droplinked.com/v1/cart -X POST` returns a cart, not 404. If it 404s, Next-ShopFront's cart layer must be migrated to cart-v2 before this works.
6. **Dev-preview-URL review gate:** add-to-cart on `shop.droplinked.com/<id>` → reaches backend → cart under MoR shop → checkout mounts shopsadiq's Stripe → **one real test order** end-to-end before any prod sign-off. Green CI ≠ working.
7. **Rollback:** unset `NEXT_PUBLIC_MOR_CHECKOUT_ENABLED` (or set ≠ `"true"`) + redeploy. Reversible, no code revert.

---

## Backend implementation plan — MoR cart mode (option 3b — NOT shipped here)

Only needed if the affiliate/consignment path (3a) is undesirable at aggregate scale (a link per product). Precise checklist:

- [ ] **`src/modules/cart-v2/dtos/create-cart.dto.ts`** — add optional `isMoR?: boolean` (or `cartMode: 'STANDARD' | 'MOR'`), validated + default STANDARD. Persist on the cart (`CartV2` Prisma model + migration).
- [ ] **`src/modules/cart-v2/use-cases/add-product-to-cart.use-case.ts:181-191`** — extend the guard: when the cart is MoR mode, allow cross-shop products without an affiliate link. Keep the existing same-shop / affiliate branches as-is for STANDARD carts. Gate the whole bypass behind an env flag `CART_MOR_MODE_ENABLED` (default OFF, fail-closed to today's behavior).
- [ ] **Authorize MoR-cart creation** — only allow `isMoR=true` for an allowlisted MoR shop-id set (env `MOR_SHOP_IDS`) so arbitrary shops can't self-declare MoR and vacuum other merchants' catalog. Reject otherwise (fail-closed).
- [ ] **`src/modules/order-v2/use-cases/distribution/*`** — confirm merchant-share settlement for cross-shop MoR items without an `affiliateInfo` block (today the split keys off `affiliateInfo.originalShopId`, set only for affiliate products in `add-product-to-cart.use-case.ts:298-304`). Either populate an equivalent `originalShopId` on MoR items or add an explicit MoR settlement branch. **This is the money-correctness crux of 3b — do not ship without it.**
- [ ] **Preserve the `crt_` cart-token access model + `TransformInterceptor`/`CartResponseEncryptionInterceptor`** ordering (`cart.controller.ts:49-62`). No raw-ObjectId leakage.
- [ ] **Tests** — extend `add-product-to-cart-use-case.spec.ts` with MoR-mode cross-shop accept + non-allowlisted reject + distribution correctness.
- [ ] **Resolve the v1↔v2 mismatch** (caveat #1) — decide whether Next-ShopFront migrates to `v2/carts` or the legacy v1 surface is re-armed; the MoR mode must land on whichever surface the storefront actually calls.

---

## Quality gates
- `npm ci` present (552 pkgs). `npx tsc --noEmit`: **8 errors in 7 files — identical to the pre-existing baseline** (checkout address/shipping, PaymentModal, footer, Header, CartTrigger, empty-cart). **Zero new errors; none in the two touched files.**
- `npx next build`: **EXIT 0, 0 errors** (14 pre-existing warnings).
- Touched: `src/lib/fetchInstance.ts` (+33/-5), `src/lib/variables/variables.ts` (+29). Confirmed **none** of the just-merged display files touched.
