### PR TITLE
perf(marketplace): public shared-cache header on /marketplace/* (CloudFront prep)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -74,6 +74,25 @@ const nextConfig = {
                     },
                 ],
             },
+            {
+                // Affiliate marketplace PDPs are ISR (revalidate 1h) + change
+                // rarely (retailer feed refreshes nightly). Emit a PUBLIC,
+                // shared-cacheable header so a CDN / crawler cache can absorb
+                // repeat crawls instead of hitting origin every time — the cost
+                // guardrail as the corpus scales, and the prerequisite for
+                // fronting /marketplace/* with CloudFront (which honours
+                // s-maxage). stale-while-revalidate keeps it snappy across the
+                // revalidate boundary. Scoped to /marketplace/* ONLY — the rest
+                // of the storefront (cart/checkout/account) keeps its default
+                // no-cache behaviour.
+                source: '/marketplace/:path*',
+                headers: [
+                    {
+                        key: 'Cache-Control',
+                        value: 'public, s-maxage=3600, stale-while-revalidate=86400',
+                    },
+                ],
+            },
         ];
     },
     webpack(config, options) {


### PR DESCRIPTION
Scopes a `Cache-Control: public, s-maxage=3600, stale-while-revalidate=86400` header to `/marketplace/:path*` via next.config `headers()`, so a CDN/crawler cache can absorb repeat crawls of the affiliate PDPs instead of every hit reaching origin. Prerequisite for fronting `/marketplace/*` with CloudFront (honours s-maxage). Scoped to /marketplace/* only — cart/checkout/account keep default no-cache. Verify post-deploy the header flips from `private,no-cache` → `public,s-maxage`; if Next still overrides it at the page layer, the authoritative caching moves to the CloudFront cache policy (separate CDN cutover) and this remains harmless.