### PR TITLE
fix(gmc): shop.droplinked.com shows the full approved catalog (POD + physical + digital)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,6 +43,10 @@ export default async function RootPage() {
     redirect("/home");
   }
 
-  const catalog = await fetchMarketplaceCatalog({ page: 1, limit: 48, type: "physical" });
+  // No `type` filter — show the full approved MoR/GMC catalog (physical + pod +
+  // digital). The feed is mostly `pod`, so filtering to physical showed almost
+  // nothing on the root grid. Limit high enough to surface the whole approved
+  // catalog on the single-page grid (no client pagination here).
+  const catalog = await fetchMarketplaceCatalog({ page: 1, limit: 200 });
   return <MarketplaceCatalog products={catalog.products} total={catalog.total} />;
 }

--- a/src/lib/catalog/marketplace-catalog-data.ts
+++ b/src/lib/catalog/marketplace-catalog-data.ts
@@ -109,10 +109,13 @@ export async function fetchMarketplaceCatalog(params?: {
 }): Promise<MarketplaceCatalog> {
   const page = params?.page ?? 1;
   const limit = params?.limit ?? 48;
-  const type = params?.type ?? "physical";
-  const url = `${APIV3_BASE}/product-v2/public/marketplace?page=${page}&limit=${limit}&type=${encodeURIComponent(
-    type,
-  )}`;
+  // No `type` → show ALL shoppable product types (physical + pod + digital).
+  // The MoR / GMC feed catalog is mostly `pod` (print-on-demand), so defaulting
+  // to `physical` hid it — the root grid must mirror the full approved catalog,
+  // not just physical goods. Callers can still pass an explicit type to narrow.
+  const type = params?.type;
+  const typeParam = type ? `&type=${encodeURIComponent(type)}` : "";
+  const url = `${APIV3_BASE}/product-v2/public/marketplace?page=${page}&limit=${limit}${typeParam}`;
 
   let response: Response;
   try {


### PR DESCRIPTION
## Problem (GMC-blocking)
`shop.droplinked.com` showed **one product**. The root marketplace grid hardcoded `type=physical`, but the approved MoR/GMC catalog is mostly **`type=pod`** (print-on-demand): across the feed shops there are **56 pod + 1 physical + 3 digital**. The physical-only filter hid all 56 POD items.

## Fix
- Drop the `type=physical` filter — the apiv3 `public/marketplace` endpoint returns **all shoppable types** when `type` is omitted (verified: 60 products vs 1).
- Raise the grid limit (48→200) so the whole approved catalog renders on the single-page (non-paginated) grid.

## Effect
The storefront now shows the same shops' approved products the GMC feed advertises (~60 live), so Google's Misrepresentation review sees the store match the feed. ISR-cached 5 min, so it reflects within minutes of deploy.

## Verify
`tsc --noEmit` clean; single caller updated; API confirmed to return pod (56) + physical (1) + digital (3). Pairs with the backend storefront↔feed allowlist sync (#3060, already live).