### PR TITLE
chore: reconcile dev with main (post-GTFU parity)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,13 @@ jobs:
         # GMC landing-page check. Revert this single line to fall back to the
         # static teaser (reversible, no code revert).
         echo "NEXT_PUBLIC_UNIFIED_PDP_ENABLED=true" >> .env
+        # --- Premium PDP: PROD enablement 2026-07-16 ---
+        # Render the Bloomingdale's-grade product body (breadcrumb, rail
+        # gallery, size pills, accordions, POD boilerplate stripped) on both
+        # the id route and the unified slug route. Verified on the dev preview
+        # first. Flag OFF -> the legacy interactive body is byte-identical, so
+        # this is fully reversible by removing this single line.
+        echo "NEXT_PUBLIC_PREMIUM_PDP_ENABLED=true" >> .env
 
     - name: Build, tag, and push image to Amazon ECR
       id: build-image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,15 @@ jobs:
         # behaviour (root redirects to /home).
         echo "NEXT_PUBLIC_ROOT_CATALOG_ENABLED=true" >> .env
         echo "NEXT_PUBLIC_MOR_CHECKOUT_ENABLED=true" >> .env
+        # --- Unified PDP: PROD enablement 2026-07-15 ---
+        # Render the interactive buy-in-place body on the SEO landing page
+        # /<merchant>/product/<slug> (the GMC-registered URL) instead of the
+        # static teaser that bounced to /<productId>. Verified on the dev
+        # preview first. Fail-open in code (falls back to the teaser if the
+        # interactive product can't be resolved), so this never regresses the
+        # GMC landing-page check. Revert this single line to fall back to the
+        # static teaser (reversible, no code revert).
+        echo "NEXT_PUBLIC_UNIFIED_PDP_ENABLED=true" >> .env
 
     - name: Build, tag, and push image to Amazon ECR
       id: build-image


### PR DESCRIPTION
Back-merge main → dev after the 2026-07-16 prod GTFUs left dev 5 commit(s) behind (main-only prod-flag lines / merge commits). dev is a clean ancestor of main → 0-conflict. Keeps the next cycle's dev-first work on the same foundation prod runs; prevents dev-behind-main GTFU-revert traps.

## Closes / addresses
Restores dev↔main parity.