### PR TITLE
fix(seo): serve IndexNow key via route handler (public/ was shadowed)

### DIFF
--- a/src/app/05ebd3aff4983438b8b06f39b0741893.txt/route.ts
+++ b/src/app/05ebd3aff4983438b8b06f39b0741893.txt/route.ts
@@ -1,0 +1,25 @@
+/**
+ * IndexNow key verification file — served at
+ * /05ebd3aff4983438b8b06f39b0741893.txt as text/plain.
+ *
+ * A route handler (not public/) because the root `(routes)/[productId]`
+ * dynamic catch-all intercepts bare `/<name>.txt` paths before Next's public/
+ * static files are served on this deployment — so public/<key>.txt rendered the
+ * SSR shell (soft-200) and IndexNow could not verify it. An explicit route
+ * segment takes precedence over the dynamic catch-all, guaranteeing the raw key.
+ *
+ * IndexNow requires this to return EXACTLY the key (no markup, no trailing
+ * newline). Mirrors robots.ts / sitemap.ts (route-generated SEO artifacts).
+ */
+export const dynamic = "force-static";
+
+const INDEXNOW_KEY = "05ebd3aff4983438b8b06f39b0741893";
+
+export function GET() {
+  return new Response(INDEXNOW_KEY, {
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "public, max-age=86400",
+    },
+  });
+}


### PR DESCRIPTION
## Problem

#166 added `public/05ebd3aff4983438b8b06f39b0741893.txt`, deployed successfully — but `shop.droplinked.com/{key}.txt` still returns the Next SSR HTML shell, not the key.

Root cause: the root `(routes)/[productId]` **dynamic catch-all** intercepts bare `/<name>.txt` paths before Next serves `public/` static files on this deployment. Evidence: the response carries `cache-control: private, no-cache, no-store` (the dynamic-render signature) whereas the working `public/llms.txt` carries `public, max-age=0` (static). IndexNow rejects the HTML — it requires the file to return the exact key.

## Fix

Serve the key from an explicit **route handler** at `src/app/05ebd3aff4983438b8b06f39b0741893.txt/route.ts` (`force-static`, `text/plain`, exact 32-char key, no trailing newline). An explicit route segment takes precedence over the dynamic `[productId]` catch-all, so the raw key is returned deterministically. Same mechanism as `robots.ts` / `sitemap.ts`, which serve fine.

## Scope / risk

One route handler, `force-static` (prerendered). No runtime cost, no effect on any other route. Next 15.5.19.

## After deploy

`shop.droplinked.com/{key}.txt` → raw key → IndexNow can verify → seed the marketplace PDP corpus (Bing → ChatGPT search + Copilot).