### PR TITLE
GTFU: dev → main (POD Printful return terms + breadcrumb polish + flag-gated passport Phase 1)

### DIFF
--- a/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
+++ b/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
@@ -23,10 +23,12 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
 import { toast } from 'sonner';
 import { IProduct, ISku } from '@/types/interfaces/product/product';
 import { MOR_CHECKOUT_ENABLED, variantIDs } from '@/lib/variables/variables';
-import { POLICY } from '@/lib/site';
+import { POD_POLICY, POLICY } from '@/lib/site';
+import { isPodProduct } from '@/lib/pod';
 import useAppCart from '@/state/hooks/cart/useAppCart';
 import productClientModel from '../details/client/context/ProductOptionsModel';
 import productVariantsModel from '../details/client/components/model';
@@ -88,6 +90,12 @@ export default function PremiumDetails({
   }, [sku]);
 
   const price = sku?.price ?? product?.skuIDs?.[0]?.price ?? 0;
+
+  // POD (made to order via Printful): the trust surface must show Printful's
+  // made-to-order terms — no buyer's-remorse/size returns; damaged/misprinted/
+  // defective replaced when reported within POD_POLICY.claimWindowDays of
+  // delivery. Non-POD copy stays byte-identical.
+  const pod = isPodProduct(product);
 
   const buy = async () => {
     if (busy) return;
@@ -159,7 +167,7 @@ export default function PremiumDetails({
           ${Number(price).toFixed(2)}
         </span>
         <span className="text-xs text-neutral-500">
-          Free {POLICY.returnWindowDays}-day returns
+          {pod ? 'Made to order' : <>Free {POLICY.returnWindowDays}-day returns</>}
         </span>
       </div>
 
@@ -282,11 +290,26 @@ export default function PremiumDetails({
           and self-fail-open. */}
       <ProductPassport product={product} />
 
-      {/* Trust row — same POLICY source as the sitewide footer */}
-      <p className="mt-6 text-[12px] leading-5 text-neutral-500">
-        Secure checkout · {POLICY.returnWindowDays}-day returns · Made to order —
-        ships in {POLICY.handlingTimeDays}
-      </p>
+      {/* Trust row — same POLICY source as the sitewide footer. POD items
+          carry Printful's made-to-order terms instead of the return window. */}
+      {pod ? (
+        <p className="mt-6 text-[12px] leading-5 text-neutral-500">
+          Secure checkout · Made to order — ships in {POLICY.handlingTimeDays} ·
+          Damaged or misprinted? We&apos;ll replace it — report within{' '}
+          {POD_POLICY.claimWindowDays} days of delivery.{' '}
+          <Link
+            href="/returns-policy"
+            className="underline underline-offset-2 hover:text-neutral-900"
+          >
+            Return policy
+          </Link>
+        </p>
+      ) : (
+        <p className="mt-6 text-[12px] leading-5 text-neutral-500">
+          Secure checkout · {POLICY.returnWindowDays}-day returns · Made to order —
+          ships in {POLICY.handlingTimeDays}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
+++ b/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
@@ -30,6 +30,7 @@ import { POLICY } from '@/lib/site';
 import useAppCart from '@/state/hooks/cart/useAppCart';
 import productClientModel from '../details/client/context/ProductOptionsModel';
 import productVariantsModel from '../details/client/components/model';
+import ProductPassport from './ProductPassport';
 
 const numericSize = (caption: string) => {
   const m = String(caption ?? '').match(/[\d.]+/);
@@ -271,14 +272,15 @@ export default function PremiumDetails({
         {MOR_CHECKOUT_ENABLED ? 'Buy now' : 'Add to bag'}
       </button>
 
-      {/* Phase 0 (product-passport strategy 2026-07-16): the authenticity slot
-          under the CTA is intentionally EMPTY, not a "Mint it to merch" link.
-          "Mint to Merch" is a CREATOR mechanism (upload artwork → mint a POD
-          design) and belongs on a creator surface, not dressed up as an
-          ownership/provenance affordance on a buy page. This slot is reserved
-          for the conditional onchain product-passport / authenticity module
-          (VerifiedOnchainBadge + dpp/proof:gtin) — rendered only when a
-          confirmed onchain record exists for the item. */}
+      {/* Authenticity slot (product-passport strategy 2026-07-16). NOT a
+          "Mint it to merch" link — "Mint to Merch" is a CREATOR mechanism and
+          belongs on a creator surface, not dressed up as a provenance affordance
+          on a buy page. This is the conditional onchain product-passport module
+          (Phase 1): flag-gated (NEXT_PUBLIC_PDP_PASSPORT_ENABLED), read-only,
+          and it renders NOTHING unless a CONFIRMED onchain DPP proof exists for
+          the item (never on pending/simulated) — so it is invisible by default
+          and self-fail-open. */}
+      <ProductPassport product={product} />
 
       {/* Trust row — same POLICY source as the sitewide footer */}
       <p className="mt-6 text-[12px] leading-5 text-neutral-500">

--- a/src/app/(routes)/[productId]/components/premium/PremiumProductExperience.tsx
+++ b/src/app/(routes)/[productId]/components/premium/PremiumProductExperience.tsx
@@ -13,7 +13,8 @@
 
 import Link from 'next/link';
 import { inter } from '@/styles/fonts';
-import { POLICY } from '@/lib/site';
+import { POD_POLICY, POLICY } from '@/lib/site';
+import { isPodProduct } from '@/lib/pod';
 import type { IProduct } from '@/types/interfaces/product/product';
 import { sanitizeHtml } from '../../product/[slug]/lib/sanitize-html';
 import styles from '../../product/[slug]/description.module.css';
@@ -108,11 +109,24 @@ export default function PremiumProductExperience({
                     Every piece is made to order and ships in {POLICY.handlingTimeDays}{' '}
                     with tracking.
                   </p>
-                  <p>
-                    Returns are free within {POLICY.returnWindowDays} days of delivery —
-                    refunds go back to your {POLICY.refundMethod} within{' '}
-                    {POLICY.refundProcessingDays}.
-                  </p>
+                  {isPodProduct(product) ? (
+                    // POD (Printful) terms: made to order, so no size-change /
+                    // change-of-mind returns; damaged/misprinted/defective is
+                    // covered when reported within the claim window.
+                    <p>
+                      Each piece is printed just for you, so returns for size or
+                      change of mind aren&apos;t available. If your order arrives
+                      damaged, misprinted, or defective, contact us within{' '}
+                      {POD_POLICY.claimWindowDays} days of delivery — we&apos;ll
+                      replace it or refund you in full.
+                    </p>
+                  ) : (
+                    <p>
+                      Returns are free within {POLICY.returnWindowDays} days of delivery —
+                      refunds go back to your {POLICY.refundMethod} within{' '}
+                      {POLICY.refundProcessingDays}.
+                    </p>
+                  )}
                   <p className="text-[13px]">
                     <Link
                       href="/shipping-policy"

--- a/src/app/(routes)/[productId]/components/premium/ProductPassport.tsx
+++ b/src/app/(routes)/[productId]/components/premium/ProductPassport.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+/**
+ * ProductPassport — the conditional onchain-authenticity module for the
+ * premium PDP's reserved authenticity slot (below the CTA in PremiumDetails).
+ *
+ * Phase 1 of the product-passport strategy (2026-07-16): port the old Vite
+ * storefront's onchain-authenticity primitives (VerifiedOnchainBadge /
+ * VerifiedBrandBadge / apis/dpp) into Next-ShopFront, rendered CONDITIONALLY
+ * and read-only.
+ *
+ * Behaviour contract:
+ *   - Flag-gated by NEXT_PUBLIC_PDP_PASSPORT_ENABLED. OFF → returns null before
+ *     any fetch fires (zero side-effects during the dark-launch window).
+ *   - Keys off the product's gtin (fallback sku/mpn). No key → renders nothing.
+ *   - Renders the badge ONLY on a CONFIRMED onchain DPP proof
+ *     (isConfirmedDppProof). Pending / simulated / unverified → nothing.
+ *   - Fail-open: any fetch error → renders nothing, never breaks the PDP. The
+ *     fetch is client-side (this is a client island), so it can never 500 the
+ *     SSR render either.
+ *   - Read-only. NO wallet gate.
+ *
+ * Copy discipline (POD items): "onchain product passport", "provenance",
+ * "proof of purchase" — never "you own this onchain".
+ */
+
+import { useEffect, useState } from 'react';
+import { PDP_PASSPORT_ENABLED } from '@/lib/variables/variables';
+import type { IProduct } from '@/types/interfaces/product/product';
+import { buildAttestationUrl, chainLabelSuffix } from '@/lib/dpp/chain';
+import type { IDppPassportFields, IPublicDppProofEnvelope } from '@/lib/dpp/interface';
+import {
+  fetchDppProof,
+  isConfirmedDppProof,
+  resolveProductPassportKey,
+} from '@/lib/dpp/services';
+
+function ShieldCheck() {
+  return (
+    <svg
+      aria-hidden="true"
+      width={13}
+      height={13}
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M8 1.5l5 2v3.5c0 3-2.1 5.4-5 6.5-2.9-1.1-5-3.5-5-6.5V3.5l5-2z"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M5.8 8l1.6 1.6L10.4 6.6"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+/** Merge passport presentation fields (nested `passport` OR flat on envelope). */
+function mergedFields(env: IPublicDppProofEnvelope): IDppPassportFields & { manufacturer?: string } {
+  const nested = env.passport ?? {};
+  return {
+    manufacturer: nested.manufacturer ?? env.manufacturer,
+    countryOfOrigin: nested.countryOfOrigin,
+    composition: nested.composition,
+    spec: nested.spec,
+    lifecycle: nested.lifecycle,
+  };
+}
+
+export default function ProductPassport({ product }: { product: IProduct }) {
+  const [env, setEnv] = useState<IPublicDppProofEnvelope | null>(null);
+  const [open, setOpen] = useState(false);
+
+  // Dark-launch gate — resolved at module init (NEXT_PUBLIC_ is inlined).
+  const flagOn = PDP_PASSPORT_ENABLED;
+  const key = flagOn ? resolveProductPassportKey(product) : null;
+
+  useEffect(() => {
+    if (!flagOn || !key) return;
+    let cancelled = false;
+    (async () => {
+      const proof = await fetchDppProof(key);
+      if (cancelled) return;
+      // Only keep a CONFIRMED proof; anything else stays null → renders nothing.
+      setEnv(isConfirmedDppProof(proof) ? proof : null);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [flagOn, key]);
+
+  // Absolute gate: nothing unless flag on + key present + a CONFIRMED proof.
+  if (!flagOn || !key) return null;
+  if (!isConfirmedDppProof(env)) return null;
+
+  const anchor = env.onchainAnchor!;
+  const fields = mergedFields(env);
+  const attestationUrl = buildAttestationUrl(anchor.chain, anchor.attestationUid);
+  const chainSuffix = chainLabelSuffix(anchor.chain);
+
+  // Two-tier label: manufacturer-vouch (stronger) vs. published DPP.
+  const manufacturerVouched = env.manufacturerVerified === true && !!fields.manufacturer;
+  const badgeLabel = manufacturerVouched
+    ? `Verified by ${fields.manufacturer}`
+    : 'Onchain product passport';
+
+  const rows: Array<{ label: string; value: string }> = [];
+  if (fields.manufacturer) rows.push({ label: 'Manufacturer', value: fields.manufacturer });
+  if (fields.countryOfOrigin)
+    rows.push({ label: 'Country of origin', value: fields.countryOfOrigin });
+  if (fields.composition) rows.push({ label: 'Composition', value: fields.composition });
+  if (fields.spec) rows.push({ label: 'Specification', value: fields.spec });
+
+  const lifecycle = Array.isArray(fields.lifecycle) ? fields.lifecycle : [];
+
+  return (
+    <div className="mt-6" data-testid="pdp-product-passport">
+      {/* Quiet badge — the presence of this on some products and not others is
+          the signal. Tap to open the passport panel. */}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls="pdp-passport-panel"
+        className="inline-flex items-center gap-1.5 rounded-full border border-neutral-300 bg-white px-3 py-1.5 text-[12px] font-medium text-neutral-700 transition-colors hover:border-neutral-900 hover:text-neutral-900"
+      >
+        <span className="text-neutral-900">
+          <ShieldCheck />
+        </span>
+        <span>{badgeLabel}</span>
+        <span className="text-neutral-400">{open ? '−' : '+'}</span>
+      </button>
+
+      {open && (
+        <div
+          id="pdp-passport-panel"
+          role="region"
+          aria-label="Product passport"
+          className="mt-3 rounded-md border border-neutral-200 bg-neutral-50 p-4 text-[13px] leading-6 text-neutral-600"
+        >
+          <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-neutral-500">
+            {manufacturerVouched
+              ? 'Manufacturer-verified passport'
+              : 'Onchain product passport'}
+          </p>
+
+          {rows.length > 0 && (
+            <dl className="mt-3 grid grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-2">
+              {rows.map((r) => (
+                <div key={r.label} className="flex flex-col">
+                  <dt className="text-[11px] uppercase tracking-wide text-neutral-400">
+                    {r.label}
+                  </dt>
+                  <dd className="text-[13px] text-neutral-800">{r.value}</dd>
+                </div>
+              ))}
+            </dl>
+          )}
+
+          {lifecycle.length > 0 && (
+            <div className="mt-4">
+              <p className="text-[11px] uppercase tracking-wide text-neutral-400">Lifecycle</p>
+              <ol className="mt-2 flex flex-col gap-1.5">
+                {lifecycle.map((ev, i) => (
+                  <li key={`${ev.label}-${i}`} className="flex items-baseline gap-2">
+                    <span className="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-neutral-400" />
+                    <span className="text-[13px] text-neutral-700">{ev.label}</span>
+                    {ev.date && (
+                      <span className="text-[12px] text-neutral-400">{ev.date}</span>
+                    )}
+                  </li>
+                ))}
+              </ol>
+            </div>
+          )}
+
+          <p className="mt-4 text-[12px] leading-5 text-neutral-500">
+            A provenance record for this item, anchored onchain{chainSuffix ? ` on ${chainSuffix}` : ''}.
+            When you purchase, it links to your proof of purchase.
+          </p>
+
+          {attestationUrl && (
+            <a
+              href={attestationUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-3 inline-flex items-center gap-1 text-[12px] font-medium text-neutral-900 underline underline-offset-2 hover:text-neutral-600"
+            >
+              View on Base
+              <span aria-hidden>↗</span>
+            </a>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(routes)/[productId]/product/[slug]/page.tsx
+++ b/src/app/(routes)/[productId]/product/[slug]/page.tsx
@@ -40,6 +40,7 @@ import {
 } from "./lib/structured-data";
 import { sanitizeHtml, htmlToText } from "./lib/sanitize-html";
 import { POLICY } from "@/lib/site";
+import { titleCaseHandle } from "@/lib/utils/handle/handle";
 import { UNIFIED_PDP_ENABLED } from "@/lib/variables/variables";
 import { getInteractiveProduct } from "../../lib/product-data";
 import ProductExperience from "../../components/ProductExperience";
@@ -163,8 +164,10 @@ export default async function ProductPage({ params }: PageProps) {
         <ProductExperience
           product={interactiveProduct}
           // Brand context for the premium body's brand line + breadcrumb: the
-          // structured-data brand name, falling back to the merchant handle.
-          brand={{ name: view.brandName || merchant }}
+          // structured-data brand name, falling back to a display-cased merchant
+          // handle (raw slug `unstoppable` → `Unstoppable`). A real brandName is
+          // already display copy and is passed through untouched.
+          brand={{ name: view.brandName || titleCaseHandle(merchant) }}
         />
       </>
     );

--- a/src/app/(routes)/returns-policy/page.tsx
+++ b/src/app/(routes)/returns-policy/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import LegalPage, { LegalSection } from "@/components/core/legal/LegalPage";
-import { POLICY, SITE } from "@/lib/site";
+import { POD_POLICY, POLICY, SITE } from "@/lib/site";
 
 export const metadata: Metadata = {
   title: "Returns & Refunds | droplinked",
@@ -57,6 +57,36 @@ export default function ReturnsPolicyPage() {
           Customers are responsible for return shipping costs unless the item
           arrived damaged, defective, or was sent in error, in which case
           droplinked covers return shipping and replacement or refund.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="Made-to-Order (Print-on-Demand) Items">
+        <p>
+          Some items on droplinked are printed on demand — produced
+          individually for your order by our fulfillment partner. Because each
+          piece is made just for you, made-to-order items cannot be returned
+          or exchanged for a different size or a change of mind. These items
+          are identified as made to order on the product page before purchase.
+        </p>
+        <p>
+          If a made-to-order item arrives damaged, misprinted, or defective,
+          email{" "}
+          <a
+            href={`mailto:${SITE.supportEmail}`}
+            className="text-mint-500 transition-colors hover:text-mint-400"
+          >
+            {SITE.supportEmail}
+          </a>{" "}
+          within <strong>{POD_POLICY.claimWindowDays} days of delivery</strong>{" "}
+          with your order number and photos of the issue. We will send a
+          replacement or issue a full refund at no cost to you.
+        </p>
+        <p>
+          For customers in the European Union: under Article 16(c) of
+          Directive 2011/83/EU on consumer rights, the 14-day right of
+          withdrawal does not apply to goods made to the consumer&apos;s
+          specifications or clearly personalized. Your statutory rights for
+          defective goods are not affected.
         </p>
       </LegalSection>
 

--- a/src/components/catalog/MarketplaceCatalog.tsx
+++ b/src/components/catalog/MarketplaceCatalog.tsx
@@ -11,9 +11,17 @@
  * Uses a plain <img> (not next/image) for product thumbnails so arbitrary
  * per-shop CDN hosts don't need next.config remotePatterns entries — matching
  * how the other SSR routes render remote product images.
+ *
+ * Visual language is deliberately aligned with the premium PDP
+ * (PremiumProductExperience / PremiumDetails): Inter type, a calm neutral
+ * palette, generous whitespace, quiet borders, and a restrained image-zoom
+ * hover — so the root grid reads as the same premium brand as the product page.
+ * This is a presentation-only pass: props, data flow, SSR output, and the
+ * ROOT_CATALOG_ENABLED gate in page.tsx are all unchanged.
  */
 
 import Link from "next/link";
+import { inter } from "@/styles/fonts";
 import type { CatalogProduct } from "@/lib/catalog/marketplace-catalog-data";
 import { SITE } from "@/lib/site";
 
@@ -24,53 +32,70 @@ interface MarketplaceCatalogProps {
 
 export default function MarketplaceCatalog({ products }: MarketplaceCatalogProps) {
   return (
-    <main className="min-h-[60vh] w-full px-4 py-10 md:px-8 lg:px-12 text-gray-900">
-      <div className="mx-auto max-w-7xl">
-        <header className="mb-8">
-          <h1 className="text-2xl font-semibold md:text-3xl">Shop all products</h1>
-          <p className="mt-2 max-w-2xl text-sm text-gray-600 md:text-base">
-            Discover products from brands and retailers on {SITE.name}.
+    <main
+      className={`${inter.className} min-h-[60vh] w-full px-6 pb-20 pt-10 text-neutral-900 md:px-8 lg:px-12`}
+    >
+      <div className="mx-auto max-w-6xl">
+        <header className="mb-10 border-b border-neutral-200 pb-8">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-500">
+            {SITE.name}
+          </p>
+          <h1 className="mt-3 text-[28px] font-medium leading-9 tracking-tight text-neutral-900 md:text-[34px] md:leading-10">
+            Shop all products
+          </h1>
+          <p className="mt-3 max-w-2xl text-[14px] leading-6 text-neutral-500">
+            A curated selection from brands and retailers on {SITE.name} —
+            verifiable, made to order, and shipped with tracking.
           </p>
         </header>
 
         {products.length === 0 ? (
-          <div className="rounded-lg border border-gray-200 bg-gray-50 py-20 text-center">
-            <p className="text-base font-medium text-gray-700">No products to show yet</p>
-            <p className="mt-1 text-sm text-gray-500">Please check back soon.</p>
+          <div className="rounded-md border border-neutral-200 bg-neutral-50 py-24 text-center">
+            <p className="text-[15px] font-medium text-neutral-700">
+              No products to show yet
+            </p>
+            <p className="mt-1 text-[13px] text-neutral-500">
+              Please check back soon.
+            </p>
           </div>
         ) : (
           <ul
-            className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
+            className="grid grid-cols-2 gap-x-6 gap-y-10 sm:grid-cols-3 lg:grid-cols-4"
             role="list"
           >
             {products.map((product) => (
               <li key={product.id} className="group">
                 <Link
                   href={product.href}
-                  className="flex h-full flex-col gap-2 overflow-hidden rounded-lg border border-gray-200 bg-white transition-all duration-200 hover:border-gray-300 hover:shadow-md"
+                  className="flex h-full flex-col"
                   aria-label={product.title}
                 >
-                  <div className="relative aspect-square w-full bg-gray-100">
+                  <div className="relative aspect-square w-full overflow-hidden rounded-md bg-neutral-100">
                     {product.imageUrl ? (
                       // eslint-disable-next-line @next/next/no-img-element
                       <img
                         src={product.imageUrl}
                         alt={product.title}
                         loading="lazy"
-                        className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                        className="h-full w-full object-cover transition-transform duration-500 ease-out group-hover:scale-[1.04]"
                       />
                     ) : (
-                      <div className="h-full w-full bg-gray-200" aria-hidden="true" />
+                      <div
+                        className="h-full w-full bg-neutral-200"
+                        aria-hidden="true"
+                      />
                     )}
                   </div>
-                  <div className="flex flex-col gap-1 px-3 pb-3">
-                    <span className="line-clamp-2 text-sm font-medium text-gray-900">
+                  <div className="mt-3 flex flex-col gap-1">
+                    {product.shopName ? (
+                      <span className="line-clamp-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-neutral-400">
+                        {product.shopName}
+                      </span>
+                    ) : null}
+                    <span className="line-clamp-2 text-[14px] leading-5 text-neutral-900 transition-colors group-hover:text-neutral-600">
                       {product.title}
                     </span>
-                    {product.shopName ? (
-                      <span className="line-clamp-1 text-xs text-gray-500">{product.shopName}</span>
-                    ) : null}
-                    <span className="text-sm font-semibold text-gray-900">
+                    <span className="mt-0.5 text-[14px] font-semibold text-neutral-900">
                       $
                       {product.price.toLocaleString("en-US", {
                         minimumFractionDigits: 2,

--- a/src/lib/dpp/chain.ts
+++ b/src/lib/dpp/chain.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure chain projectors for the DPP passport module.
+ *
+ * Ported from the old Vite storefront's
+ *   src/components/VerifiedOnchainBadge/chainLabel.ts
+ * and extended with the confirmed-chain predicate + the Base attestation
+ * explorer deep-link ("View on Base").
+ *
+ * No React / DOM imports — pure functions, safe to run on the server or in a
+ * node test.
+ *
+ * "Base mainnet" / "Base sepolia" are EVM chain identifiers (not partner
+ * branding) and are allowed in user-visible strings. `simulated` is the
+ * local/dev synthetic anchor and is NEVER a confirmed chain.
+ */
+
+import type { DppChainSlug } from "./interface";
+
+/** The only two chain slugs that represent a CONFIRMED onchain anchor. */
+const CONFIRMED_CHAINS = new Set<DppChainSlug>(["base-mainnet", "base-sepolia"]);
+
+/**
+ * True only for a confirmed EVM anchor. `simulated`, unknown slugs, null, and
+ * undefined all return false — the badge must never light on a non-confirmed
+ * anchor.
+ */
+export function isConfirmedChain(chain: DppChainSlug | null | undefined): boolean {
+  return !!chain && CONFIRMED_CHAINS.has(chain);
+}
+
+/**
+ * BE `onchainAnchor.chain` slug → user-visible suffix. Returns null for any
+ * non-confirmed chain (keep the generic label; never surface "simulated").
+ */
+export function chainLabelSuffix(chain: DppChainSlug | null | undefined): string | null {
+  if (chain === "base-mainnet") return "Base mainnet";
+  if (chain === "base-sepolia") return "Base sepolia";
+  return null;
+}
+
+/**
+ * Build the EAS attestation explorer URL on Base for a confirmed anchor.
+ * Returns null when the chain isn't confirmed or the UID is missing — so the
+ * "View on Base" affordance only ever renders when it can point at a real,
+ * confirmed attestation.
+ */
+export function buildAttestationUrl(
+  chain: DppChainSlug | null | undefined,
+  attestationUid: string | null | undefined,
+): string | null {
+  if (!attestationUid) return null;
+  if (chain === "base-mainnet") {
+    return `https://base.easscan.org/attestation/view/${attestationUid}`;
+  }
+  if (chain === "base-sepolia") {
+    return `https://base-sepolia.easscan.org/attestation/view/${attestationUid}`;
+  }
+  return null;
+}

--- a/src/lib/dpp/interface.ts
+++ b/src/lib/dpp/interface.ts
@@ -1,0 +1,89 @@
+/**
+ * Public DPP (Digital Product Passport) proof envelope returned by
+ *   GET https://apiv3.droplinked.com/dpp/proof/:gtin   (live, @Public, no auth)
+ *
+ * Ported from the old Vite storefront's `src/apis/dpp/interface.ts`
+ * (droplinked-shopfront, Schema F public envelope) and EXTENDED with the
+ * canonical passport-presentation fields the premium PDP panel renders
+ * (manufacturer / country of origin / composition / spec / lifecycle).
+ *
+ * Every field is defensively OPTIONAL: the BE envelope shape is treated as
+ * untrusted input. The module keys its render decision off the confirmed
+ * onchain-anchor + `verified` flag (see `isConfirmedDppProof`), and the panel
+ * renders only the presentation fields that are actually present — so an
+ * envelope that omits, renames, or nests any field degrades gracefully to a
+ * smaller panel rather than a crash.
+ *
+ * Truth-condition note: the two BE-blessed CONFIRMED EVM slugs are
+ * `base-mainnet` / `base-sepolia`. `simulated` is the local/dev synthetic
+ * anchor and MUST NEVER light the badge (see chain.ts + services.ts). Given
+ * the batched-writer gas-stub history (minted rows that never landed onchain),
+ * a PENDING/simulated anchor is explicitly not a confirmed proof.
+ */
+
+/** BE onchain-anchor chain slug. Only the two EVM slugs are "confirmed". */
+export type DppChainSlug = "base-mainnet" | "base-sepolia" | "simulated" | (string & {});
+
+/** A single lifecycle timeline entry (created / anchored / imported / ...). */
+export interface IDppLifecycleEvent {
+  /** Human label, e.g. "Manufactured", "Anchored onchain". */
+  label: string;
+  /** ISO date string; optional. */
+  date?: string;
+  /** Optional place/context, e.g. a country or facility. */
+  location?: string;
+}
+
+/** Canonical passport presentation fields (ESPR-aligned). All optional. */
+export interface IDppPassportFields {
+  manufacturer?: string;
+  countryOfOrigin?: string;
+  composition?: string;
+  /** Frozen canonical spec summary (free text). */
+  spec?: string;
+  lifecycle?: IDppLifecycleEvent[];
+}
+
+/** Onchain anchor metadata for the confirmed-proof gate + "View on Base" link. */
+export interface IDppOnchainAnchor {
+  chain: DppChainSlug;
+  attestationUid: string;
+  batchPeriod?: string;
+  merkleRoot?: string;
+  recordCount?: number;
+  /** Optional confirmation status; anything other than CONFIRMED is not shown. */
+  status?: "CONFIRMED" | "PENDING" | (string & {});
+}
+
+/**
+ * The public DPP proof envelope. Fields the badge/panel consume are typed;
+ * unknown extra fields (frozenFields, merkleProof, proofLengthBytes, …) are
+ * ignored — independent verifiers read those, the customer-facing panel does
+ * not.
+ */
+export interface IPublicDppProofEnvelope {
+  gtin?: string;
+  sku?: string;
+  schema?: string;
+  /** null/absent = no onchain anchor → not a confirmed proof. */
+  onchainAnchor?: IDppOnchainAnchor | null;
+  leafHash?: string;
+  /** BE's own verification flag — must be true for a confirmed proof. */
+  verified?: boolean;
+  /** Published DPP timestamp; part of the "published + confirmed anchor" gate. */
+  publishedAt?: string | null;
+
+  /**
+   * Passport presentation fields. The BE may return these flat on the envelope
+   * OR nested under `passport`; the panel reads both (see ProductPassport).
+   */
+  passport?: IDppPassportFields;
+
+  /**
+   * Manufacturer-vouch (brand-attestation MINTED) tier — the STRONGER
+   * "Verified by {manufacturer}" label. Only used when explicitly confirmed;
+   * absent → the panel uses the "Onchain product passport" label.
+   */
+  manufacturer?: string;
+  manufacturerVerified?: boolean;
+}

--- a/src/lib/dpp/services.ts
+++ b/src/lib/dpp/services.ts
@@ -1,0 +1,133 @@
+/**
+ * Public DPP proof client + the confirmed-proof truth condition + the
+ * product → gtin/sku/mpn identifier resolver.
+ *
+ * Ported/adapted from the old Vite storefront's `src/apis/dpp/services.ts`
+ * (which used the app axios instance). Next-ShopFront has no shared axios
+ * client, so this uses a plain `fetch` against the absolute apiv3 host — the
+ * same pattern the SSR structured-data loader uses. The DPP proof endpoint is
+ * @Public (no auth / no shop context needed).
+ *
+ * ENDPOINT NOTE: the strategy memo refers to this read as `dpp/proof/:gtin`,
+ * but the LIVE apiv3 route is `v2/dpp/:gtin` (confirmed 2026-07-16 by probing:
+ * `GET /dpp/proof/<x>` → route-level 404 "Cannot GET"; `GET /v2/dpp/<x>` →
+ * data-level 404 "gtin <x> not found" — i.e. the route exists and only the
+ * gtin is unknown). This is the same public Schema F envelope the old Vite
+ * shopfront's VerifiedOnchainBadge already consumed. Fail-open makes the path
+ * choice non-fatal, but we point at the route that actually resolves.
+ *
+ * Posture (unchanged from the port):
+ *   - Silent-degrade: returns null on ANY non-2xx / network error / bad JSON.
+ *     The caller renders NOTHING on null — a stale/unconfirmed "verified" claim
+ *     is worse than no badge, and the PDP must never break on a passport miss.
+ *   - SSR-safe: never throws, so a server render can call it without a chance
+ *     of 500-ing the page (the Phase-1 component calls it client-side, but the
+ *     fetcher is agnostic).
+ *   - No retry: the BE endpoint is CDN-cached and rate-limited; one request is
+ *     enough for the PDP lifetime.
+ */
+
+import type { IProduct } from "@/types/interfaces/product/product";
+import { isConfirmedChain } from "./chain";
+import type { IPublicDppProofEnvelope } from "./interface";
+
+/** Absolute apiv3 host — matches the SSR structured-data loader. */
+const APIV3_BASE = "https://apiv3.droplinked.com";
+
+/**
+ * Fetch the public DPP proof envelope for a gtin (or sku/mpn — the endpoint
+ * resolves any of them by path). Returns null on ANY failure. Never throws.
+ */
+export async function fetchDppProof(
+  identifier: string | null | undefined,
+): Promise<IPublicDppProofEnvelope | null> {
+  const key = (identifier ?? "").trim();
+  if (!key) return null;
+
+  try {
+    const res = await fetch(
+      `${APIV3_BASE}/v2/dpp/${encodeURIComponent(key)}`,
+      {
+        headers: { Accept: "application/json" },
+        // ISR-friendly if ever called from the server; harmless client-side.
+        next: { revalidate: 300 },
+      },
+    );
+    if (!res.ok) return null; // 404 (no passport) / 5xx / etc. → silent-degrade
+    const data = (await res.json()) as IPublicDppProofEnvelope;
+    return data ?? null;
+  } catch {
+    // Network / CORS / bad JSON → silent-degrade. Caller renders nothing.
+    return null;
+  }
+}
+
+/**
+ * THE truth condition. A passport badge may render ONLY when the envelope
+ * represents a CONFIRMED onchain proof:
+ *   - BE `verified` flag is true, AND
+ *   - there is an onchain anchor with a real attestation UID, AND
+ *   - the anchor chain is a confirmed EVM slug (base-mainnet / base-sepolia) —
+ *     NEVER `simulated`, AND
+ *   - the anchor status (when present) is not PENDING.
+ *
+ * Anything else — no envelope, verified false/absent, no anchor, simulated
+ * chain, pending status — returns false, so the module renders nothing. This
+ * is the guard that keeps a badge from ever pointing at a non-existent /
+ * unlanded attestation.
+ */
+export function isConfirmedDppProof(
+  env: IPublicDppProofEnvelope | null | undefined,
+): env is IPublicDppProofEnvelope {
+  if (!env) return false;
+  if (env.verified !== true) return false;
+
+  const anchor = env.onchainAnchor;
+  if (!anchor) return false;
+  if (!anchor.attestationUid) return false;
+  if (!isConfirmedChain(anchor.chain)) return false;
+  if (anchor.status && anchor.status !== "CONFIRMED") return false;
+
+  return true;
+}
+
+/**
+ * Resolve the best passport lookup key from a product: gtin first, then a sku
+ * code, then an mpn. Returns null when the product carries none — in which case
+ * the module renders nothing (POD/long-tail items frequently have no gtin).
+ *
+ * IProduct does not type these identity fields today, so we read them
+ * defensively across the likely locations (product-level and first-sku level,
+ * including `recordData`). Every access is guarded and string-trimmed.
+ */
+export function resolveProductPassportKey(product: IProduct | null | undefined): string | null {
+  if (!product) return null;
+
+  const p = product as unknown as Record<string, unknown>;
+  const firstSku = (product.skuIDs?.[0] ?? {}) as unknown as Record<string, unknown>;
+  const skuRecord = (firstSku.recordData ?? {}) as Record<string, unknown>;
+
+  const pick = (v: unknown): string | null => {
+    if (typeof v === "string") {
+      const t = v.trim();
+      return t.length > 0 ? t : null;
+    }
+    if (typeof v === "number" && Number.isFinite(v)) return String(v);
+    return null;
+  };
+
+  // Priority: gtin (barcode) → sku code → mpn.
+  return (
+    pick(p.gtin) ??
+    pick(p.barcode) ??
+    pick(skuRecord.gtin) ??
+    pick(skuRecord.barcode) ??
+    pick(firstSku.gtin) ??
+    pick(firstSku.sku) ??
+    pick(firstSku.externalID) ??
+    pick(p.custome_external_id) ??
+    pick(p.mpn) ??
+    pick(skuRecord.mpn) ??
+    null
+  );
+}

--- a/src/lib/pod.ts
+++ b/src/lib/pod.ts
@@ -1,0 +1,29 @@
+/**
+ * pod.ts — the ONE print-on-demand (POD) product detector.
+ *
+ * POD items are produced per order by the print partner (Printful), so every
+ * trust surface must render made-to-order terms (see POD_POLICY in site.ts),
+ * never the standard return window — a made-to-order item promising "free
+ * 14-day returns" is a promise fulfillment cannot deliver.
+ *
+ * The type spelling differs by data source, so match both:
+ *   • product-v2 public API carries `type: "pod"` (uppercased to "POD" by the
+ *     V2→legacy adapter in product-data.ts, which maps type/product_type via
+ *     `String(v2.type).toUpperCase()`).
+ *   • the legacy shop-scoped product API carries `PRINT_ON_DEMAND`
+ *     (product-type enum on droplinked-backend).
+ */
+import type { IProduct } from '@/types/interfaces/product/product';
+
+const POD_TYPES = new Set(['POD', 'PRINT_ON_DEMAND']);
+
+/** True when the product is print-on-demand (made to order, Printful terms). */
+export function isPodProduct(
+  product: Pick<IProduct, 'type' | 'product_type'> | null | undefined,
+): boolean {
+  if (!product) return false;
+  return (
+    POD_TYPES.has(String(product.type ?? '').toUpperCase()) ||
+    POD_TYPES.has(String(product.product_type ?? '').toUpperCase())
+  );
+}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -78,6 +78,24 @@ export const POLICY = {
   handlingTimeDays: "1–3 business days",
 } as const;
 
+/**
+ * Made-to-order (print-on-demand) terms. POD items are produced per order by
+ * the print partner (Printful), so they piggyback Printful's return terms
+ * instead of the standard {@link POLICY} return window: no returns for size
+ * changes or change of mind; damaged, misprinted, or defective items are
+ * replaced or refunded when reported within {@link POD_POLICY.claimWindowDays}
+ * days of delivery. Source: Printful Return Policy
+ * (https://www.printful.com/policies/returns, last updated 2022-06-03) —
+ * "Any claims for misprinted/damaged/defective items must be submitted within
+ * 30 days after the product has been received." EU nuance: per Article 16(c)
+ * of Directive 2011/83/EU the 14-day right of withdrawal may not be provided
+ * for goods made to the consumer's specifications or clearly personalized.
+ */
+export const POD_POLICY = {
+  /** Damaged / misprinted / defective claim window, in days from delivery. */
+  claimWindowDays: 30,
+} as const;
+
 /** Footer / policy navigation targets. Every href resolves to a real route. */
 export const POLICY_LINKS = [
   { label: "Shipping Policy", href: "/shipping-policy" },

--- a/src/lib/utils/handle/handle.ts
+++ b/src/lib/utils/handle/handle.ts
@@ -1,0 +1,44 @@
+/**
+ * titleCaseHandle — present a raw merchant handle/slug as a display name.
+ *
+ * Used ONLY as a fallback when a product has no real brand name and the PDP
+ * would otherwise show the bare, lowercase merchant slug in the breadcrumb /
+ * brand line (e.g. `unstoppable`). A real `brandName` must never be passed
+ * through this — it is already display copy and could be mangled.
+ *
+ * Splitting rules (best-effort, never throws):
+ *   - split on `-`, `_`, `.`, `+` and whitespace → separate words
+ *   - split camelCase / PascalCase boundaries (`theShoeCircle` → the Shoe Circle)
+ *   - uppercase only the FIRST letter of each word; the rest is left untouched
+ *     so an acronym (`nasa`→`Nasa`, `UNSTOPPABLE`→`UNSTOPPABLE`) is not damaged
+ *
+ * A blob slug with no clean delimiter/camel boundary (e.g. `theshoecircle`)
+ * degrades gracefully to a single capitalised word (`Theshoecircle`) — the
+ * "else just capitalize words" branch. That is strictly better than the raw
+ * lowercase slug and never invents word boundaries that aren't there.
+ *
+ * @example titleCaseHandle('unstoppable')      // 'Unstoppable'
+ * @example titleCaseHandle('the-shoe-circle')  // 'The Shoe Circle'
+ * @example titleCaseHandle('theShoeCircle')    // 'The Shoe Circle'
+ * @example titleCaseHandle('theshoecircle')    // 'Theshoecircle'
+ */
+export function titleCaseHandle(handle: string): string {
+  if (!handle || typeof handle !== "string") return handle ?? "";
+
+  const words = handle
+    // camelCase / PascalCase → space-separated
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    // delimiter families → spaces
+    .replace(/[-_.+\s]+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean);
+
+  if (words.length === 0) return handle;
+
+  return words
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+export default titleCaseHandle;

--- a/src/lib/variables/variables.ts
+++ b/src/lib/variables/variables.ts
@@ -51,6 +51,20 @@ export const UNIFIED_PDP_ENABLED =
  */
 export const PREMIUM_PDP_ENABLED =
   process.env.NEXT_PUBLIC_PREMIUM_PDP_ENABLED === "true";
+
+/**
+ * PDP product passport (Phase 1): render the conditional onchain-authenticity
+ * module in the premium PDP's reserved authenticity slot (below the CTA). When
+ * ON, the module reads the public DPP proof (`GET apiv3/dpp/proof/:gtin`) for
+ * the item and renders a quiet badge + passport panel ONLY when a CONFIRMED
+ * onchain proof exists (never on pending/simulated); no proof → renders
+ * nothing. Read-only, no wallet gate; fail-open (any fetch error → nothing).
+ * NEXT_PUBLIC_ so Next inlines it at build time (standalone runner carries no
+ * .env). Default OFF — set NEXT_PUBLIC_PDP_PASSPORT_ENABLED=true to enable
+ * (reversible, no code revert). See product-passport-platform-strategy-2026-07-16.
+ */
+export const PDP_PASSPORT_ENABLED =
+  process.env.NEXT_PUBLIC_PDP_PASSPORT_ENABLED === "true";
 export const variantIDs = { color: { _id: "62a989ab1f2c2bbc5b1e7153" }, size: { _id: "62a989e21f2c2bbc5b1e7154" } };
 export const app_vertical = "flex flex-col items-center justify-center";
 export const app_center = "flex items-center justify-center";


### PR DESCRIPTION
## Closes / addresses
Ships to shop.droplinked.com:
- #193 POD PDPs show Printful made-to-order return terms (30-day defect claims, no remorse returns, EU Art. 16(c) carve-out on /returns-policy) — operator directive; non-POD byte-identical (runtime-verified both ways)
- #191 breadcrumb title-case fallback + premium grid polish
- #192 onchain product-passport module — FLAG-GATED (env not set on prod build → OFF, byte-identical)

dev ahead 4 / behind 0 — clean train. Pairs with droplinked-backend fix/pod-returns-structured-data (JSON-LD POD branch, in flight) for full landing-page↔machine-data consistency on the GMC reinstatement track.