### PR TITLE
perf(marketplace): raise PDP ISR 5min → 1h (catalogue-scale cost guardrail)

### DIFF
--- a/src/app/(routes)/marketplace/[advertiserId]/[itemId]/[slug]/lib/marketplace-data.ts
+++ b/src/app/(routes)/marketplace/[advertiserId]/[itemId]/[slug]/lib/marketplace-data.ts
@@ -248,7 +248,10 @@ export async function fetchMarketplaceItem(
   let response: Response;
   try {
     response = await fetch(url, {
-      next: { revalidate: 300 },
+      // 1h cache — matches the page ISR window + the apiv3 endpoint's
+      // Cache-Control: max-age=3600. Cost guardrail: minimizes origin fetches
+      // as the marketplace corpus scales.
+      next: { revalidate: 3600 },
       headers: {
         Accept: "application/json",
         "User-Agent": `${SITE.name}-shopfront/1.0 (marketplace-pdp)`,

--- a/src/app/(routes)/marketplace/[advertiserId]/[itemId]/[slug]/page.tsx
+++ b/src/app/(routes)/marketplace/[advertiserId]/[itemId]/[slug]/page.tsx
@@ -24,7 +24,7 @@
  *
  * Data source (apiv3, @Public, no auth):
  *   GET /v2/marketplace/:advertiserId/:itemId
- * ISR: revalidate every 5 minutes. Fully 5xx-safe (notFound() on null).
+ * ISR: revalidate hourly. Fully 5xx-safe (notFound() on null).
  */
 
 import { notFound } from "next/navigation";
@@ -37,8 +37,12 @@ import {
   type MarketplaceView,
 } from "./lib/marketplace-data";
 
-// ISR — revalidate every 5 minutes (matches the sibling product page).
-export const revalidate = 300;
+// ISR — revalidate hourly. Affiliate items change rarely (price/availability
+// come from the retailer feed, refreshed nightly), so a 1h window slashes
+// re-render/origin-fetch volume ~12x vs 5min as the marketplace corpus scales
+// to tens of thousands of PDPs — the cost guardrail for catalogue expansion.
+// Aligns with the apiv3 endpoint's own Cache-Control: max-age=3600.
+export const revalidate = 3600;
 
 interface PageProps {
   params: Promise<{ advertiserId: string; itemId: string; slug: string }>;


### PR DESCRIPTION
## What

Raises the affiliate marketplace PDP ISR window from **5 min → 1 h**, in both places:
- `page.tsx`: `export const revalidate = 3600` (was 300)
- `marketplace-data.ts`: `fetch(..., { next: { revalidate: 3600 } })` (was 300)

## Why (cost guardrail for catalogue expansion)

As the marketplace corpus scales (8 → 29 → up to ~40k PDPs), a 5-min ISR window means each crawled URL can trigger a re-render + a fresh apiv3 origin fetch every 5 minutes. Affiliate price/availability come from the retailer feed (refreshed nightly), so **1 h is plenty fresh** and cuts re-render + origin-fetch volume **~12×**. Aligns with the apiv3 `/v2/marketplace` endpoint's own `Cache-Control: max-age=3600`.

No behaviour change beyond cache TTL. Native storefront PDPs untouched.

## Context / follow-up (not in this PR)

Verified while doing this: `shop.droplinked.com` is **not behind CloudFront**, and the marketplace PDP emits `cache-control: private, no-cache` — so the HTML isn't edge-cached; every crawl hits origin (served from the ISR render cache, so cheap, but request-volume-bound). If crawler/agent volume grows materially, fronting `/marketplace/*` with CloudFront + a public `Cache-Control` is the bigger lever — flagged for a future infra pass.