### PR TITLE
feat(pdp): flag-gated onchain product-passport module (Phase 1) [DO NOT MERGE]

### DIFF
--- a/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
+++ b/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
@@ -30,6 +30,7 @@ import { POLICY } from '@/lib/site';
 import useAppCart from '@/state/hooks/cart/useAppCart';
 import productClientModel from '../details/client/context/ProductOptionsModel';
 import productVariantsModel from '../details/client/components/model';
+import ProductPassport from './ProductPassport';
 
 const numericSize = (caption: string) => {
   const m = String(caption ?? '').match(/[\d.]+/);
@@ -271,14 +272,15 @@ export default function PremiumDetails({
         {MOR_CHECKOUT_ENABLED ? 'Buy now' : 'Add to bag'}
       </button>
 
-      {/* Phase 0 (product-passport strategy 2026-07-16): the authenticity slot
-          under the CTA is intentionally EMPTY, not a "Mint it to merch" link.
-          "Mint to Merch" is a CREATOR mechanism (upload artwork → mint a POD
-          design) and belongs on a creator surface, not dressed up as an
-          ownership/provenance affordance on a buy page. This slot is reserved
-          for the conditional onchain product-passport / authenticity module
-          (VerifiedOnchainBadge + dpp/proof:gtin) — rendered only when a
-          confirmed onchain record exists for the item. */}
+      {/* Authenticity slot (product-passport strategy 2026-07-16). NOT a
+          "Mint it to merch" link — "Mint to Merch" is a CREATOR mechanism and
+          belongs on a creator surface, not dressed up as a provenance affordance
+          on a buy page. This is the conditional onchain product-passport module
+          (Phase 1): flag-gated (NEXT_PUBLIC_PDP_PASSPORT_ENABLED), read-only,
+          and it renders NOTHING unless a CONFIRMED onchain DPP proof exists for
+          the item (never on pending/simulated) — so it is invisible by default
+          and self-fail-open. */}
+      <ProductPassport product={product} />
 
       {/* Trust row — same POLICY source as the sitewide footer */}
       <p className="mt-6 text-[12px] leading-5 text-neutral-500">

--- a/src/app/(routes)/[productId]/components/premium/ProductPassport.tsx
+++ b/src/app/(routes)/[productId]/components/premium/ProductPassport.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+/**
+ * ProductPassport — the conditional onchain-authenticity module for the
+ * premium PDP's reserved authenticity slot (below the CTA in PremiumDetails).
+ *
+ * Phase 1 of the product-passport strategy (2026-07-16): port the old Vite
+ * storefront's onchain-authenticity primitives (VerifiedOnchainBadge /
+ * VerifiedBrandBadge / apis/dpp) into Next-ShopFront, rendered CONDITIONALLY
+ * and read-only.
+ *
+ * Behaviour contract:
+ *   - Flag-gated by NEXT_PUBLIC_PDP_PASSPORT_ENABLED. OFF → returns null before
+ *     any fetch fires (zero side-effects during the dark-launch window).
+ *   - Keys off the product's gtin (fallback sku/mpn). No key → renders nothing.
+ *   - Renders the badge ONLY on a CONFIRMED onchain DPP proof
+ *     (isConfirmedDppProof). Pending / simulated / unverified → nothing.
+ *   - Fail-open: any fetch error → renders nothing, never breaks the PDP. The
+ *     fetch is client-side (this is a client island), so it can never 500 the
+ *     SSR render either.
+ *   - Read-only. NO wallet gate.
+ *
+ * Copy discipline (POD items): "onchain product passport", "provenance",
+ * "proof of purchase" — never "you own this onchain".
+ */
+
+import { useEffect, useState } from 'react';
+import { PDP_PASSPORT_ENABLED } from '@/lib/variables/variables';
+import type { IProduct } from '@/types/interfaces/product/product';
+import { buildAttestationUrl, chainLabelSuffix } from '@/lib/dpp/chain';
+import type { IDppPassportFields, IPublicDppProofEnvelope } from '@/lib/dpp/interface';
+import {
+  fetchDppProof,
+  isConfirmedDppProof,
+  resolveProductPassportKey,
+} from '@/lib/dpp/services';
+
+function ShieldCheck() {
+  return (
+    <svg
+      aria-hidden="true"
+      width={13}
+      height={13}
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M8 1.5l5 2v3.5c0 3-2.1 5.4-5 6.5-2.9-1.1-5-3.5-5-6.5V3.5l5-2z"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M5.8 8l1.6 1.6L10.4 6.6"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+/** Merge passport presentation fields (nested `passport` OR flat on envelope). */
+function mergedFields(env: IPublicDppProofEnvelope): IDppPassportFields & { manufacturer?: string } {
+  const nested = env.passport ?? {};
+  return {
+    manufacturer: nested.manufacturer ?? env.manufacturer,
+    countryOfOrigin: nested.countryOfOrigin,
+    composition: nested.composition,
+    spec: nested.spec,
+    lifecycle: nested.lifecycle,
+  };
+}
+
+export default function ProductPassport({ product }: { product: IProduct }) {
+  const [env, setEnv] = useState<IPublicDppProofEnvelope | null>(null);
+  const [open, setOpen] = useState(false);
+
+  // Dark-launch gate — resolved at module init (NEXT_PUBLIC_ is inlined).
+  const flagOn = PDP_PASSPORT_ENABLED;
+  const key = flagOn ? resolveProductPassportKey(product) : null;
+
+  useEffect(() => {
+    if (!flagOn || !key) return;
+    let cancelled = false;
+    (async () => {
+      const proof = await fetchDppProof(key);
+      if (cancelled) return;
+      // Only keep a CONFIRMED proof; anything else stays null → renders nothing.
+      setEnv(isConfirmedDppProof(proof) ? proof : null);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [flagOn, key]);
+
+  // Absolute gate: nothing unless flag on + key present + a CONFIRMED proof.
+  if (!flagOn || !key) return null;
+  if (!isConfirmedDppProof(env)) return null;
+
+  const anchor = env.onchainAnchor!;
+  const fields = mergedFields(env);
+  const attestationUrl = buildAttestationUrl(anchor.chain, anchor.attestationUid);
+  const chainSuffix = chainLabelSuffix(anchor.chain);
+
+  // Two-tier label: manufacturer-vouch (stronger) vs. published DPP.
+  const manufacturerVouched = env.manufacturerVerified === true && !!fields.manufacturer;
+  const badgeLabel = manufacturerVouched
+    ? `Verified by ${fields.manufacturer}`
+    : 'Onchain product passport';
+
+  const rows: Array<{ label: string; value: string }> = [];
+  if (fields.manufacturer) rows.push({ label: 'Manufacturer', value: fields.manufacturer });
+  if (fields.countryOfOrigin)
+    rows.push({ label: 'Country of origin', value: fields.countryOfOrigin });
+  if (fields.composition) rows.push({ label: 'Composition', value: fields.composition });
+  if (fields.spec) rows.push({ label: 'Specification', value: fields.spec });
+
+  const lifecycle = Array.isArray(fields.lifecycle) ? fields.lifecycle : [];
+
+  return (
+    <div className="mt-6" data-testid="pdp-product-passport">
+      {/* Quiet badge — the presence of this on some products and not others is
+          the signal. Tap to open the passport panel. */}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls="pdp-passport-panel"
+        className="inline-flex items-center gap-1.5 rounded-full border border-neutral-300 bg-white px-3 py-1.5 text-[12px] font-medium text-neutral-700 transition-colors hover:border-neutral-900 hover:text-neutral-900"
+      >
+        <span className="text-neutral-900">
+          <ShieldCheck />
+        </span>
+        <span>{badgeLabel}</span>
+        <span className="text-neutral-400">{open ? '−' : '+'}</span>
+      </button>
+
+      {open && (
+        <div
+          id="pdp-passport-panel"
+          role="region"
+          aria-label="Product passport"
+          className="mt-3 rounded-md border border-neutral-200 bg-neutral-50 p-4 text-[13px] leading-6 text-neutral-600"
+        >
+          <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-neutral-500">
+            {manufacturerVouched
+              ? 'Manufacturer-verified passport'
+              : 'Onchain product passport'}
+          </p>
+
+          {rows.length > 0 && (
+            <dl className="mt-3 grid grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-2">
+              {rows.map((r) => (
+                <div key={r.label} className="flex flex-col">
+                  <dt className="text-[11px] uppercase tracking-wide text-neutral-400">
+                    {r.label}
+                  </dt>
+                  <dd className="text-[13px] text-neutral-800">{r.value}</dd>
+                </div>
+              ))}
+            </dl>
+          )}
+
+          {lifecycle.length > 0 && (
+            <div className="mt-4">
+              <p className="text-[11px] uppercase tracking-wide text-neutral-400">Lifecycle</p>
+              <ol className="mt-2 flex flex-col gap-1.5">
+                {lifecycle.map((ev, i) => (
+                  <li key={`${ev.label}-${i}`} className="flex items-baseline gap-2">
+                    <span className="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-neutral-400" />
+                    <span className="text-[13px] text-neutral-700">{ev.label}</span>
+                    {ev.date && (
+                      <span className="text-[12px] text-neutral-400">{ev.date}</span>
+                    )}
+                  </li>
+                ))}
+              </ol>
+            </div>
+          )}
+
+          <p className="mt-4 text-[12px] leading-5 text-neutral-500">
+            A provenance record for this item, anchored onchain{chainSuffix ? ` on ${chainSuffix}` : ''}.
+            When you purchase, it links to your proof of purchase.
+          </p>
+
+          {attestationUrl && (
+            <a
+              href={attestationUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-3 inline-flex items-center gap-1 text-[12px] font-medium text-neutral-900 underline underline-offset-2 hover:text-neutral-600"
+            >
+              View on Base
+              <span aria-hidden>↗</span>
+            </a>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/dpp/chain.ts
+++ b/src/lib/dpp/chain.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure chain projectors for the DPP passport module.
+ *
+ * Ported from the old Vite storefront's
+ *   src/components/VerifiedOnchainBadge/chainLabel.ts
+ * and extended with the confirmed-chain predicate + the Base attestation
+ * explorer deep-link ("View on Base").
+ *
+ * No React / DOM imports — pure functions, safe to run on the server or in a
+ * node test.
+ *
+ * "Base mainnet" / "Base sepolia" are EVM chain identifiers (not partner
+ * branding) and are allowed in user-visible strings. `simulated` is the
+ * local/dev synthetic anchor and is NEVER a confirmed chain.
+ */
+
+import type { DppChainSlug } from "./interface";
+
+/** The only two chain slugs that represent a CONFIRMED onchain anchor. */
+const CONFIRMED_CHAINS = new Set<DppChainSlug>(["base-mainnet", "base-sepolia"]);
+
+/**
+ * True only for a confirmed EVM anchor. `simulated`, unknown slugs, null, and
+ * undefined all return false — the badge must never light on a non-confirmed
+ * anchor.
+ */
+export function isConfirmedChain(chain: DppChainSlug | null | undefined): boolean {
+  return !!chain && CONFIRMED_CHAINS.has(chain);
+}
+
+/**
+ * BE `onchainAnchor.chain` slug → user-visible suffix. Returns null for any
+ * non-confirmed chain (keep the generic label; never surface "simulated").
+ */
+export function chainLabelSuffix(chain: DppChainSlug | null | undefined): string | null {
+  if (chain === "base-mainnet") return "Base mainnet";
+  if (chain === "base-sepolia") return "Base sepolia";
+  return null;
+}
+
+/**
+ * Build the EAS attestation explorer URL on Base for a confirmed anchor.
+ * Returns null when the chain isn't confirmed or the UID is missing — so the
+ * "View on Base" affordance only ever renders when it can point at a real,
+ * confirmed attestation.
+ */
+export function buildAttestationUrl(
+  chain: DppChainSlug | null | undefined,
+  attestationUid: string | null | undefined,
+): string | null {
+  if (!attestationUid) return null;
+  if (chain === "base-mainnet") {
+    return `https://base.easscan.org/attestation/view/${attestationUid}`;
+  }
+  if (chain === "base-sepolia") {
+    return `https://base-sepolia.easscan.org/attestation/view/${attestationUid}`;
+  }
+  return null;
+}

--- a/src/lib/dpp/interface.ts
+++ b/src/lib/dpp/interface.ts
@@ -1,0 +1,89 @@
+/**
+ * Public DPP (Digital Product Passport) proof envelope returned by
+ *   GET https://apiv3.droplinked.com/dpp/proof/:gtin   (live, @Public, no auth)
+ *
+ * Ported from the old Vite storefront's `src/apis/dpp/interface.ts`
+ * (droplinked-shopfront, Schema F public envelope) and EXTENDED with the
+ * canonical passport-presentation fields the premium PDP panel renders
+ * (manufacturer / country of origin / composition / spec / lifecycle).
+ *
+ * Every field is defensively OPTIONAL: the BE envelope shape is treated as
+ * untrusted input. The module keys its render decision off the confirmed
+ * onchain-anchor + `verified` flag (see `isConfirmedDppProof`), and the panel
+ * renders only the presentation fields that are actually present — so an
+ * envelope that omits, renames, or nests any field degrades gracefully to a
+ * smaller panel rather than a crash.
+ *
+ * Truth-condition note: the two BE-blessed CONFIRMED EVM slugs are
+ * `base-mainnet` / `base-sepolia`. `simulated` is the local/dev synthetic
+ * anchor and MUST NEVER light the badge (see chain.ts + services.ts). Given
+ * the batched-writer gas-stub history (minted rows that never landed onchain),
+ * a PENDING/simulated anchor is explicitly not a confirmed proof.
+ */
+
+/** BE onchain-anchor chain slug. Only the two EVM slugs are "confirmed". */
+export type DppChainSlug = "base-mainnet" | "base-sepolia" | "simulated" | (string & {});
+
+/** A single lifecycle timeline entry (created / anchored / imported / ...). */
+export interface IDppLifecycleEvent {
+  /** Human label, e.g. "Manufactured", "Anchored onchain". */
+  label: string;
+  /** ISO date string; optional. */
+  date?: string;
+  /** Optional place/context, e.g. a country or facility. */
+  location?: string;
+}
+
+/** Canonical passport presentation fields (ESPR-aligned). All optional. */
+export interface IDppPassportFields {
+  manufacturer?: string;
+  countryOfOrigin?: string;
+  composition?: string;
+  /** Frozen canonical spec summary (free text). */
+  spec?: string;
+  lifecycle?: IDppLifecycleEvent[];
+}
+
+/** Onchain anchor metadata for the confirmed-proof gate + "View on Base" link. */
+export interface IDppOnchainAnchor {
+  chain: DppChainSlug;
+  attestationUid: string;
+  batchPeriod?: string;
+  merkleRoot?: string;
+  recordCount?: number;
+  /** Optional confirmation status; anything other than CONFIRMED is not shown. */
+  status?: "CONFIRMED" | "PENDING" | (string & {});
+}
+
+/**
+ * The public DPP proof envelope. Fields the badge/panel consume are typed;
+ * unknown extra fields (frozenFields, merkleProof, proofLengthBytes, …) are
+ * ignored — independent verifiers read those, the customer-facing panel does
+ * not.
+ */
+export interface IPublicDppProofEnvelope {
+  gtin?: string;
+  sku?: string;
+  schema?: string;
+  /** null/absent = no onchain anchor → not a confirmed proof. */
+  onchainAnchor?: IDppOnchainAnchor | null;
+  leafHash?: string;
+  /** BE's own verification flag — must be true for a confirmed proof. */
+  verified?: boolean;
+  /** Published DPP timestamp; part of the "published + confirmed anchor" gate. */
+  publishedAt?: string | null;
+
+  /**
+   * Passport presentation fields. The BE may return these flat on the envelope
+   * OR nested under `passport`; the panel reads both (see ProductPassport).
+   */
+  passport?: IDppPassportFields;
+
+  /**
+   * Manufacturer-vouch (brand-attestation MINTED) tier — the STRONGER
+   * "Verified by {manufacturer}" label. Only used when explicitly confirmed;
+   * absent → the panel uses the "Onchain product passport" label.
+   */
+  manufacturer?: string;
+  manufacturerVerified?: boolean;
+}

--- a/src/lib/dpp/services.ts
+++ b/src/lib/dpp/services.ts
@@ -1,0 +1,133 @@
+/**
+ * Public DPP proof client + the confirmed-proof truth condition + the
+ * product → gtin/sku/mpn identifier resolver.
+ *
+ * Ported/adapted from the old Vite storefront's `src/apis/dpp/services.ts`
+ * (which used the app axios instance). Next-ShopFront has no shared axios
+ * client, so this uses a plain `fetch` against the absolute apiv3 host — the
+ * same pattern the SSR structured-data loader uses. The DPP proof endpoint is
+ * @Public (no auth / no shop context needed).
+ *
+ * ENDPOINT NOTE: the strategy memo refers to this read as `dpp/proof/:gtin`,
+ * but the LIVE apiv3 route is `v2/dpp/:gtin` (confirmed 2026-07-16 by probing:
+ * `GET /dpp/proof/<x>` → route-level 404 "Cannot GET"; `GET /v2/dpp/<x>` →
+ * data-level 404 "gtin <x> not found" — i.e. the route exists and only the
+ * gtin is unknown). This is the same public Schema F envelope the old Vite
+ * shopfront's VerifiedOnchainBadge already consumed. Fail-open makes the path
+ * choice non-fatal, but we point at the route that actually resolves.
+ *
+ * Posture (unchanged from the port):
+ *   - Silent-degrade: returns null on ANY non-2xx / network error / bad JSON.
+ *     The caller renders NOTHING on null — a stale/unconfirmed "verified" claim
+ *     is worse than no badge, and the PDP must never break on a passport miss.
+ *   - SSR-safe: never throws, so a server render can call it without a chance
+ *     of 500-ing the page (the Phase-1 component calls it client-side, but the
+ *     fetcher is agnostic).
+ *   - No retry: the BE endpoint is CDN-cached and rate-limited; one request is
+ *     enough for the PDP lifetime.
+ */
+
+import type { IProduct } from "@/types/interfaces/product/product";
+import { isConfirmedChain } from "./chain";
+import type { IPublicDppProofEnvelope } from "./interface";
+
+/** Absolute apiv3 host — matches the SSR structured-data loader. */
+const APIV3_BASE = "https://apiv3.droplinked.com";
+
+/**
+ * Fetch the public DPP proof envelope for a gtin (or sku/mpn — the endpoint
+ * resolves any of them by path). Returns null on ANY failure. Never throws.
+ */
+export async function fetchDppProof(
+  identifier: string | null | undefined,
+): Promise<IPublicDppProofEnvelope | null> {
+  const key = (identifier ?? "").trim();
+  if (!key) return null;
+
+  try {
+    const res = await fetch(
+      `${APIV3_BASE}/v2/dpp/${encodeURIComponent(key)}`,
+      {
+        headers: { Accept: "application/json" },
+        // ISR-friendly if ever called from the server; harmless client-side.
+        next: { revalidate: 300 },
+      },
+    );
+    if (!res.ok) return null; // 404 (no passport) / 5xx / etc. → silent-degrade
+    const data = (await res.json()) as IPublicDppProofEnvelope;
+    return data ?? null;
+  } catch {
+    // Network / CORS / bad JSON → silent-degrade. Caller renders nothing.
+    return null;
+  }
+}
+
+/**
+ * THE truth condition. A passport badge may render ONLY when the envelope
+ * represents a CONFIRMED onchain proof:
+ *   - BE `verified` flag is true, AND
+ *   - there is an onchain anchor with a real attestation UID, AND
+ *   - the anchor chain is a confirmed EVM slug (base-mainnet / base-sepolia) —
+ *     NEVER `simulated`, AND
+ *   - the anchor status (when present) is not PENDING.
+ *
+ * Anything else — no envelope, verified false/absent, no anchor, simulated
+ * chain, pending status — returns false, so the module renders nothing. This
+ * is the guard that keeps a badge from ever pointing at a non-existent /
+ * unlanded attestation.
+ */
+export function isConfirmedDppProof(
+  env: IPublicDppProofEnvelope | null | undefined,
+): env is IPublicDppProofEnvelope {
+  if (!env) return false;
+  if (env.verified !== true) return false;
+
+  const anchor = env.onchainAnchor;
+  if (!anchor) return false;
+  if (!anchor.attestationUid) return false;
+  if (!isConfirmedChain(anchor.chain)) return false;
+  if (anchor.status && anchor.status !== "CONFIRMED") return false;
+
+  return true;
+}
+
+/**
+ * Resolve the best passport lookup key from a product: gtin first, then a sku
+ * code, then an mpn. Returns null when the product carries none — in which case
+ * the module renders nothing (POD/long-tail items frequently have no gtin).
+ *
+ * IProduct does not type these identity fields today, so we read them
+ * defensively across the likely locations (product-level and first-sku level,
+ * including `recordData`). Every access is guarded and string-trimmed.
+ */
+export function resolveProductPassportKey(product: IProduct | null | undefined): string | null {
+  if (!product) return null;
+
+  const p = product as unknown as Record<string, unknown>;
+  const firstSku = (product.skuIDs?.[0] ?? {}) as unknown as Record<string, unknown>;
+  const skuRecord = (firstSku.recordData ?? {}) as Record<string, unknown>;
+
+  const pick = (v: unknown): string | null => {
+    if (typeof v === "string") {
+      const t = v.trim();
+      return t.length > 0 ? t : null;
+    }
+    if (typeof v === "number" && Number.isFinite(v)) return String(v);
+    return null;
+  };
+
+  // Priority: gtin (barcode) → sku code → mpn.
+  return (
+    pick(p.gtin) ??
+    pick(p.barcode) ??
+    pick(skuRecord.gtin) ??
+    pick(skuRecord.barcode) ??
+    pick(firstSku.gtin) ??
+    pick(firstSku.sku) ??
+    pick(firstSku.externalID) ??
+    pick(p.custome_external_id) ??
+    pick(p.mpn) ??
+    pick(skuRecord.mpn) ??
+    null
+  );
+}

--- a/src/lib/variables/variables.ts
+++ b/src/lib/variables/variables.ts
@@ -51,6 +51,20 @@ export const UNIFIED_PDP_ENABLED =
  */
 export const PREMIUM_PDP_ENABLED =
   process.env.NEXT_PUBLIC_PREMIUM_PDP_ENABLED === "true";
+
+/**
+ * PDP product passport (Phase 1): render the conditional onchain-authenticity
+ * module in the premium PDP's reserved authenticity slot (below the CTA). When
+ * ON, the module reads the public DPP proof (`GET apiv3/dpp/proof/:gtin`) for
+ * the item and renders a quiet badge + passport panel ONLY when a CONFIRMED
+ * onchain proof exists (never on pending/simulated); no proof → renders
+ * nothing. Read-only, no wallet gate; fail-open (any fetch error → nothing).
+ * NEXT_PUBLIC_ so Next inlines it at build time (standalone runner carries no
+ * .env). Default OFF — set NEXT_PUBLIC_PDP_PASSPORT_ENABLED=true to enable
+ * (reversible, no code revert). See product-passport-platform-strategy-2026-07-16.
+ */
+export const PDP_PASSPORT_ENABLED =
+  process.env.NEXT_PUBLIC_PDP_PASSPORT_ENABLED === "true";
 export const variantIDs = { color: { _id: "62a989ab1f2c2bbc5b1e7153" }, size: { _id: "62a989e21f2c2bbc5b1e7154" } };
 export const app_vertical = "flex flex-col items-center justify-center";
 export const app_center = "flex items-center justify-center";


### PR DESCRIPTION
**PR — DO NOT MERGE.** Review-only; awaiting operator merge gate. Flag-gated **OFF** by default.

Phase 1 of the product-passport strategy (`product-passport-platform-strategy-2026-07-16.md`): port the already-built onchain-authenticity primitives from the old Vite storefront into the premium PDP, rendered **conditionally** and **read-only**, in the authenticity slot below the CTA (`PremiumDetails.tsx`) that was reserved for exactly this.

## What renders, and when
A quiet badge — **"Onchain product passport"** (published DPP) or **"Verified by {manufacturer}"** (manufacturer-vouch tier) — appears **only** when the item resolves to a **confirmed** onchain DPP proof. Tapping it opens an inline passport panel: canonical fields (manufacturer, country of origin, composition, spec), a lifecycle timeline, a provenance/"proof of purchase" line, and a **"View on Base"** attestation deep-link. No wallet gate.

### Exact render condition (`isConfirmedDppProof`)
Renders **iff** ALL hold:
- envelope present AND `verified === true`, AND
- `onchainAnchor` present with a non-empty `attestationUid`, AND
- `onchainAnchor.chain` ∈ { `base-mainnet`, `base-sepolia` } — **never `simulated`**, AND
- `onchainAnchor.status` (when present) is not `PENDING`.

Otherwise → **renders nothing** (no "unverified" shell). This is the guard that keeps a badge from ever pointing at a non-existent / unlanded attestation (given the batched-writer gas-stub history).

### Fail-open
Flag OFF, no resolvable gtin/sku/mpn, any non-2xx / CORS / network / bad-JSON, or a non-confirmed proof → the component returns `null` and the PDP is untouched. The fetch is **client-side** (this is a client island), so it can never 500 the SSR render. `fetchDppProof` never throws.

### Copy discipline
"provenance record", "proof of purchase", "anchored onchain" — never "you own this onchain" (POD items).

## Ported vs. new
**Ported / adapted** from `droplinked-shopfront` (the OTHER repo was NOT modified):
- `apis/dpp/interface.ts` + `services.ts` → `src/lib/dpp/interface.ts` + `services.ts` (Chakra/axios removed; plain `fetch`, App-Router conventions).
- `VerifiedOnchainBadge/chainLabel.ts` → `src/lib/dpp/chain.ts` (chain-suffix projector), extended with `isConfirmedChain` + `buildAttestationUrl` (Base EAScan link).
- `VerifiedOnchainBadge.tsx` / `VerifiedBrandBadge.tsx` behaviour (defensive "render nothing unless verified", two-tier label) → folded into the new component with MUI-free Tailwind matching `PremiumDetails.tsx`.

**Net-new** (per Phase-1 plan):
- `NEXT_PUBLIC_PDP_PASSPORT_ENABLED` flag.
- `resolveProductPassportKey(product)` — gtin → sku code → mpn resolution off `IProduct` (defensive; those identity fields aren't typed today).
- `ProductPassport.tsx` — the SSR-safe client island + passport panel UI.
- confirmed-proof truth predicate `isConfirmedDppProof`.

## Endpoint note
The strategy shorthand is `dpp/proof/:gtin`, but that is **not a live route** — probed 2026-07-16: `GET /dpp/proof/<x>` → route-level 404 "Cannot GET"; `GET /v2/dpp/<x>` → data-level 404 "gtin `<x>` not found" (route exists, gtin just unknown). The client points at the **live** `v2/dpp/:gtin` (the same public Schema F envelope the old shopfront's badge consumed). Fail-open makes this non-fatal either way.

## GTIN coverage (deferred / note)
The demo product `womens-athletic-shoes` could not be resolved to a GTIN: `v2/dpp/womens-athletic-shoes` → "gtin not found", and its structured-data lookup 404s under the `shop` handle used for probing — so there is **no confirmed proof to light the badge with today**, and the module correctly renders nothing. Enabling the flag is safe (renders nothing until a real gtin with a confirmed proof exists). Measuring premium-catalog GTIN coverage before a wider rollout is the open item from strategy §5.1.

## Flag-gate / scope
- Flag lives in `src/lib/variables/variables.ts`, default OFF. **Nothing added to `main.yml` / `dev.yml`** (flags flipped separately).
- Additive only; no change to any existing render path when the flag is OFF.

## Files changed
- `src/lib/variables/variables.ts` — new flag
- `src/lib/dpp/interface.ts` (new), `src/lib/dpp/chain.ts` (new), `src/lib/dpp/services.ts` (new)
- `src/app/(routes)/[productId]/components/premium/ProductPassport.tsx` (new)
- `src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx` — render the module in the reserved slot

## Gates
- `npx tsc --noEmit -p tsconfig.json` → 0 errors
- `npm test` (node --test smoke) → 3 pass / 0 fail
- `NEXT_TELEMETRY_DISABLED=1 npx next build` → exit 0, 0 errors

## Closes / addresses
- Replaces the empty/"Mint-to-Merch" authenticity slot on the premium PDP with the conditional onchain product-passport module (strategy §3 / Phase 1).
- Establishes the confirmed-proof-only render gate (strategy §2 truth condition / §5.2) so a badge can never surface a pending/simulated attestation.
