### PR TITLE
GTFU: dev → main (footer: remove phone, tighten tagline)

### DIFF
--- a/src/components/core/footer/footer.tsx
+++ b/src/components/core/footer/footer.tsx
@@ -1,7 +1,7 @@
 import AppIcons from "@/assets/AppIcons";
 import DroplinkedLogo from "@/assets/icons/droplinked-logo.svg";
 import { AppSeparator, AppTypography } from "@/components/ui";
-import { COMPANY_LINKS, POLICY, POLICY_LINKS, SITE, SITE_ADDRESS_LINE, SITE_PHONE_TEL, SOCIAL_LINKS } from "@/lib/site";
+import { COMPANY_LINKS, POLICY, POLICY_LINKS, SITE, SITE_ADDRESS_LINE, SOCIAL_LINKS } from "@/lib/site";
 import Link from "next/link";
 import React from "react";
 
@@ -39,12 +39,6 @@ const Footer = () => {
               className="text-sm text-foreground/70 hover:text-foreground transition-colors"
             >
               {SITE.supportEmail}
-            </a>
-            <a
-              href={SITE_PHONE_TEL}
-              className="text-sm text-foreground/70 hover:text-foreground transition-colors"
-            >
-              {SITE.supportPhone}
             </a>
             <address className="text-sm not-italic text-foreground/70">
               {SITE_ADDRESS_LINE}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -25,10 +25,9 @@ export const SITE = {
   /** One-line description of what the platform is (no placeholder copy). */
   tagline: "Powering the next generation of commerce.",
   description:
-    "droplinked is the commerce platform for modern brands and retailers — " +
-    "sell physical and digital products, reach new customers across AI " +
-    "shopping agents and affiliate networks, and get paid through the " +
-    "checkout and payment providers you already trust.",
+    "droplinked is the commerce platform for modern brands — sell physical " +
+    "and digital products, get found by AI shopping agents and affiliates, " +
+    "and get paid through providers you already trust.",
   /** Primary customer support channel. */
   supportEmail: "support@droplinked.com",
   /** Customer-service phone (matches Merchant Center → Business info contact). */


### PR DESCRIPTION
Promotes #188 to prod: removes the support phone from the storefront footer + tightens the platform tagline (269→189 chars).

## Closes / addresses
Storefront footer polish.