### PR TITLE
ci(prod): enable premium PDP on prod

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,13 @@ jobs:
         # GMC landing-page check. Revert this single line to fall back to the
         # static teaser (reversible, no code revert).
         echo "NEXT_PUBLIC_UNIFIED_PDP_ENABLED=true" >> .env
+        # --- Premium PDP: PROD enablement 2026-07-16 ---
+        # Render the Bloomingdale's-grade product body (breadcrumb, rail
+        # gallery, size pills, accordions, POD boilerplate stripped) on both
+        # the id route and the unified slug route. Verified on the dev preview
+        # first. Flag OFF -> the legacy interactive body is byte-identical, so
+        # this is fully reversible by removing this single line.
+        echo "NEXT_PUBLIC_PREMIUM_PDP_ENABLED=true" >> .env
 
     - name: Build, tag, and push image to Amazon ECR
       id: build-image


### PR DESCRIPTION
Flips `NEXT_PUBLIC_PREMIUM_PDP_ENABLED=true` on prod so `/<merchant>/product/<slug>` and `/<productId>` render the Bloomingdale's-grade premium body (breadcrumb, rail gallery, size pills, accordions, POD boilerplate stripped). Premium components are on main (GTFU #183). Verified on the shopdev preview. Flag OFF keeps the legacy body byte-identical — reversible by removing this one line.

## Closes / addresses
Premium PDP prod enablement (operator: preview and proceed, 2026-07-16).