### PR TITLE
fix(pdp): MoR Buy-now sends the context product id, not the URL merchant segment

### DIFF
--- a/src/app/(routes)/[productId]/components/details/client/components/ProductCartActions.tsx
+++ b/src/app/(routes)/[productId]/components/details/client/components/ProductCartActions.tsx
@@ -10,6 +10,7 @@ import { MOR_CHECKOUT_ENABLED } from '@/lib/variables/variables';
 const ProductCartActions = () => {
   const {
     states: {
+      product,
       sku,
       option: { quantity },
     },
@@ -39,8 +40,16 @@ const ProductCartActions = () => {
     e.preventDefault();
     return toast.promise(
       async () => {
+        // The product ObjectId must come from the product CONTEXT, not the URL:
+        // on the unified SEO landing route /<merchant>/product/<slug> the first
+        // URL segment (folder-named [productId]) carries the MERCHANT handle,
+        // so params.productId would send e.g. "unstoppable" and the backend DTO
+        // rejects it ("productId must be a mongodb id"). The context product is
+        // authoritative on both routes; keep the URL param only as a fallback
+        // for the id-route while context hydrates.
         const raw = params?.productId;
-        const productId = Array.isArray(raw) ? raw[0] : raw;
+        const fromUrl = Array.isArray(raw) ? raw[0] : raw;
+        const productId = product?._id || fromUrl;
         if (!productId || !sku?._id) throw new Error('Missing product or variant');
         const cartToken =
           globalThis.crypto?.randomUUID?.() ??


### PR DESCRIPTION
## Caught by the dev preview verification of #175/#178 — blocks #177
On the unified slug route `/<merchant>/product/<slug>`, `params.productId` carries the **merchant handle** (route-nesting reuses the `[productId]` folder name). `ProductCartActions` used it as the product id, so Buy-now POSTed `productId: "unstoppable"` → backend DTO 400 ("productId must be a mongodb id") → 'Checkout is unavailable' toast. **Reproduced live on shopdev** (network: `POST /api/mor-checkout/session` → 400). Prod's slug page would fail identically after the #177 flip.

## Fix
Use the **ProductContext product's `_id`** (authoritative on both routes); URL param kept only as an id-route fallback while context hydrates. Id-route behavior unchanged (context id == URL id there).

## Verification
`tsc` 0 · smoke 3/3 · `next build` exit 0. Evidence chain: FE 400 on shopdev → curl replication shows apiv3 DTO progression (bad id → sku → email/cartToken) → payload with real ObjectId passes DTO on both hosts.

## Closes / addresses
Unblocks the prod flip #177 (must land + deploy before it).