### PR TITLE
fix(pdp): title-case merchant breadcrumb fallback + premium root grid polish [DO NOT MERGE]

### DIFF
--- a/src/app/(routes)/[productId]/product/[slug]/page.tsx
+++ b/src/app/(routes)/[productId]/product/[slug]/page.tsx
@@ -40,6 +40,7 @@ import {
 } from "./lib/structured-data";
 import { sanitizeHtml, htmlToText } from "./lib/sanitize-html";
 import { POLICY } from "@/lib/site";
+import { titleCaseHandle } from "@/lib/utils/handle/handle";
 import { UNIFIED_PDP_ENABLED } from "@/lib/variables/variables";
 import { getInteractiveProduct } from "../../lib/product-data";
 import ProductExperience from "../../components/ProductExperience";
@@ -163,8 +164,10 @@ export default async function ProductPage({ params }: PageProps) {
         <ProductExperience
           product={interactiveProduct}
           // Brand context for the premium body's brand line + breadcrumb: the
-          // structured-data brand name, falling back to the merchant handle.
-          brand={{ name: view.brandName || merchant }}
+          // structured-data brand name, falling back to a display-cased merchant
+          // handle (raw slug `unstoppable` → `Unstoppable`). A real brandName is
+          // already display copy and is passed through untouched.
+          brand={{ name: view.brandName || titleCaseHandle(merchant) }}
         />
       </>
     );

--- a/src/components/catalog/MarketplaceCatalog.tsx
+++ b/src/components/catalog/MarketplaceCatalog.tsx
@@ -11,9 +11,17 @@
  * Uses a plain <img> (not next/image) for product thumbnails so arbitrary
  * per-shop CDN hosts don't need next.config remotePatterns entries — matching
  * how the other SSR routes render remote product images.
+ *
+ * Visual language is deliberately aligned with the premium PDP
+ * (PremiumProductExperience / PremiumDetails): Inter type, a calm neutral
+ * palette, generous whitespace, quiet borders, and a restrained image-zoom
+ * hover — so the root grid reads as the same premium brand as the product page.
+ * This is a presentation-only pass: props, data flow, SSR output, and the
+ * ROOT_CATALOG_ENABLED gate in page.tsx are all unchanged.
  */
 
 import Link from "next/link";
+import { inter } from "@/styles/fonts";
 import type { CatalogProduct } from "@/lib/catalog/marketplace-catalog-data";
 import { SITE } from "@/lib/site";
 
@@ -24,53 +32,70 @@ interface MarketplaceCatalogProps {
 
 export default function MarketplaceCatalog({ products }: MarketplaceCatalogProps) {
   return (
-    <main className="min-h-[60vh] w-full px-4 py-10 md:px-8 lg:px-12 text-gray-900">
-      <div className="mx-auto max-w-7xl">
-        <header className="mb-8">
-          <h1 className="text-2xl font-semibold md:text-3xl">Shop all products</h1>
-          <p className="mt-2 max-w-2xl text-sm text-gray-600 md:text-base">
-            Discover products from brands and retailers on {SITE.name}.
+    <main
+      className={`${inter.className} min-h-[60vh] w-full px-6 pb-20 pt-10 text-neutral-900 md:px-8 lg:px-12`}
+    >
+      <div className="mx-auto max-w-6xl">
+        <header className="mb-10 border-b border-neutral-200 pb-8">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-500">
+            {SITE.name}
+          </p>
+          <h1 className="mt-3 text-[28px] font-medium leading-9 tracking-tight text-neutral-900 md:text-[34px] md:leading-10">
+            Shop all products
+          </h1>
+          <p className="mt-3 max-w-2xl text-[14px] leading-6 text-neutral-500">
+            A curated selection from brands and retailers on {SITE.name} —
+            verifiable, made to order, and shipped with tracking.
           </p>
         </header>
 
         {products.length === 0 ? (
-          <div className="rounded-lg border border-gray-200 bg-gray-50 py-20 text-center">
-            <p className="text-base font-medium text-gray-700">No products to show yet</p>
-            <p className="mt-1 text-sm text-gray-500">Please check back soon.</p>
+          <div className="rounded-md border border-neutral-200 bg-neutral-50 py-24 text-center">
+            <p className="text-[15px] font-medium text-neutral-700">
+              No products to show yet
+            </p>
+            <p className="mt-1 text-[13px] text-neutral-500">
+              Please check back soon.
+            </p>
           </div>
         ) : (
           <ul
-            className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
+            className="grid grid-cols-2 gap-x-6 gap-y-10 sm:grid-cols-3 lg:grid-cols-4"
             role="list"
           >
             {products.map((product) => (
               <li key={product.id} className="group">
                 <Link
                   href={product.href}
-                  className="flex h-full flex-col gap-2 overflow-hidden rounded-lg border border-gray-200 bg-white transition-all duration-200 hover:border-gray-300 hover:shadow-md"
+                  className="flex h-full flex-col"
                   aria-label={product.title}
                 >
-                  <div className="relative aspect-square w-full bg-gray-100">
+                  <div className="relative aspect-square w-full overflow-hidden rounded-md bg-neutral-100">
                     {product.imageUrl ? (
                       // eslint-disable-next-line @next/next/no-img-element
                       <img
                         src={product.imageUrl}
                         alt={product.title}
                         loading="lazy"
-                        className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                        className="h-full w-full object-cover transition-transform duration-500 ease-out group-hover:scale-[1.04]"
                       />
                     ) : (
-                      <div className="h-full w-full bg-gray-200" aria-hidden="true" />
+                      <div
+                        className="h-full w-full bg-neutral-200"
+                        aria-hidden="true"
+                      />
                     )}
                   </div>
-                  <div className="flex flex-col gap-1 px-3 pb-3">
-                    <span className="line-clamp-2 text-sm font-medium text-gray-900">
+                  <div className="mt-3 flex flex-col gap-1">
+                    {product.shopName ? (
+                      <span className="line-clamp-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-neutral-400">
+                        {product.shopName}
+                      </span>
+                    ) : null}
+                    <span className="line-clamp-2 text-[14px] leading-5 text-neutral-900 transition-colors group-hover:text-neutral-600">
                       {product.title}
                     </span>
-                    {product.shopName ? (
-                      <span className="line-clamp-1 text-xs text-gray-500">{product.shopName}</span>
-                    ) : null}
-                    <span className="text-sm font-semibold text-gray-900">
+                    <span className="mt-0.5 text-[14px] font-semibold text-neutral-900">
                       $
                       {product.price.toLocaleString("en-US", {
                         minimumFractionDigits: 2,

--- a/src/lib/utils/handle/handle.ts
+++ b/src/lib/utils/handle/handle.ts
@@ -1,0 +1,44 @@
+/**
+ * titleCaseHandle — present a raw merchant handle/slug as a display name.
+ *
+ * Used ONLY as a fallback when a product has no real brand name and the PDP
+ * would otherwise show the bare, lowercase merchant slug in the breadcrumb /
+ * brand line (e.g. `unstoppable`). A real `brandName` must never be passed
+ * through this — it is already display copy and could be mangled.
+ *
+ * Splitting rules (best-effort, never throws):
+ *   - split on `-`, `_`, `.`, `+` and whitespace → separate words
+ *   - split camelCase / PascalCase boundaries (`theShoeCircle` → the Shoe Circle)
+ *   - uppercase only the FIRST letter of each word; the rest is left untouched
+ *     so an acronym (`nasa`→`Nasa`, `UNSTOPPABLE`→`UNSTOPPABLE`) is not damaged
+ *
+ * A blob slug with no clean delimiter/camel boundary (e.g. `theshoecircle`)
+ * degrades gracefully to a single capitalised word (`Theshoecircle`) — the
+ * "else just capitalize words" branch. That is strictly better than the raw
+ * lowercase slug and never invents word boundaries that aren't there.
+ *
+ * @example titleCaseHandle('unstoppable')      // 'Unstoppable'
+ * @example titleCaseHandle('the-shoe-circle')  // 'The Shoe Circle'
+ * @example titleCaseHandle('theShoeCircle')    // 'The Shoe Circle'
+ * @example titleCaseHandle('theshoecircle')    // 'Theshoecircle'
+ */
+export function titleCaseHandle(handle: string): string {
+  if (!handle || typeof handle !== "string") return handle ?? "";
+
+  const words = handle
+    // camelCase / PascalCase → space-separated
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    // delimiter families → spaces
+    .replace(/[-_.+\s]+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean);
+
+  if (words.length === 0) return handle;
+
+  return words
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+export default titleCaseHandle;


### PR DESCRIPTION
**PR — DO NOT MERGE.** Review-only; awaiting operator merge gate.

Two mechanical polish fixes on the premium PDP surface. Base `dev`. No flag/data changes; presentation only.

## 1. Breadcrumb title-cases the merchant handle fallback
On the SEO slug route (`/<merchant>/product/<slug>`), the premium PDP brand line + breadcrumb fell back to the **raw lowercase merchant slug** (e.g. `unstoppable`) whenever a product had no real `brandName`. New pure helper `titleCaseHandle()` presents that fallback as a display name:

- `unstoppable` → `Unstoppable`
- `the-shoe-circle` / `theShoeCircle` → `The Shoe Circle`
- `theshoecircle` → `Theshoecircle` (no clean split → single capitalized word, per the "else just capitalize words" rule)

Applied **only** to the `merchant` fallback in the slug page's brand context — a real `brandName` is passed through untouched (never mangled). First letter of each word only, so acronyms/ALLCAPS aren't damaged.

## 2. Root catalog grid polish
Restyled `MarketplaceCatalog` to match the premium PDP's calm aesthetic (`PremiumProductExperience` / `PremiumDetails`): Inter type, neutral palette, generous whitespace, quiet borders, a restrained image-zoom hover, and a refined heading/subhead with an uppercase brand eyebrow. Cards drop the heavy boxed border for an editorial image-first layout.

Kept identical: it remains a **server component** (no client fetch — full grid in the initial HTML, crawlable by GMC/Googlebot), same props/data flow, same plain `<img>` (arbitrary CDN hosts), and the `ROOT_CATALOG_ENABLED` gate in `page.tsx` is untouched. No SSR/crawlability regression.

## Files changed
- `src/lib/utils/handle/handle.ts` (new) — `titleCaseHandle()` pure helper
- `src/app/(routes)/[productId]/product/[slug]/page.tsx` — apply helper to merchant fallback
- `src/components/catalog/MarketplaceCatalog.tsx` — visual polish

## Gates
- `npx tsc --noEmit -p tsconfig.json` → 0 errors
- `npm test` (node --test smoke) → 3 pass / 0 fail
- `NEXT_TELEMETRY_DISABLED=1 npx next build` → exit 0, 0 errors

## Closes / addresses
- Breadcrumb shows lowercase raw merchant slug (`unstoppable`) instead of a display-cased brand name on the premium PDP fallback path.
- Aggregate root catalog grid visually diverged from the premium PDP; this aligns it to one premium brand system.
