### PR TITLE
chore(pdp): remove mislabeled 'Mint it to merch' from the authenticity slot (Phase 0)

### DIFF
--- a/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
+++ b/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
@@ -271,13 +271,14 @@ export default function PremiumDetails({
         {MOR_CHECKOUT_ENABLED ? 'Buy now' : 'Add to bag'}
       </button>
 
-      {/* Differentiator, demoted from a co-equal button to an affordance */}
-      <p className="mt-3 text-center text-[12px] text-neutral-500">
-        Own the design?{' '}
-        <span className="cursor-pointer underline underline-offset-2 hover:text-neutral-900">
-          Mint it to merch
-        </span>
-      </p>
+      {/* Phase 0 (product-passport strategy 2026-07-16): the authenticity slot
+          under the CTA is intentionally EMPTY, not a "Mint it to merch" link.
+          "Mint to Merch" is a CREATOR mechanism (upload artwork → mint a POD
+          design) and belongs on a creator surface, not dressed up as an
+          ownership/provenance affordance on a buy page. This slot is reserved
+          for the conditional onchain product-passport / authenticity module
+          (VerifiedOnchainBadge + dpp/proof:gtin) — rendered only when a
+          confirmed onchain record exists for the item. */}
 
       {/* Trust row — same POLICY source as the sitewide footer */}
       <p className="mt-6 text-[12px] leading-5 text-neutral-500">


### PR DESCRIPTION
## Why
Operator flagged that the premium PDP's "Own the design? **Mint it to merch**" (under the Buy CTA) is the wrong concept for that slot. **Mint-to-Merch is a CREATOR mechanism** (upload artwork → position → mint a POD design — the real flow lives in the Vite shopfront's `pages/product/components/m2m/`). In Next-ShopFront it was never wired to anything (a dead `<span>`), and putting a creation verb where a provenance affordance belongs undermines the "onchain" trust language on a premium buy page.

## Change
Remove the affordance; reserve the slot (documented in a comment) for the conditional **onchain product-passport / authenticity module** — the already-built `VerifiedOnchainBadge` + `dpp/proof/:gtin` client — to be ported in a later phase, rendered **only** when a confirmed onchain record exists for the item.

Phase 0 of the product-passport strategy: `~/workspace/droplinked/product-passport-platform-strategy-2026-07-16.md`. No functional change (the affordance did nothing).

## Verification
tsc 0 · smoke 3/3 · `next build` 0.

## Closes / addresses
Retires the mislabeled Mint-to-Merch PDP affordance; sets up the passport authenticity slot.