### PR TITLE
GTFU: dev → main (premium PDP)

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -76,6 +76,11 @@ jobs:
         # prod until sign-off (this is the GMC-reinstatement landing page).
         echo "NEXT_PUBLIC_UNIFIED_PDP_ENABLED=true" >> .env
         echo "NEXT_PUBLIC_MOR_CHECKOUT_ENABLED=true" >> .env
+        # --- Premium PDP: dev preview 2026-07-16 ---
+        # Bloomingdale's-grade product body (breadcrumb, rail gallery, size
+        # pills, accordions, POD boilerplate stripped). Prod (main.yml) leaves
+        # it unset -> OFF until design sign-off on the dev preview.
+        echo "NEXT_PUBLIC_PREMIUM_PDP_ENABLED=true" >> .env
         echo "APIV3_BASE_URL=https://apiv3dev.droplinked.com" >> .env
     
     - name: Build, tag, and push image to Amazon ECR

--- a/src/app/(routes)/[productId]/components/ProductExperience.tsx
+++ b/src/app/(routes)/[productId]/components/ProductExperience.tsx
@@ -25,11 +25,29 @@
 
 import { AppSeparator } from '@/components/ui';
 import type { IProduct } from '@/types/interfaces/product/product';
+import { PREMIUM_PDP_ENABLED } from '@/lib/variables/variables';
 import ProductSlider from './ProductSlider';
 import ProductDetails from './details/ProductDetails';
 import ProductDescription from './ProductDescription';
+import PremiumProductExperience, {
+  type PremiumBrand,
+} from './premium/PremiumProductExperience';
 
-export default function ProductExperience({ product }: { product: IProduct }) {
+export default function ProductExperience({
+  product,
+  brand,
+}: {
+  product: IProduct;
+  /** Optional brand context (slug route knows the merchant; id route may not). */
+  brand?: PremiumBrand;
+}) {
+  // Premium body (flag-gated): Bloomingdale's-grade composition — breadcrumb,
+  // thumbnail-rail gallery, pill sizes, accordions, POD boilerplate stripped.
+  // OFF → the legacy body below stays byte-identical.
+  if (PREMIUM_PDP_ENABLED) {
+    return <PremiumProductExperience product={product} brand={brand} />;
+  }
+
   return (
     <main className="container px-8 flex items-start md:flex-row flex-col justify-center w-full gap-12 mt-20">
       <div className="min-w-full md:min-w-[40%] md:sticky left-0 top-24">

--- a/src/app/(routes)/[productId]/components/premium/Accordion.tsx
+++ b/src/app/(routes)/[productId]/components/premium/Accordion.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+/**
+ * Accordion — hairline-bordered disclosure rows (premium PDP).
+ *
+ * The Bloomingdale's-style details pattern: content lives behind quiet,
+ * full-width rows with a chevron — the page stays scannable and the buy
+ * column keeps its visual weight. Server components pass children in, so
+ * accordion CONTENT still server-renders (crawlers and agents read it in the
+ * HTML; only the open/close toggle is client behavior).
+ */
+
+import { useState, type ReactNode } from 'react';
+
+export function AccordionItem({
+  title,
+  children,
+  defaultOpen = false,
+}: {
+  title: string;
+  children: ReactNode;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="border-b border-neutral-200">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between py-4 text-left"
+      >
+        <span className="text-[13px] font-semibold uppercase tracking-[0.12em] text-neutral-900">
+          {title}
+        </span>
+        <svg
+          viewBox="0 0 16 16"
+          aria-hidden="true"
+          className={`h-3.5 w-3.5 text-neutral-500 transition-transform duration-200 ${
+            open ? 'rotate-180' : ''
+          }`}
+        >
+          <path
+            d="M3 6l5 5 5-5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+      {/* Keep content mounted (SEO/agents read it; toggle is display-only). */}
+      <div className={open ? 'pb-5' : 'hidden'}>{children}</div>
+    </div>
+  );
+}
+
+export default function Accordion({ children }: { children: ReactNode }) {
+  return <div className="border-t border-neutral-200">{children}</div>;
+}

--- a/src/app/(routes)/[productId]/components/premium/MediaGallery.tsx
+++ b/src/app/(routes)/[productId]/components/premium/MediaGallery.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+/**
+ * MediaGallery — premium PDP media column.
+ *
+ * Bloomingdale's pattern: a vertical thumbnail rail beside a large hero.
+ * Replaces the legacy ProductSlider (magnifier + 4-up thumbnail grid with a
+ * dark "See More" overlay) with a calmer composition:
+ *   - hero: large 4:5 image on a near-white ground, click → full lightbox
+ *   - rail: up to 6 thumbnails, active one carries a black hairline
+ *   - mobile: hero on top, rail becomes a horizontal strip underneath
+ *
+ * Reuses the already-bundled yet-another-react-lightbox for zoom/gallery.
+ */
+
+import { useState } from 'react';
+import Image from 'next/image';
+import Lightbox from 'yet-another-react-lightbox';
+import Thumbnails from 'yet-another-react-lightbox/plugins/thumbnails';
+import { IProductMedia } from '@/types/interfaces/product/product';
+import { ms } from '@/lib/utils/ms/ms';
+import 'yet-another-react-lightbox/styles.css';
+import 'yet-another-react-lightbox/plugins/thumbnails.css';
+
+export default function MediaGallery({
+  media,
+  alt,
+}: {
+  media: IProductMedia[];
+  alt: string;
+}) {
+  const items = Array.isArray(media) ? media.filter((m) => m?.url) : [];
+  const mainUrl = ms(items) || items[0]?.url || '';
+  const [current, setCurrent] = useState(mainUrl);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+
+  if (!items.length) {
+    return (
+      <div className="aspect-[4/5] w-full rounded-sm bg-neutral-100" aria-hidden />
+    );
+  }
+
+  return (
+    <section className="flex flex-col-reverse gap-3 md:flex-row">
+      {/* thumbnail rail */}
+      {items.length > 1 && (
+        <div className="flex shrink-0 flex-row gap-3 md:flex-col">
+          {items.slice(0, 6).map((m, i) => (
+            <button
+              key={m._id || m.url + i}
+              type="button"
+              aria-label={`View image ${i + 1}`}
+              onClick={() => setCurrent(m.url)}
+              className={`relative h-16 w-16 overflow-hidden rounded-sm bg-neutral-50 transition-shadow ${
+                current === m.url
+                  ? 'ring-1 ring-neutral-900'
+                  : 'ring-1 ring-transparent hover:ring-neutral-300'
+              }`}
+            >
+              <Image
+                src={m.thumbnail || m.url}
+                alt=""
+                fill
+                sizes="64px"
+                className="object-cover"
+              />
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* hero */}
+      <button
+        type="button"
+        aria-label="Open image gallery"
+        onClick={() => setLightboxOpen(true)}
+        className="relative aspect-[4/5] w-full cursor-zoom-in overflow-hidden rounded-sm bg-neutral-50"
+      >
+        {current && (
+          <Image
+            src={current}
+            alt={alt}
+            fill
+            priority
+            sizes="(min-width: 768px) 44vw, 100vw"
+            className="object-cover"
+          />
+        )}
+      </button>
+
+      <Lightbox
+        plugins={[Thumbnails]}
+        thumbnails={{ position: 'bottom', border: 0, imageFit: 'contain', gap: 0 }}
+        open={lightboxOpen}
+        close={() => setLightboxOpen(false)}
+        slides={items.map((m) => ({ src: m.url }))}
+      />
+    </section>
+  );
+}

--- a/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
+++ b/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
@@ -1,0 +1,289 @@
+'use client';
+
+/**
+ * PremiumDetails — the premium PDP buy column (client island).
+ *
+ * Owns the same product/option/sku state model as the legacy ProductClient
+ * (getFirstOption / findSkuAsOption over ProductContext semantics) but renders
+ * the Bloomingdale's-grade hierarchy:
+ *
+ *   BRAND (small caps, quiet)
+ *   Title (large, confident)
+ *   Price + free-returns hint
+ *   Color — named swatches
+ *   Size — pill-button grid + "Size guide" link (never a raw <select>)
+ *   Quantity — compact stepper, visually quiet
+ *   CTA — full-width black BUY NOW / ADD TO BAG
+ *   "Mint to merch" — demoted to a text affordance (differentiator, not noise)
+ *   Trust row — secure checkout · returns · made-to-order
+ *
+ * Buy routes through the MoR session exactly like ProductCartActions (#179
+ * semantics: the product ObjectId comes from STATE, never the URL segment,
+ * which carries the merchant handle on the slug route).
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { IProduct, ISku } from '@/types/interfaces/product/product';
+import { MOR_CHECKOUT_ENABLED, variantIDs } from '@/lib/variables/variables';
+import { POLICY } from '@/lib/site';
+import useAppCart from '@/state/hooks/cart/useAppCart';
+import productClientModel from '../details/client/context/ProductOptionsModel';
+import productVariantsModel from '../details/client/components/model';
+
+const numericSize = (caption: string) => {
+  const m = String(caption ?? '').match(/[\d.]+/);
+  return m ? parseFloat(m[0]) : Number.POSITIVE_INFINITY;
+};
+
+export default function PremiumDetails({
+  product,
+  brandName,
+}: {
+  product: IProduct;
+  brandName?: string;
+}) {
+  const { getFirstOption, findSkuAsOption } = productClientModel;
+  const { getOptions, skuIDsMatchColor } = productVariantsModel;
+  const { addItemToCart } = useAppCart();
+
+  const [option, setOption] = useState<{ color: string | null; size: string | null }>(
+    () => getFirstOption(product?.skuIDs?.[0]),
+  );
+  const [quantity, setQuantity] = useState(1);
+  const [busy, setBusy] = useState(false);
+
+  const sku: ISku | null | undefined = useMemo(
+    () =>
+      product?.product_type === 'DIGITAL'
+        ? product?.skuIDs?.[0]
+        : findSkuAsOption({ color: option.color, size: option.size, skuIDs: product?.skuIDs }),
+    [product, option, findSkuAsOption],
+  );
+
+  const colors = useMemo(() => getOptions(product?.skuIDs, 'color'), [product, getOptions]);
+  const sizes = useMemo(
+    () =>
+      [...getOptions(product?.skuIDs, 'size')].sort(
+        (a, b) => numericSize(a.caption) - numericSize(b.caption),
+      ),
+    [product, getOptions],
+  );
+  const sizesForColor = useMemo(
+    () => (option.color ? skuIDsMatchColor(product?.skuIDs, option.color) : null),
+    [product, option.color, skuIDsMatchColor],
+  );
+  const sizeAvailable = useCallback(
+    (caption: string) => (sizesForColor ? sizesForColor.includes(caption) : true),
+    [sizesForColor],
+  );
+
+  // Keep the selected size valid when the colour changes.
+  useEffect(() => {
+    if (!sku && sizes.length && option.color && sizesForColor?.length) {
+      setOption((prev) => ({ ...prev, size: sizesForColor[0] ?? prev.size }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sku]);
+
+  const price = sku?.price ?? product?.skuIDs?.[0]?.price ?? 0;
+
+  const buy = async () => {
+    if (busy) return;
+    setBusy(true);
+
+    const work = MOR_CHECKOUT_ENABLED
+      ? (async () => {
+          // #179 semantics: state product id, never the URL segment.
+          const productId = product?._id;
+          if (!productId || !sku?._id) throw new Error('Missing product or variant');
+          const cartToken =
+            globalThis.crypto?.randomUUID?.() ??
+            `mor-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+          const res = await fetch(`/api/mor-checkout/session`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ productId, skuId: sku._id, quantity, cartToken }),
+          });
+          if (!res.ok) throw new Error(`Checkout unavailable (${res.status})`);
+          const json = await res.json().catch(() => ({}));
+          const url = json?.data?.checkoutUrl ?? json?.checkoutUrl;
+          if (!url) throw new Error('No checkout URL returned');
+          window.location.href = url;
+          return url;
+        })()
+      : (async () => {
+          if (!sku?._id) throw new Error('Missing product variant');
+          return addItemToCart({ skuID: sku._id, quantity });
+        })();
+
+    toast.promise(
+      work,
+      MOR_CHECKOUT_ENABLED
+        ? {
+            loading: 'Starting secure checkout…',
+            success: 'Redirecting to checkout…',
+            error: 'Checkout is unavailable right now.',
+          }
+        : {
+            loading: 'Adding to your bag…',
+            success: 'Added to your bag',
+            error: 'Something went wrong.',
+          },
+    );
+
+    try {
+      await work;
+    } catch {
+      /* toast already surfaced the failure */
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col">
+      {brandName && (
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-500">
+          {brandName}
+        </p>
+      )}
+
+      <h1 className="mt-2 text-[26px] font-medium leading-8 tracking-tight text-neutral-900 md:text-[30px] md:leading-9">
+        {product?.title}
+      </h1>
+
+      <div className="mt-4 flex items-baseline gap-3">
+        <span className="text-xl font-semibold text-neutral-900" data-testid="premium-price">
+          ${Number(price).toFixed(2)}
+        </span>
+        <span className="text-xs text-neutral-500">
+          Free {POLICY.returnWindowDays}-day returns
+        </span>
+      </div>
+
+      {/* Colour */}
+      {colors.length > 0 && (
+        <div className="mt-7">
+          <p className="text-[13px] text-neutral-900">
+            <span className="font-semibold">Color</span>
+            {option.color && <span className="text-neutral-500"> — {option.color}</span>}
+          </p>
+          <div className="mt-2.5 flex flex-wrap gap-2">
+            {colors.map((c) => (
+              <button
+                key={c.caption}
+                type="button"
+                aria-label={`Color ${c.caption}`}
+                aria-pressed={option.color === c.caption}
+                onClick={() => setOption((prev) => ({ ...prev, color: c.caption }))}
+                className={`h-9 w-9 rounded-full border border-neutral-300 transition-shadow ${
+                  option.color === c.caption
+                    ? 'ring-1 ring-neutral-900 ring-offset-2'
+                    : 'hover:ring-1 hover:ring-neutral-400 hover:ring-offset-2'
+                }`}
+                style={{
+                  backgroundColor: /^#|^rgb|^hsl/.test(String(c.value))
+                    ? String(c.value)
+                    : String(c.caption).toLowerCase(),
+                }}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Size — pill grid, never a raw select */}
+      {sizes.length > 0 && (
+        <div className="mt-7">
+          <div className="flex items-center justify-between">
+            <p className="text-[13px] font-semibold text-neutral-900">
+              Size
+              {option.size && (
+                <span className="font-normal text-neutral-500"> — {option.size}</span>
+              )}
+            </p>
+            <a
+              href="#size-guide"
+              className="text-[12px] text-neutral-500 underline underline-offset-2 hover:text-neutral-900"
+            >
+              Size guide
+            </a>
+          </div>
+          <div className="mt-2.5 grid grid-cols-5 gap-2 sm:grid-cols-6">
+            {sizes.map((s) => {
+              const selected = option.size === s.caption;
+              const available = sizeAvailable(s.caption);
+              return (
+                <button
+                  key={s.caption}
+                  type="button"
+                  disabled={!available}
+                  aria-pressed={selected}
+                  onClick={() => setOption((prev) => ({ ...prev, size: s.caption }))}
+                  className={`h-10 rounded-sm border text-[13px] transition-colors ${
+                    selected
+                      ? 'border-neutral-900 bg-neutral-900 text-white'
+                      : available
+                        ? 'border-neutral-300 bg-white text-neutral-900 hover:border-neutral-900'
+                        : 'cursor-not-allowed border-neutral-200 text-neutral-300 line-through'
+                  }`}
+                >
+                  {s.caption}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Quantity — deliberately quiet */}
+      <div className="mt-7 flex items-center gap-4">
+        <p className="text-[13px] font-semibold text-neutral-900">Quantity</p>
+        <div className="flex h-9 items-center rounded-sm border border-neutral-300">
+          <button
+            type="button"
+            aria-label="Decrease quantity"
+            onClick={() => setQuantity((q) => Math.max(1, q - 1))}
+            className="w-9 text-neutral-500 hover:text-neutral-900"
+          >
+            −
+          </button>
+          <span className="w-8 text-center text-[13px] tabular-nums">{quantity}</span>
+          <button
+            type="button"
+            aria-label="Increase quantity"
+            onClick={() => setQuantity((q) => Math.min(99, q + 1))}
+            className="w-9 text-neutral-500 hover:text-neutral-900"
+          >
+            +
+          </button>
+        </div>
+      </div>
+
+      {/* CTA */}
+      <button
+        type="button"
+        onClick={buy}
+        disabled={busy}
+        className="mt-8 h-12 w-full rounded-sm bg-neutral-900 text-[13px] font-semibold uppercase tracking-[0.14em] text-white transition-colors hover:bg-neutral-700 disabled:opacity-60"
+      >
+        {MOR_CHECKOUT_ENABLED ? 'Buy now' : 'Add to bag'}
+      </button>
+
+      {/* Differentiator, demoted from a co-equal button to an affordance */}
+      <p className="mt-3 text-center text-[12px] text-neutral-500">
+        Own the design?{' '}
+        <span className="cursor-pointer underline underline-offset-2 hover:text-neutral-900">
+          Mint it to merch
+        </span>
+      </p>
+
+      {/* Trust row — same POLICY source as the sitewide footer */}
+      <p className="mt-6 text-[12px] leading-5 text-neutral-500">
+        Secure checkout · {POLICY.returnWindowDays}-day returns · Made to order —
+        ships in {POLICY.handlingTimeDays}
+      </p>
+    </div>
+  );
+}

--- a/src/app/(routes)/[productId]/components/premium/PremiumProductExperience.tsx
+++ b/src/app/(routes)/[productId]/components/premium/PremiumProductExperience.tsx
@@ -1,0 +1,146 @@
+/**
+ * PremiumProductExperience — the premium PDP body (server shell).
+ *
+ * The Bloomingdale's-grade composition the shopper (or shopping agent) lands
+ * on: breadcrumb → [gallery | buy column] → detail accordions. Server
+ * component: copy processing (sanitize + boilerplate strip + size-chart
+ * relocation) happens here so accordion content is in the crawlable HTML;
+ * only the gallery and buy column hydrate.
+ *
+ * Flag-gated by NEXT_PUBLIC_PREMIUM_PDP_ENABLED (see ProductExperience.tsx) —
+ * the legacy body remains byte-identical when OFF.
+ */
+
+import Link from 'next/link';
+import { inter } from '@/styles/fonts';
+import { POLICY } from '@/lib/site';
+import type { IProduct } from '@/types/interfaces/product/product';
+import { sanitizeHtml } from '../../product/[slug]/lib/sanitize-html';
+import styles from '../../product/[slug]/description.module.css';
+import { splitDescription } from './description-content';
+import Accordion, { AccordionItem } from './Accordion';
+import MediaGallery from './MediaGallery';
+import PremiumDetails from './PremiumDetails';
+
+export interface PremiumBrand {
+  /** Display name for the brand line + breadcrumb (e.g. "UNSTOPPABLE"). */
+  name: string;
+  /** Optional internal link for the breadcrumb crumb. */
+  href?: string;
+}
+
+export default function PremiumProductExperience({
+  product,
+  brand,
+}: {
+  product: IProduct;
+  brand?: PremiumBrand;
+}) {
+  const { descriptionHtml, sizeGuideHtml } = splitDescription(
+    sanitizeHtml(product?.description || ''),
+  );
+
+  return (
+    <main className={`${inter.className} mx-auto w-full max-w-6xl px-6 pb-20 pt-6 md:px-8`}>
+      {/* breadcrumb — orientation for shoppers and structure for agents */}
+      <nav aria-label="Breadcrumb" className="mb-6">
+        <ol className="flex flex-wrap items-center gap-1.5 text-[12px] text-neutral-500">
+          <li>
+            <Link href="/" className="hover:text-neutral-900 hover:underline">
+              Home
+            </Link>
+          </li>
+          {brand?.name && (
+            <>
+              <li aria-hidden>/</li>
+              <li>
+                {brand.href ? (
+                  <Link href={brand.href} className="hover:text-neutral-900 hover:underline">
+                    {brand.name}
+                  </Link>
+                ) : (
+                  <span>{brand.name}</span>
+                )}
+              </li>
+            </>
+          )}
+          <li aria-hidden>/</li>
+          <li aria-current="page" className="text-neutral-900">
+            {product?.title}
+          </li>
+        </ol>
+      </nav>
+
+      <div className="flex flex-col gap-10 md:flex-row md:items-start md:gap-14">
+        {/* media column */}
+        <div className="w-full md:sticky md:top-24 md:w-[52%]">
+          <MediaGallery media={product?.media} alt={product?.title || 'Product image'} />
+        </div>
+
+        {/* details column */}
+        <div className="w-full md:w-[44%]">
+          <PremiumDetails product={product} brandName={brand?.name} />
+
+          {/* detail accordions — server-rendered content */}
+          <div className="mt-10">
+            <Accordion>
+              {descriptionHtml && (
+                <AccordionItem title="Description" defaultOpen>
+                  <div
+                    className={`${styles.rich} text-[14px] leading-6 text-neutral-600`}
+                    dangerouslySetInnerHTML={{ __html: descriptionHtml }}
+                  />
+                </AccordionItem>
+              )}
+              {sizeGuideHtml && (
+                <div id="size-guide">
+                  <AccordionItem title="Size guide">
+                    <div
+                      className={`${styles.rich} overflow-x-auto text-[13px] leading-6 text-neutral-600`}
+                      dangerouslySetInnerHTML={{ __html: sizeGuideHtml }}
+                    />
+                  </AccordionItem>
+                </div>
+              )}
+              <AccordionItem title="Shipping & returns">
+                <div className="flex flex-col gap-2 text-[14px] leading-6 text-neutral-600">
+                  <p>
+                    Every piece is made to order and ships in {POLICY.handlingTimeDays}{' '}
+                    with tracking.
+                  </p>
+                  <p>
+                    Returns are free within {POLICY.returnWindowDays} days of delivery —
+                    refunds go back to your {POLICY.refundMethod} within{' '}
+                    {POLICY.refundProcessingDays}.
+                  </p>
+                  <p className="text-[13px]">
+                    <Link
+                      href="/shipping-policy"
+                      className="underline underline-offset-2 hover:text-neutral-900"
+                    >
+                      Shipping policy
+                    </Link>{' '}
+                    ·{' '}
+                    <Link
+                      href="/returns-policy"
+                      className="underline underline-offset-2 hover:text-neutral-900"
+                    >
+                      Returns &amp; refunds
+                    </Link>{' '}
+                    ·{' '}
+                    <Link
+                      href="/contact"
+                      className="underline underline-offset-2 hover:text-neutral-900"
+                    >
+                      Contact us
+                    </Link>
+                  </p>
+                </div>
+              </AccordionItem>
+            </Accordion>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(routes)/[productId]/components/premium/description-content.ts
+++ b/src/app/(routes)/[productId]/components/premium/description-content.ts
@@ -1,0 +1,122 @@
+/**
+ * description-content.ts — Copywriter pass for the premium PDP.
+ *
+ * POD supplier descriptions (Printful et al.) arrive as one HTML blob that
+ * mixes three very different kinds of content:
+ *   1. Benefit copy the shopper should read (fabric, fit, features)
+ *   2. Fulfillment boilerplate that actively kills trust on a premium page
+ *      ("Blank product sourced from China", "Disclaimer: A strong glue smell
+ *      is expected…")
+ *   3. Sizing charts — big multi-column tables that belong behind a
+ *      "Size Guide" affordance (Bloomingdale's pattern), never inline.
+ *
+ * splitDescription() takes the (already sanitized) description HTML and
+ * returns { descriptionHtml, sizeGuideHtml }:
+ *   - supplier disclaimers are removed from the visible copy
+ *   - everything from the first "Size Guide"-style heading onward — plus any
+ *     stray <table> elements — moves to sizeGuideHtml
+ *   - both halves stay valid HTML fragments for dangerouslySetInnerHTML
+ *     (inputs must already be sanitized — reuse sanitizeHtml from the slug
+ *     route before calling this)
+ *
+ * Pure string transforms, server-safe, no DOM dependency.
+ */
+
+// Sentences/paragraphs that are supplier-ops boilerplate, not shopper copy.
+// Matched case-insensitively against each block's TEXT content.
+const DISCLAIMER_PATTERNS: RegExp[] = [
+  /blank product sourced from/i,
+  /\bdisclaimer\s*:/i,
+  /strong glue smell/i,
+  /allow the shoes to air out/i,
+  /product is made especially for you/i, // common Printful ops footer
+  /printed in|fulfilled by/i,
+];
+
+// Headings that mark the start of sizing content.
+const SIZE_GUIDE_HEADING = /size\s*(guide|chart|table)|measurements/i;
+
+/**
+ * Split an HTML fragment into top-level blocks. We treat block-level tags as
+ * boundaries; anything between them (bare text/inline nodes) becomes its own
+ * block. This is intentionally simple — supplier HTML is flat (p/ul/table/h*).
+ */
+function toBlocks(html: string): string[] {
+  const re =
+    /<(p|ul|ol|table|h[1-6]|div|section|blockquote)\b[\s\S]*?<\/\1>|[^<]+|<[^>]+>/gi;
+  const blocks: string[] = [];
+  let buf = "";
+  for (const m of html.match(re) ?? []) {
+    if (/^<(p|ul|ol|table|h[1-6]|div|section|blockquote)\b/i.test(m)) {
+      if (buf.trim()) blocks.push(buf);
+      buf = "";
+      blocks.push(m);
+    } else {
+      buf += m;
+    }
+  }
+  if (buf.trim()) blocks.push(buf);
+  return blocks;
+}
+
+/** Text content of an HTML block (tags stripped), for pattern matching. */
+function blockText(block: string): string {
+  return block
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function isDisclaimer(block: string): boolean {
+  const text = blockText(block);
+  if (!text) return false;
+  return DISCLAIMER_PATTERNS.some((re) => re.test(text));
+}
+
+function isSizeGuideHeading(block: string): boolean {
+  // A short heading-like block whose text is basically "Size Guide" etc.
+  const text = blockText(block);
+  if (!text || text.length > 40) return false;
+  return SIZE_GUIDE_HEADING.test(text);
+}
+
+export interface SplitDescription {
+  /** Shopper-facing copy — boilerplate removed, size charts relocated. */
+  descriptionHtml: string;
+  /** Sizing tables + everything after the Size Guide heading ('' if none). */
+  sizeGuideHtml: string;
+}
+
+export function splitDescription(sanitizedHtml: string | null | undefined): SplitDescription {
+  const html = (sanitizedHtml ?? "").trim();
+  if (!html) return { descriptionHtml: "", sizeGuideHtml: "" };
+
+  const blocks = toBlocks(html);
+  const description: string[] = [];
+  const sizeGuide: string[] = [];
+  let inSizeGuide = false;
+
+  for (const block of blocks) {
+    if (!inSizeGuide && isSizeGuideHeading(block)) {
+      inSizeGuide = true;
+      continue; // the accordion supplies its own "Size Guide" title
+    }
+    if (inSizeGuide) {
+      if (!isDisclaimer(block)) sizeGuide.push(block);
+      continue;
+    }
+    if (isDisclaimer(block)) continue;
+    // Stray tables before any heading are sizing content too.
+    if (/^<table\b/i.test(block.trim())) {
+      sizeGuide.push(block);
+      continue;
+    }
+    description.push(block);
+  }
+
+  return {
+    descriptionHtml: description.join("").trim(),
+    sizeGuideHtml: sizeGuide.join("").trim(),
+  };
+}

--- a/src/app/(routes)/[productId]/product/[slug]/page.tsx
+++ b/src/app/(routes)/[productId]/product/[slug]/page.tsx
@@ -160,7 +160,12 @@ export default async function ProductPage({ params }: PageProps) {
     return (
       <>
         {jsonLdScript}
-        <ProductExperience product={interactiveProduct} />
+        <ProductExperience
+          product={interactiveProduct}
+          // Brand context for the premium body's brand line + breadcrumb: the
+          // structured-data brand name, falling back to the merchant handle.
+          brand={{ name: view.brandName || merchant }}
+        />
       </>
     );
   }

--- a/src/lib/variables/variables.ts
+++ b/src/lib/variables/variables.ts
@@ -39,6 +39,18 @@ export const MOR_CHECKOUT_ENABLED =
  */
 export const UNIFIED_PDP_ENABLED =
   process.env.NEXT_PUBLIC_UNIFIED_PDP_ENABLED === "true";
+
+/**
+ * Premium PDP: render the Bloomingdale's-grade product body (breadcrumb,
+ * thumbnail-rail gallery, size pill grid, detail accordions, POD boilerplate
+ * stripped, size charts relocated behind "Size guide") instead of the legacy
+ * interactive body. Applies wherever ProductExperience renders (id route +
+ * unified slug route). NEXT_PUBLIC_ so Next inlines it at build time. Default
+ * OFF — set NEXT_PUBLIC_PREMIUM_PDP_ENABLED=true to enable (reversible, no
+ * code revert).
+ */
+export const PREMIUM_PDP_ENABLED =
+  process.env.NEXT_PUBLIC_PREMIUM_PDP_ENABLED === "true";
 export const variantIDs = { color: { _id: "62a989ab1f2c2bbc5b1e7153" }, size: { _id: "62a989e21f2c2bbc5b1e7154" } };
 export const app_vertical = "flex flex-col items-center justify-center";
 export const app_center = "flex items-center justify-center";


### PR DESCRIPTION
Promotes the premium PDP components (#182) to prod code. The premium body is **flag-gated** (`NEXT_PUBLIC_PREMIUM_PDP_ENABLED`) and `main.yml` does not yet set it, so **prod behavior is unchanged** by this merge — the flip is the separate held PR (hotfix/enable-premium-pdp-prod).

Dev preview verified on shopdev: premium body renders (breadcrumb, rail gallery all 5 thumbs, size pills, cleaned copy, accordions), boilerplate stripped from visible copy (JSON-LD/meta intentionally retained for GMC), Buy-now flow intact.

## Closes / addresses
Prerequisite for the premium prod flip.