### PR TITLE
feat(pdp): unify the product page — buy-in-place on the SEO landing route

### DIFF
--- a/src/app/(routes)/[productId]/components/ProductExperience.tsx
+++ b/src/app/(routes)/[productId]/components/ProductExperience.tsx
@@ -1,0 +1,45 @@
+/**
+ * ProductExperience — the ONE shared, interactive product body.
+ *
+ * WHY THIS EXISTS (the "two experiences" consolidation)
+ * -----------------------------------------------------
+ * The same product was reachable at two URLs with two different bodies:
+ *   • /<productId>                       → this interactive body (slider +
+ *     variant/qty/Buy-now/Mint + description), fed by getInteractiveProduct().
+ *   • /<merchant>/product/<slug>         → a SEO landing page that rendered a
+ *     static price teaser off the lean structured-data endpoint (sparse images →
+ *     black thumbnails) and a "Buy now" that BOUNCED to /<productId>.
+ *
+ * A shopper (or Googlebot) landing on the GMC-registered slug URL hit a
+ * read-only dead-end and had to jump to a second page to transact. This
+ * component is the single body both routes now render, so the slug landing
+ * page is fully transactional (Buy in place) with the SAME rich media the
+ * interactive route uses — no bounce, no divergent image set.
+ *
+ * Server component (no 'use client'): it only composes the client subtrees
+ * (ProductSlider / ProductDetails→ProductClient / ProductDescription), which
+ * carry their own interactivity + cart context. Rendering it under the SSR
+ * slug route keeps the price/title/availability in the server HTML for the
+ * GMC landing-page crawler while hydrating Buy-now on the client.
+ */
+
+import { AppSeparator } from '@/components/ui';
+import type { IProduct } from '@/types/interfaces/product/product';
+import ProductSlider from './ProductSlider';
+import ProductDetails from './details/ProductDetails';
+import ProductDescription from './ProductDescription';
+
+export default function ProductExperience({ product }: { product: IProduct }) {
+  return (
+    <main className="container px-8 flex items-start md:flex-row flex-col justify-center w-full gap-12 mt-20">
+      <div className="min-w-full md:min-w-[40%] md:sticky left-0 top-24">
+        <ProductSlider media={product?.media} />
+      </div>
+      <div className="flex flex-col gap-9 min-w-full md:min-w-[60%]">
+        <ProductDetails product={product} />
+        <AppSeparator />
+        <ProductDescription description={product?.description || ''} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(routes)/[productId]/page.tsx
+++ b/src/app/(routes)/[productId]/page.tsx
@@ -1,11 +1,7 @@
 'use server';
 
 import { notFound } from 'next/navigation';
-import ProductDescription from './components/ProductDescription';
-import ProductDetails from './components/details/ProductDetails';
-
-import { AppSeparator } from '@/components/ui';
-import ProductSlider from './components/ProductSlider';
+import ProductExperience from './components/ProductExperience';
 import { getInteractiveProduct } from './lib/product-data';
 
 // type IProps = { params: { productId: string } };
@@ -18,16 +14,8 @@ export default async function Page({ params } : { params: Promise<{ productId: s
   const data = await getInteractiveProduct(productId);
   if (!data) notFound();
 
-  return (
-    <main className="container px-8 flex items-start md:flex-row flex-col justify-center w-full gap-12 mt-20">
-      <div className="min-w-full md:min-w-[40%] md:sticky left-0 top-24">
-        <ProductSlider media={data?.media} />
-      </div>
-      <div className="flex flex-col gap-9 min-w-full md:min-w-[60%]">
-        <ProductDetails product={data} />
-        <AppSeparator />
-        <ProductDescription description={data?.description || ''} />
-      </div>
-    </main>
-  );
+  // ProductExperience is the ONE shared body — the same interactive slider +
+  // Buy-now + description now also rendered by the /<merchant>/product/<slug>
+  // SEO landing page, so there is a single product experience across both URLs.
+  return <ProductExperience product={data} />;
 }

--- a/src/app/(routes)/[productId]/product/[slug]/page.tsx
+++ b/src/app/(routes)/[productId]/product/[slug]/page.tsx
@@ -40,6 +40,9 @@ import {
 } from "./lib/structured-data";
 import { sanitizeHtml, htmlToText } from "./lib/sanitize-html";
 import { POLICY } from "@/lib/site";
+import { UNIFIED_PDP_ENABLED } from "@/lib/variables/variables";
+import { getInteractiveProduct } from "../../lib/product-data";
+import ProductExperience from "../../components/ProductExperience";
 import styles from "./description.module.css";
 
 // ISR — revalidate every 5 minutes.
@@ -122,23 +125,49 @@ export default async function ProductPage({ params }: PageProps) {
   // structured-data payload carried no product id.
   const purchaseUrl = data.productId ? `/${data.productId}` : view.canonicalUrl;
 
+  // ── Unified PDP ────────────────────────────────────────────────────────
+  // When enabled, resolve the SAME rich interactive product the /<productId>
+  // route uses and render the shared transactional body IN PLACE — so this
+  // GMC-registered landing URL becomes buy-in-place (no bounce) and shares the
+  // rich media (fixes the sparse structured-data thumbnails). Fail-open: any
+  // miss (flag off, no productId, loader null) falls back to the static teaser
+  // below, so the landing page never regresses to content-less for GMC.
+  const interactiveProduct =
+    UNIFIED_PDP_ENABLED && data.productId
+      ? await getInteractiveProduct(data.productId)
+      : null;
+
+  // Schema.org Product JSON-LD — host-normalised to shop.droplinked.com. This
+  // is what Googlebot / GMC's landing-page check reads to match the feed item.
+  // Emitted in BOTH branches (interactive + teaser) so crawlability is
+  // identical regardless of the rendered body. Inline per App Router convention.
+  const jsonLdScript = (
+    <script
+      type="application/ld+json"
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{
+        // JSON-LD description is a TEXT field — flatten the imported HTML so
+        // GMC/Googlebot reads a clean product description, not raw markup.
+        __html: JSON.stringify({
+          ...data.jsonLd,
+          description: htmlToText(data.jsonLd.description, 5000),
+        }),
+      }}
+    />
+  );
+
+  if (interactiveProduct) {
+    return (
+      <>
+        {jsonLdScript}
+        <ProductExperience product={interactiveProduct} />
+      </>
+    );
+  }
+
   return (
     <>
-      {/* Schema.org Product JSON-LD — host-normalised to shop.droplinked.com.
-          This is what Googlebot / GMC's landing-page check reads to match
-          the feed item. Inline per Next.js App Router convention. */}
-      <script
-        type="application/ld+json"
-        // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{
-          // JSON-LD description is a TEXT field — flatten the imported HTML so
-          // GMC/Googlebot reads a clean product description, not raw markup.
-          __html: JSON.stringify({
-            ...data.jsonLd,
-            description: htmlToText(data.jsonLd.description, 5000),
-          }),
-        }}
-      />
+      {jsonLdScript}
 
       <main className="container mx-auto px-6 md:px-8 py-12 flex flex-col md:flex-row items-start gap-10 max-w-6xl">
         {/* ── media column ── */}

--- a/src/lib/variables/variables.ts
+++ b/src/lib/variables/variables.ts
@@ -24,6 +24,21 @@ export const ROOT_CATALOG_ENABLED =
  */
 export const MOR_CHECKOUT_ENABLED =
   process.env.NEXT_PUBLIC_MOR_CHECKOUT_ENABLED === "true";
+
+/**
+ * Unified PDP: render the full interactive product body (slider + variant/qty +
+ * Buy-now/Mint + description) on the SEO landing page `/<merchant>/product/
+ * <slug>` instead of the static price teaser that bounced to `/<productId>`.
+ * When ON, the GMC-registered landing URL is transactional in place and shares
+ * the same rich media as the interactive route (fixes the sparse structured-
+ * data thumbnails). When OFF, the landing page keeps today's static teaser so
+ * the GMC landing-page check never regresses.
+ * NEXT_PUBLIC_ so Next inlines it at build time (standalone runner carries no
+ * .env). Default OFF — set NEXT_PUBLIC_UNIFIED_PDP_ENABLED=true to enable
+ * (reversible, no code revert).
+ */
+export const UNIFIED_PDP_ENABLED =
+  process.env.NEXT_PUBLIC_UNIFIED_PDP_ENABLED === "true";
 export const variantIDs = { color: { _id: "62a989ab1f2c2bbc5b1e7153" }, size: { _id: "62a989e21f2c2bbc5b1e7154" } };
 export const app_vertical = "flex flex-col items-center justify-center";
 export const app_center = "flex items-center justify-center";


### PR DESCRIPTION
Replaces #174 (auto-closed when its stacked base branch `chore/reconcile-dev-with-main` was deleted on merge of #173). Reconcile is now in `dev`; this PR carries **only** the unified-PDP commit.

## Problem
The same product was two disjoint experiences: the GMC-registered slug URL (`/<merchant>/product/<slug>`) was a read-only teaser (sparse structured-data images → **black thumbnails**, a Buy-now that **bounced** to `/<productId>`), while the real Buy/variant/qty lived only at the id URL.

## Fix
- **`ProductExperience`** — one shared interactive body (slider + Buy-now + description); both routes render it.
- SEO route renders it **in place** behind `NEXT_PUBLIC_UNIFIED_PDP_ENABLED`, keeping `fetchStructuredData` **only** for JSON-LD + canonical (GMC crawlability preserved — script emitted in both branches) and resolving the **same** `getInteractiveProduct()` → rich media fixes the thumbnails.
- **Fail-open** → flag off / no productId / loader null falls back to today's teaser; GMC page never regresses.
- Flag defaults OFF (`NEXT_PUBLIC_`). MoR buy already wired via `MOR_CHECKOUT_ENABLED`.

## Verification
`tsc` 0 errors · smoke 3/3 · ESLint clean · `next build` exit 0.

## Rollout
Merge → `NEXT_PUBLIC_UNIFIED_PDP_ENABLED=true` on **dev** → preview the slug URL → flip prod after sign-off (page is mid-GMC-reinstatement, stays gated).

## Closes / addresses
Consolidates the dual MoR product-page experience into one buy-in-place page + fixes landing-page thumbnails. Supersedes #174.