### PR TITLE
ci(dev): enable unified PDP + MoR checkout on the dev preview

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -65,6 +65,17 @@ jobs:
         # ROOT_CATALOG_ENABLED absent = OFF, so the prod root keeps redirecting
         # to /home until an explicit prod enablement.
         echo "NEXT_PUBLIC_ROOT_CATALOG_ENABLED=true" >> .env
+        # --- Unified PDP + MoR checkout: dev preview 2026-07-15 ---
+        # UNIFIED_PDP: render the interactive product body (slider + Buy-now +
+        # description) on the SEO landing page /<merchant>/product/<slug> instead
+        # of the static teaser that bounced to /<productId>. MOR_CHECKOUT: route
+        # the aggregate-root Buy-now through the platform MoR Stripe session
+        # (POST /mor-checkout/session) — the aggregate root has no shop-scoped
+        # cart context, so the unified PDP's Buy only completes with this ON.
+        # Prod (main.yml) already has MOR_CHECKOUT on; UNIFIED_PDP stays OFF on
+        # prod until sign-off (this is the GMC-reinstatement landing page).
+        echo "NEXT_PUBLIC_UNIFIED_PDP_ENABLED=true" >> .env
+        echo "NEXT_PUBLIC_MOR_CHECKOUT_ENABLED=true" >> .env
         echo "APIV3_BASE_URL=https://apiv3dev.droplinked.com" >> .env
     
     - name: Build, tag, and push image to Amazon ECR


### PR DESCRIPTION
Flips the dev preview flags so you can review the unified product page:
- `NEXT_PUBLIC_UNIFIED_PDP_ENABLED=true` — the `/<merchant>/product/<slug>` landing page now renders the interactive **buy-in-place** body (from #175) instead of the static teaser.
- `NEXT_PUBLIC_MOR_CHECKOUT_ENABLED=true` — prod already has this; dev didn't. The aggregate root has no shop-scoped cart, so the unified PDP's Buy only completes via the MoR Stripe session with this ON. Also matches the PSP-agent's MoR dev-shop testing.

**Prod stays OFF** for UNIFIED_PDP (main.yml unset) until you sign off on the dev preview — this is the GMC-reinstatement landing page. Reversible via env, no code revert.

## Closes / addresses
Enables the #175 unified PDP on dev for preview before any prod flip.