### PR TITLE
ACTIVATE: NEXT_PUBLIC_MOR_CHECKOUT_ENABLED=true on shop.droplinked.com

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,7 @@ jobs:
         # prod API host. Revert this single line to fall back to the previous
         # behaviour (root redirects to /home).
         echo "NEXT_PUBLIC_ROOT_CATALOG_ENABLED=true" >> .env
+        echo "NEXT_PUBLIC_MOR_CHECKOUT_ENABLED=true" >> .env
 
     - name: Build, tag, and push image to Amazon ECR
       id: build-image


### PR DESCRIPTION
Activates the aggregate-PDP MoR Buy button on shop.droplinked.com (pairs with backend #2968). FE #158 on prod, default OFF; this flips it. Isolated to Next-ShopFront — merchant-direct shops (droplinked-shopfront) unaffected. Real money (live Stripe) — controlled test order at go-live.