### PR TITLE
feat(seo): host Bing Webmaster site-verification (/BingSiteAuth.xml)

### DIFF
--- a/src/app/BingSiteAuth.xml/route.ts
+++ b/src/app/BingSiteAuth.xml/route.ts
@@ -1,0 +1,23 @@
+/**
+ * Bing Webmaster Tools site-verification file — served at /BingSiteAuth.xml.
+ *
+ * A route handler (not public/) for the same reason as the IndexNow key: the
+ * root (routes)/[productId] dynamic catch-all shadows bare public/ files, so
+ * public/BingSiteAuth.xml would render the SSR shell and Bing verification would
+ * fail. An explicit route segment takes precedence and returns the exact XML.
+ */
+export const dynamic = "force-static";
+
+const BING_SITE_AUTH = `<?xml version="1.0"?>
+<users>
+	<user>23995FC2C54A0CB9B1F3DF0CB74676ED</user>
+</users>`;
+
+export function GET() {
+  return new Response(BING_SITE_AUTH, {
+    headers: {
+      "content-type": "text/xml; charset=utf-8",
+      "cache-control": "public, max-age=86400",
+    },
+  });
+}


### PR DESCRIPTION
Serves `/BingSiteAuth.xml` (verification code `23995FC2…76ED`) so shop.droplinked.com can be added + verified in Bing Webmaster Tools — unlocking Bing search-performance analytics for the marketplace PDPs, which feeds the weekly discovery report's Bing section. Route handler (not public/) for the same reason as the IndexNow key: the root `[productId]` catch-all shadows bare public/ files. Returns exact XML as text/xml.