### PR TITLE
ci(prod): enable unified PDP on prod — HOLD until dev preview sign-off

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,15 @@ jobs:
         # behaviour (root redirects to /home).
         echo "NEXT_PUBLIC_ROOT_CATALOG_ENABLED=true" >> .env
         echo "NEXT_PUBLIC_MOR_CHECKOUT_ENABLED=true" >> .env
+        # --- Unified PDP: PROD enablement 2026-07-15 ---
+        # Render the interactive buy-in-place body on the SEO landing page
+        # /<merchant>/product/<slug> (the GMC-registered URL) instead of the
+        # static teaser that bounced to /<productId>. Verified on the dev
+        # preview first. Fail-open in code (falls back to the teaser if the
+        # interactive product can't be resolved), so this never regresses the
+        # GMC landing-page check. Revert this single line to fall back to the
+        # static teaser (reversible, no code revert).
+        echo "NEXT_PUBLIC_UNIFIED_PDP_ENABLED=true" >> .env
 
     - name: Build, tag, and push image to Amazon ECR
       id: build-image


### PR DESCRIPTION
## HELD — do not merge until the dev preview (#176) is signed off

Flips the single prod flag `NEXT_PUBLIC_UNIFIED_PDP_ENABLED=true` so the GMC-registered landing page `/<merchant>/product/<slug>` renders the interactive **buy-in-place** body (from #175) instead of the static teaser that bounced to `/<productId>`.

- Prod already has `NEXT_PUBLIC_MOR_CHECKOUT_ENABLED=true` + `ROOT_CATALOG_ENABLED=true`, so aggregate-root Buy-now completes via the platform MoR Stripe session — no other prod flag needed.
- **Fail-open in code:** if the interactive product can't be resolved, the page falls back to today's static teaser (JSON-LD emitted in both branches), so this **cannot regress** the GMC landing-page check.
- **Reversible:** revert this one line to fall back to the teaser — no code revert.

### Rollout gate
1. Merge #176 → dev deploy → preview `https://shop.droplinked.com/unstoppable/product/womens-athletic-shoes-a36ed` on the dev host.
2. Confirm: price + size/qty + Buy-now render in place, thumbnails load, Buy routes through MoR.
3. **Then** merge this PR → prod deploy flips it live.

## Closes / addresses
Prod enablement of the #175 unified PDP, gated behind dev sign-off.