### PR TITLE
fix(gmc): clamp marketplace limit to 100 (200 returned empty grid)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,8 +45,9 @@ export default async function RootPage() {
 
   // No `type` filter — show the full approved MoR/GMC catalog (physical + pod +
   // digital). The feed is mostly `pod`, so filtering to physical showed almost
-  // nothing on the root grid. Limit high enough to surface the whole approved
-  // catalog on the single-page grid (no client pagination here).
-  const catalog = await fetchMarketplaceCatalog({ page: 1, limit: 200 });
+  // nothing on the root grid. limit=100 is the apiv3 max (DTO @Max(100)) and
+  // covers the whole approved catalog on the single-page grid (>100 would fail
+  // validation and return an empty grid).
+  const catalog = await fetchMarketplaceCatalog({ page: 1, limit: 100 });
   return <MarketplaceCatalog products={catalog.products} total={catalog.total} />;
 }

--- a/src/lib/catalog/marketplace-catalog-data.ts
+++ b/src/lib/catalog/marketplace-catalog-data.ts
@@ -108,7 +108,9 @@ export async function fetchMarketplaceCatalog(params?: {
   type?: "physical" | "digital" | "pod";
 }): Promise<MarketplaceCatalog> {
   const page = params?.page ?? 1;
-  const limit = params?.limit ?? 48;
+  // Clamp to the apiv3 max (DTO @Max(100)): a limit >100 fails validation and
+  // the endpoint returns an empty grid, so never let a caller exceed it.
+  const limit = Math.min(params?.limit ?? 48, 100);
   // No `type` → show ALL shoppable product types (physical + pod + digital).
   // The MoR / GMC feed catalog is mostly `pod` (print-on-demand), so defaulting
   // to `physical` hid it — the root grid must mirror the full approved catalog,


### PR DESCRIPTION
**Follow-up to #171.** #171 set the root grid `limit=200`, but apiv3's `public/marketplace` DTO caps limit at `@Max(100)` — a limit >100 fails validation and returns an **empty grid (0 products)**. Set the grid to **100** (the max; covers the whole ~60-item approved catalog) and clamp in the loader so no caller can exceed the server max again. `tsc` clean; `limit=100` verified to return 60.