### PR TITLE
feat(checkout): flag-gated MoR Buy button on aggregate PDP (default OFF)

### DIFF
--- a/src/app/(routes)/[productId]/components/details/client/components/ProductCartActions.tsx
+++ b/src/app/(routes)/[productId]/components/details/client/components/ProductCartActions.tsx
@@ -2,34 +2,96 @@ import AppIcons from '@/assets/AppIcons';
 import { AppButton } from '@/components/ui';
 import useAppCart from '@/state/hooks/cart/useAppCart';
 import { useContext } from 'react';
+import { useParams } from 'next/navigation';
 import { toast } from 'sonner';
 import { ProductContext } from '../context';
+import { BASE_API_URL, MOR_CHECKOUT_ENABLED } from '@/lib/variables/variables';
 
 const ProductCartActions = () => {
-  const {states: { sku,  option: { quantity } } } = useContext(ProductContext);
+  const {
+    states: {
+      sku,
+      option: { quantity },
+    },
+  } = useContext(ProductContext);
   const { addItemToCart } = useAppCart();
+  const params = useParams();
 
-  const submit = async (e: React.FormEvent<HTMLFormElement>) =>
+  // Normal shop-scoped add-to-cart.
+  const addToCart = async (e: React.FormEvent<HTMLFormElement>) =>
     toast.promise(
       async () => {
         e.preventDefault();
         return await addItemToCart({ skuID: sku._id, quantity });
       },
-      { loading: 'Adding product to your cart...', success: 'Added to your cart!', error: 'Something went wrong.' }
+      {
+        loading: 'Adding product to your cart...',
+        success: 'Added to your cart!',
+        error: 'Something went wrong.',
+      },
     );
-    
+
+  // Merchant-of-Record checkout (flag-gated). The aggregate storefront root has
+  // no shop context, so Buy routes through the backend MoR endpoint (platform
+  // Stripe as MoR) → Stripe Checkout, which collects the email. A per-attempt
+  // cartToken is the idempotency key so a retried click never double-creates.
+  const morCheckout = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    return toast.promise(
+      async () => {
+        const raw = params?.productId;
+        const productId = Array.isArray(raw) ? raw[0] : raw;
+        if (!productId || !sku?._id) throw new Error('Missing product or variant');
+        const cartToken =
+          globalThis.crypto?.randomUUID?.() ??
+          `mor-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const base = (BASE_API_URL || '').replace(/\/$/, '');
+        const res = await fetch(`${base}/mor-checkout/session`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ productId, skuId: sku._id, quantity, cartToken }),
+        });
+        if (!res.ok) throw new Error(`Checkout unavailable (${res.status})`);
+        const json = await res.json().catch(() => ({}));
+        const url = json?.data?.checkoutUrl ?? json?.checkoutUrl;
+        if (!url) throw new Error('No checkout URL returned');
+        window.location.href = url;
+        return url;
+      },
+      {
+        loading: 'Starting secure checkout…',
+        success: 'Redirecting to checkout…',
+        error: 'Checkout is unavailable right now.',
+      },
+    );
+  };
+
   return (
     <div className="flex w-full gap-6">
       <div className="min-w-fit">
-        <AppButton appClassName="rounded-sm w-full" hasIcon appVariant="outlined" appSize="lg">
+        <AppButton
+          appClassName="rounded-sm w-full"
+          hasIcon
+          appVariant="outlined"
+          appSize="lg"
+        >
           <AppIcons.Merch />
           Mint to Merch
         </AppButton>
       </div>
-      <form className="w-full" onSubmit={submit}>
-        <AppButton type="submit" appClassName="rounded-sm w-full" hasIcon appVariant="filled" appSize="lg">
+      <form
+        className="w-full"
+        onSubmit={MOR_CHECKOUT_ENABLED ? morCheckout : addToCart}
+      >
+        <AppButton
+          type="submit"
+          appClassName="rounded-sm w-full"
+          hasIcon
+          appVariant="filled"
+          appSize="lg"
+        >
           <AppIcons.CartLight />
-          Add to cart
+          {MOR_CHECKOUT_ENABLED ? 'Buy now' : 'Add to cart'}
         </AppButton>
       </form>
     </div>

--- a/src/lib/variables/variables.ts
+++ b/src/lib/variables/variables.ts
@@ -13,6 +13,17 @@ export const APP_DEVELOPMENT = process.env.NEXT_PUBLIC_APP_DEVELOPMENT === "true
  */
 export const ROOT_CATALOG_ENABLED =
   process.env.NEXT_PUBLIC_ROOT_CATALOG_ENABLED === "true";
+
+/**
+ * Merchant-of-Record checkout for the aggregate storefront. When ON, the Buy
+ * button on an aggregate PDP routes through the backend `POST /mor-checkout/
+ * session` (droplinked's platform Stripe as MoR) → Stripe Checkout, instead of
+ * the shop-scoped cart (which the aggregate root has no shop context for).
+ * NEXT_PUBLIC_ so Next inlines it at build time. Default OFF — set
+ * NEXT_PUBLIC_MOR_CHECKOUT_ENABLED=true to enable (reversible, no code revert).
+ */
+export const MOR_CHECKOUT_ENABLED =
+  process.env.NEXT_PUBLIC_MOR_CHECKOUT_ENABLED === "true";
 export const variantIDs = { color: { _id: "62a989ab1f2c2bbc5b1e7153" }, size: { _id: "62a989e21f2c2bbc5b1e7154" } };
 export const app_vertical = "flex flex-col items-center justify-center";
 export const app_center = "flex items-center justify-center";


### PR DESCRIPTION
## Closes / addresses
FE last-mile of the Merchant-of-Record checkout (droplinked-backend **#2965** / **#2966**, 3rdp-integration-services **#379**). Makes aggregate/imported products on shop.droplinked.com purchasable.

## What
On the interactive aggregate PDP, when **`NEXT_PUBLIC_MOR_CHECKOUT_ENABLED=true`**, the Buy button ("Buy now") POSTs to the backend **`POST /mor-checkout/session`** `{productId, skuId, quantity, cartToken}` and redirects to the returned Stripe Checkout URL. Stripe collects the email; the backend webhook records the `MorOrder`.
- Platform Stripe (the SaaS-billing account) acts as MoR — no new Stripe, no parallel path.
- `cartToken = crypto.randomUUID()` per attempt = the idempotency key (retried click never double-creates a session).
- Fail-open via `toast.promise` — an error toasts, never crashes.

## Scope / safety
- **Default OFF** (flag absent) → button stays "Add to cart" with the exact current behaviour. Zero change on prod until the flag is set.
- 2 files (`variables.ts` flag + `ProductCartActions.tsx`). tsc clean; `next build` Errors: 0.
- No new `t()` keys (existing toasts are plain strings — matches surrounding code).
- Base `main` (shop.droplinked.com deploys from main); inert until activation.

## Activation
Set `NEXT_PUBLIC_MOR_CHECKOUT_ENABLED=true` on the storefront deployment AND `MOR_CHECKOUT_ENABLED=true` on apiv3 + `/stripe/checkout-payment` live on the integration service, then a test order on the platform TEST key before prod.