### PR TITLE
fix(checkout): MoR Buy → same-origin /api proxy (was hitting a 404 relative URL)

### DIFF
--- a/src/app/(routes)/[productId]/components/details/client/components/ProductCartActions.tsx
+++ b/src/app/(routes)/[productId]/components/details/client/components/ProductCartActions.tsx
@@ -5,7 +5,7 @@ import { useContext } from 'react';
 import { useParams } from 'next/navigation';
 import { toast } from 'sonner';
 import { ProductContext } from '../context';
-import { BASE_API_URL, MOR_CHECKOUT_ENABLED } from '@/lib/variables/variables';
+import { MOR_CHECKOUT_ENABLED } from '@/lib/variables/variables';
 
 const ProductCartActions = () => {
   const {
@@ -45,8 +45,10 @@ const ProductCartActions = () => {
         const cartToken =
           globalThis.crypto?.randomUUID?.() ??
           `mor-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-        const base = (BASE_API_URL || '').replace(/\/$/, '');
-        const res = await fetch(`${base}/mor-checkout/session`, {
+        // Same-origin proxy (BASE_API_URL is not inlined in the client bundle;
+        // the aggregate root has no x-shop-id). The /api route forwards to
+        // apiv3's public /mor-checkout/session server-side.
+        const res = await fetch(`/api/mor-checkout/session`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ productId, skuId: sku._id, quantity, cartToken }),

--- a/src/app/api/mor-checkout/session/route.ts
+++ b/src/app/api/mor-checkout/session/route.ts
@@ -1,0 +1,31 @@
+import { BASE_API_URL } from '@/lib/variables/variables';
+import { NextResponse } from 'next/server';
+
+/**
+ * Same-origin proxy for the public Merchant-of-Record checkout endpoint.
+ *
+ * The aggregate storefront root has no shop identity, so the client cannot call
+ * apiv3 directly (`fetchInstance` throws without an x-shop-id, and
+ * NEXT_PUBLIC_BASE_API_URL is not inlined in the client bundle). This route runs
+ * SERVER-SIDE, where BASE_API_URL is set, and forwards to apiv3's PUBLIC
+ * `/mor-checkout/session` (no x-shop-id). Mirrors `src/app/api/products/route.ts`.
+ */
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const base = (BASE_API_URL || '').replace(/\/$/, '');
+    const res = await fetch(`${base}/mor-checkout/session`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (error: unknown) {
+    console.error('mor-checkout proxy error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Internal Server Error' },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Problem (live)
Buy now on shop.droplinked.com → 'Checkout is unavailable'. Browser network showed the POST going to **`shop.droplinked.com/mor-checkout/session` → 404** (relative URL), not apiv3.

## Root cause
The FE did `fetch(`${BASE_API_URL}/mor-checkout/session`)` but **NEXT_PUBLIC_BASE_API_URL isn't inlined in the client bundle** → `BASE_API_URL` empty client-side → relative path → 404. (CORS + the Stripe key were fine — server-side the endpoint returns a real `cs_live_` session.)

## Fix
Same-origin **`/api/mor-checkout/session`** proxy (server-side, where BASE_API_URL is set; the endpoint is `@Public` so no x-shop-id) → forwards to apiv3. FE calls `/api/mor-checkout/session`. Mirrors `/api/products`, `/api/cart`.

## Scope
2 files. tsc clean; `next build` Errors: 0. Base main (storefront). Unblocks the live MoR checkout.