### PR TITLE
fix(pdp): POD items show Printful made-to-order return terms, not the 14-day window

### DIFF
--- a/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
+++ b/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
@@ -23,10 +23,12 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
 import { toast } from 'sonner';
 import { IProduct, ISku } from '@/types/interfaces/product/product';
 import { MOR_CHECKOUT_ENABLED, variantIDs } from '@/lib/variables/variables';
-import { POLICY } from '@/lib/site';
+import { POD_POLICY, POLICY } from '@/lib/site';
+import { isPodProduct } from '@/lib/pod';
 import useAppCart from '@/state/hooks/cart/useAppCart';
 import productClientModel from '../details/client/context/ProductOptionsModel';
 import productVariantsModel from '../details/client/components/model';
@@ -88,6 +90,12 @@ export default function PremiumDetails({
   }, [sku]);
 
   const price = sku?.price ?? product?.skuIDs?.[0]?.price ?? 0;
+
+  // POD (made to order via Printful): the trust surface must show Printful's
+  // made-to-order terms — no buyer's-remorse/size returns; damaged/misprinted/
+  // defective replaced when reported within POD_POLICY.claimWindowDays of
+  // delivery. Non-POD copy stays byte-identical.
+  const pod = isPodProduct(product);
 
   const buy = async () => {
     if (busy) return;
@@ -159,7 +167,7 @@ export default function PremiumDetails({
           ${Number(price).toFixed(2)}
         </span>
         <span className="text-xs text-neutral-500">
-          Free {POLICY.returnWindowDays}-day returns
+          {pod ? 'Made to order' : <>Free {POLICY.returnWindowDays}-day returns</>}
         </span>
       </div>
 
@@ -282,11 +290,26 @@ export default function PremiumDetails({
           and self-fail-open. */}
       <ProductPassport product={product} />
 
-      {/* Trust row — same POLICY source as the sitewide footer */}
-      <p className="mt-6 text-[12px] leading-5 text-neutral-500">
-        Secure checkout · {POLICY.returnWindowDays}-day returns · Made to order —
-        ships in {POLICY.handlingTimeDays}
-      </p>
+      {/* Trust row — same POLICY source as the sitewide footer. POD items
+          carry Printful's made-to-order terms instead of the return window. */}
+      {pod ? (
+        <p className="mt-6 text-[12px] leading-5 text-neutral-500">
+          Secure checkout · Made to order — ships in {POLICY.handlingTimeDays} ·
+          Damaged or misprinted? We&apos;ll replace it — report within{' '}
+          {POD_POLICY.claimWindowDays} days of delivery.{' '}
+          <Link
+            href="/returns-policy"
+            className="underline underline-offset-2 hover:text-neutral-900"
+          >
+            Return policy
+          </Link>
+        </p>
+      ) : (
+        <p className="mt-6 text-[12px] leading-5 text-neutral-500">
+          Secure checkout · {POLICY.returnWindowDays}-day returns · Made to order —
+          ships in {POLICY.handlingTimeDays}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/app/(routes)/[productId]/components/premium/PremiumProductExperience.tsx
+++ b/src/app/(routes)/[productId]/components/premium/PremiumProductExperience.tsx
@@ -13,7 +13,8 @@
 
 import Link from 'next/link';
 import { inter } from '@/styles/fonts';
-import { POLICY } from '@/lib/site';
+import { POD_POLICY, POLICY } from '@/lib/site';
+import { isPodProduct } from '@/lib/pod';
 import type { IProduct } from '@/types/interfaces/product/product';
 import { sanitizeHtml } from '../../product/[slug]/lib/sanitize-html';
 import styles from '../../product/[slug]/description.module.css';
@@ -108,11 +109,24 @@ export default function PremiumProductExperience({
                     Every piece is made to order and ships in {POLICY.handlingTimeDays}{' '}
                     with tracking.
                   </p>
-                  <p>
-                    Returns are free within {POLICY.returnWindowDays} days of delivery —
-                    refunds go back to your {POLICY.refundMethod} within{' '}
-                    {POLICY.refundProcessingDays}.
-                  </p>
+                  {isPodProduct(product) ? (
+                    // POD (Printful) terms: made to order, so no size-change /
+                    // change-of-mind returns; damaged/misprinted/defective is
+                    // covered when reported within the claim window.
+                    <p>
+                      Each piece is printed just for you, so returns for size or
+                      change of mind aren&apos;t available. If your order arrives
+                      damaged, misprinted, or defective, contact us within{' '}
+                      {POD_POLICY.claimWindowDays} days of delivery — we&apos;ll
+                      replace it or refund you in full.
+                    </p>
+                  ) : (
+                    <p>
+                      Returns are free within {POLICY.returnWindowDays} days of delivery —
+                      refunds go back to your {POLICY.refundMethod} within{' '}
+                      {POLICY.refundProcessingDays}.
+                    </p>
+                  )}
                   <p className="text-[13px]">
                     <Link
                       href="/shipping-policy"

--- a/src/app/(routes)/returns-policy/page.tsx
+++ b/src/app/(routes)/returns-policy/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import LegalPage, { LegalSection } from "@/components/core/legal/LegalPage";
-import { POLICY, SITE } from "@/lib/site";
+import { POD_POLICY, POLICY, SITE } from "@/lib/site";
 
 export const metadata: Metadata = {
   title: "Returns & Refunds | droplinked",
@@ -57,6 +57,36 @@ export default function ReturnsPolicyPage() {
           Customers are responsible for return shipping costs unless the item
           arrived damaged, defective, or was sent in error, in which case
           droplinked covers return shipping and replacement or refund.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Made-to-Order (Print-on-Demand) Items">
+        <p>
+          Some items on droplinked are printed on demand — produced
+          individually for your order by our fulfillment partner. Because each
+          piece is made just for you, made-to-order items cannot be returned
+          or exchanged for a different size or a change of mind. These items
+          are identified as made to order on the product page before purchase.
+        </p>
+        <p>
+          If a made-to-order item arrives damaged, misprinted, or defective,
+          email{" "}
+          <a
+            href={`mailto:${SITE.supportEmail}`}
+            className="text-mint-500 transition-colors hover:text-mint-400"
+          >
+            {SITE.supportEmail}
+          </a>{" "}
+          within <strong>{POD_POLICY.claimWindowDays} days of delivery</strong>{" "}
+          with your order number and photos of the issue. We will send a
+          replacement or issue a full refund at no cost to you.
+        </p>
+        <p>
+          For customers in the European Union: under Article 16(c) of
+          Directive 2011/83/EU on consumer rights, the 14-day right of
+          withdrawal does not apply to goods made to the consumer&apos;s
+          specifications or clearly personalized. Your statutory rights for
+          defective goods are not affected.
         </p>
       </LegalSection>
 

--- a/src/lib/pod.ts
+++ b/src/lib/pod.ts
@@ -1,0 +1,29 @@
+/**
+ * pod.ts — the ONE print-on-demand (POD) product detector.
+ *
+ * POD items are produced per order by the print partner (Printful), so every
+ * trust surface must render made-to-order terms (see POD_POLICY in site.ts),
+ * never the standard return window — a made-to-order item promising "free
+ * 14-day returns" is a promise fulfillment cannot deliver.
+ *
+ * The type spelling differs by data source, so match both:
+ *   • product-v2 public API carries `type: "pod"` (uppercased to "POD" by the
+ *     V2→legacy adapter in product-data.ts, which maps type/product_type via
+ *     `String(v2.type).toUpperCase()`).
+ *   • the legacy shop-scoped product API carries `PRINT_ON_DEMAND`
+ *     (product-type enum on droplinked-backend).
+ */
+import type { IProduct } from '@/types/interfaces/product/product';
+
+const POD_TYPES = new Set(['POD', 'PRINT_ON_DEMAND']);
+
+/** True when the product is print-on-demand (made to order, Printful terms). */
+export function isPodProduct(
+  product: Pick<IProduct, 'type' | 'product_type'> | null | undefined,
+): boolean {
+  if (!product) return false;
+  return (
+    POD_TYPES.has(String(product.type ?? '').toUpperCase()) ||
+    POD_TYPES.has(String(product.product_type ?? '').toUpperCase())
+  );
+}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -78,6 +78,24 @@ export const POLICY = {
   handlingTimeDays: "1–3 business days",
 } as const;
 
+/**
+ * Made-to-order (print-on-demand) terms. POD items are produced per order by
+ * the print partner (Printful), so they piggyback Printful's return terms
+ * instead of the standard {@link POLICY} return window: no returns for size
+ * changes or change of mind; damaged, misprinted, or defective items are
+ * replaced or refunded when reported within {@link POD_POLICY.claimWindowDays}
+ * days of delivery. Source: Printful Return Policy
+ * (https://www.printful.com/policies/returns, last updated 2022-06-03) —
+ * "Any claims for misprinted/damaged/defective items must be submitted within
+ * 30 days after the product has been received." EU nuance: per Article 16(c)
+ * of Directive 2011/83/EU the 14-day right of withdrawal may not be provided
+ * for goods made to the consumer's specifications or clearly personalized.
+ */
+export const POD_POLICY = {
+  /** Damaged / misprinted / defective claim window, in days from delivery. */
+  claimWindowDays: 30,
+} as const;
+
 /** Footer / policy navigation targets. Every href resolves to a real route. */
 export const POLICY_LINKS = [
   { label: "Shipping Policy", href: "/shipping-policy" },


### PR DESCRIPTION
## Closes / addresses
Operator directive: POD (Printful-fulfilled) items on shop.droplinked.com must reflect Printful's terms, not the blanket 14-day GMC policy.

**Printful terms verified** (printful.com/policies/returns): claims for misprinted/damaged/defective items within 30 days of delivery; no buyer's-remorse refunds (Brazil carve-out); EU Directive 2011/83/EU Art. 16(c)/(e) withdrawal carve-out for made-to-order goods.

**Changes (POD-only branch via isPodProduct(); non-POD byte-identical, runtime-verified):**
- Price row: 'Free 14-day returns' → 'Made to order'
- Trust row: '… · Made to order — ships in 1–3 business days · Damaged or misprinted? We'll replace it — report within 30 days of delivery.' + Return policy link
- Accordion: made-to-order no-remorse + 30-day defect replacement copy
- /returns-policy: new Made-to-Order (POD) section incl. EU Art. 16(c) notice + statutory-rights preservation

**Verified:** built + served against the real prod POD payload and a type-mutated non-POD twin — POD branch renders new copy, non-POD renders the exact legacy strings, unknown type fails open to legacy. lint 0 errors · build 28/28 · smoke 3/3.

**Follow-ups flagged (not this PR):** backend JSON-LD emits 14-day MerchantReturnFiniteReturnWindow for ALL products (structured-data.service.ts:244 — BE PR incoming); Merchant Center account-level return settings (manual, account 5814803688); sitewide footer 14-day line; slug-route static-teaser fallback lacks product type.