### PR TITLE
fix(pdp): first SELLABLE source wins in the interactive loader

### DIFF
--- a/src/app/(routes)/[productId]/lib/product-data.ts
+++ b/src/app/(routes)/[productId]/lib/product-data.ts
@@ -211,19 +211,41 @@ async function fetchPublicProductV2(
 }
 
 /**
+ * A product is SELLABLE when it carries at least one SKU — that's what the
+ * interactive body needs to render price / variants / Buy. A source can
+ * legitimately return a product-shaped object with ZERO skus (observed on the
+ * dev env: the shop-scoped legacy endpoint holds a partial copy of a prod
+ * product — title only, no skus/media). Accepting such a payload renders an
+ * empty buy page (no price, no size, no images) and poisons the ISR cache for
+ * 5 minutes, so sources that answer but aren't sellable only WIN if nothing
+ * better exists.
+ */
+function isSellable(p: IProduct | null | undefined): boolean {
+  return !!p && Array.isArray(p.skuIDs) && p.skuIDs.length > 0;
+}
+
+/**
  * Resolve the interactive PDP product, fail-open. Tries the legacy shop-scoped
  * endpoint first (single-shop deployments), then the public cross-shop
- * product-v2 endpoint (aggregate root). Returns a legacy-shaped IProduct, or
- * null when the product cannot be resolved anywhere → page calls notFound().
- * NEVER throws.
+ * product-v2 endpoint (aggregate root). The FIRST SELLABLE result wins;
+ * sku-less partials are kept only as a last resort so the page still renders
+ * something identifiable. Returns null when no source knows the product →
+ * page calls notFound(). NEVER throws.
  */
 export async function getInteractiveProduct(productId: string): Promise<IProduct | null> {
+  // Best non-sellable answer seen so far (title-only partials etc.).
+  let partial: IProduct | null = null;
+
   // 1. Legacy shop-scoped endpoint. On the aggregate root this throws
-  //    "Unauthorized!" (no x-shop-id) — swallow and fall through.
+  //    "Unauthorized!" (no x-shop-id) — swallow and fall through. On dev this
+  //    endpoint can answer with a PARTIAL product (no skus) — do not let it
+  //    shadow the full payload from the sources below.
   try {
     const legacy = await fetchInstance(`products/${productId}`);
     if (legacy && typeof legacy === 'object' && Array.isArray((legacy as IProduct).skuIDs)) {
-      return legacy as IProduct;
+      const p = legacy as IProduct;
+      if (isSellable(p)) return p;
+      partial = partial ?? p;
     }
   } catch {
     /* no shop identity on the aggregate root, or route/product missing */
@@ -231,7 +253,11 @@ export async function getInteractiveProduct(productId: string): Promise<IProduct
 
   // 2. Public cross-shop product-v2 endpoint (no auth), adapted to legacy shape.
   const v2 = await fetchPublicProductV2(productId);
-  if (v2) return adaptProductV2ToLegacy(v2);
+  if (v2) {
+    const p = adaptProductV2ToLegacy(v2);
+    if (isSellable(p)) return p;
+    partial = partial ?? p;
+  }
 
   // 3. Dev-preview cross-host fallback. The per-product SEO landing page sources
   //    its structured-data from PROD apiv3 (hardcoded in structured-data.ts), so
@@ -242,8 +268,14 @@ export async function getInteractiveProduct(productId: string): Promise<IProduct
   //    APIV3_BASE already IS prod (the two are equal → skipped). Still fail-open.
   if (APIV3_BASE !== APIV3_PROD) {
     const prodV2 = await fetchPublicProductV2(productId, APIV3_PROD);
-    if (prodV2) return adaptProductV2ToLegacy(prodV2);
+    if (prodV2) {
+      const p = adaptProductV2ToLegacy(prodV2);
+      if (isSellable(p)) return p;
+      partial = partial ?? p;
+    }
   }
 
-  return null;
+  // Nothing sellable anywhere — render the best partial rather than a 404
+  // (the product exists; it just has no purchasable variants right now).
+  return partial;
 }


### PR DESCRIPTION
## Found completing the dev re-verification for #179 / gating #180+#177
The dev slug page flipped to an **empty buy page** (title + quantity, no price/size/images): the legacy shop-scoped endpoint on dev answers with a **partial** copy of the prod product (zero skus), and the loader accepted it — shadowing the full product-v2/prod-fallback payload and poisoning ISR for 5 min. Variance was apiv3dev **scale-to-zero**: cold → legacy fetch throws → full prod data; warm → partial wins. (My own API probes warmed it — that's why the page degraded mid-verification.)

## Fix
Same resolution order, but a source is accepted only if **sellable (≥1 sku)**; sku-less partials render only as a last resort. Prod aggregate unaffected (no shop key → step 1 always throws) — this makes the dev preview deterministic.

## Verification
tsc 0 · smoke 3/3 · next build 0.

## Closes / addresses
Unblocks the stable dev preview for the #180 GTFU and the #177 prod flip.