### PR TITLE
fix(teaser): POD static-teaser trust row shows made-to-order terms, not the 14-day window

### DIFF
--- a/src/app/(routes)/[productId]/product/[slug]/lib/structured-data.ts
+++ b/src/app/(routes)/[productId]/product/[slug]/lib/structured-data.ts
@@ -76,10 +76,29 @@ export interface OpenGraphBlock {
   [key: string]: string | undefined;
 }
 
+/**
+ * Normalised product type exposed by the BE as a top-level SIBLING of
+ * `jsonLd` (droplinked-backend `feat/seo-structured-data-expose-type`).
+ * `pod` = print-on-demand (made to order) — the teaser trust row must
+ * render Printful's made-to-order terms (see POD_POLICY in site.ts),
+ * never the standard return window. The BE OMITS the field when the
+ * stored type is absent/unknown; older BE builds don't send it at all —
+ * consumers must fail-open to the existing non-POD copy either way.
+ */
+export type StructuredDataProductType = "pod" | "physical" | "digital";
+
+const KNOWN_PRODUCT_TYPES = new Set<StructuredDataProductType>([
+  "pod",
+  "physical",
+  "digital",
+]);
+
 export interface StructuredData {
   productId: string;
   /** Canonical URL — normalised to the served shop.droplinked.com host. */
   canonicalUrl: string;
+  /** Absent on older BE builds / unknown types — treat as non-POD. */
+  productType?: StructuredDataProductType;
   jsonLd: ProductJsonLd;
   openGraph: OpenGraphBlock;
 }
@@ -160,9 +179,18 @@ function parseStructuredData(
       ? { ...(r.openGraph as OpenGraphBlock), "og:url": servedUrl }
       : { "og:url": servedUrl };
 
+  // Fail-open type parse: only the known vocabulary passes through; any
+  // other/missing value leaves the field absent (→ existing non-POD copy).
+  const productType =
+    typeof r.productType === "string" &&
+    KNOWN_PRODUCT_TYPES.has(r.productType as StructuredDataProductType)
+      ? (r.productType as StructuredDataProductType)
+      : undefined;
+
   return {
     productId: typeof r.productId === "string" ? r.productId : "",
     canonicalUrl: servedUrl,
+    ...(productType ? { productType } : {}),
     jsonLd,
     openGraph,
   };

--- a/src/app/(routes)/[productId]/product/[slug]/page.tsx
+++ b/src/app/(routes)/[productId]/product/[slug]/page.tsx
@@ -39,7 +39,8 @@ import {
   buildServedUrl,
 } from "./lib/structured-data";
 import { sanitizeHtml, htmlToText } from "./lib/sanitize-html";
-import { POLICY } from "@/lib/site";
+import { POD_POLICY, POLICY } from "@/lib/site";
+import { isPodProduct } from "@/lib/pod";
 import { titleCaseHandle } from "@/lib/utils/handle/handle";
 import { UNIFIED_PDP_ENABLED } from "@/lib/variables/variables";
 import { getInteractiveProduct } from "../../lib/product-data";
@@ -125,6 +126,14 @@ export default async function ProductPage({ params }: PageProps) {
   // reviewer cannot get past. Fall back to the canonical URL only when the
   // structured-data payload carried no product id.
   const purchaseUrl = data.productId ? `/${data.productId}` : view.canonicalUrl;
+
+  // POD (made to order via Printful): the static-teaser trust row must show
+  // the SAME made-to-order terms as the live PDP (PremiumDetails, PR #193),
+  // never the standard return window. Branches on the structured-data
+  // envelope's `productType` sibling field; routed through the ONE detector
+  // in @/lib/pod so the spelling logic never forks. Missing field (older BE,
+  // unknown type) → false → existing copy, byte-identical (fail-open).
+  const pod = isPodProduct({ type: data.productType ?? "", product_type: "" });
 
   // ── Unified PDP ────────────────────────────────────────────────────────
   // When enabled, resolve the SAME rich interactive product the /<productId>
@@ -268,30 +277,61 @@ export default async function ProductPage({ params }: PageProps) {
             {view.inStock ? "Buy now" : "View product"}
           </Link>
 
-          {/* Trust affordances a reviewer sees on the feed landing page. */}
-          <p className="text-xs text-ink-faint">
-            Secure checkout · {POLICY.returnWindowDays}-day{" "}
-            <Link
-              href="/returns-policy"
-              className="text-mint-500 hover:text-mint-400 transition-colors"
-            >
-              returns
-            </Link>{" "}
-            ·{" "}
-            <Link
-              href="/shipping-policy"
-              className="text-mint-500 hover:text-mint-400 transition-colors"
-            >
-              shipping info
-            </Link>{" "}
-            ·{" "}
-            <Link
-              href="/contact"
-              className="text-mint-500 hover:text-mint-400 transition-colors"
-            >
-              contact
-            </Link>
-          </p>
+          {/* Trust affordances a reviewer sees on the feed landing page.
+              POD items carry Printful's made-to-order terms (the exact #193
+              line) instead of the return window; non-POD stays byte-identical. */}
+          {pod ? (
+            <p className="text-xs text-ink-faint">
+              Secure checkout · Made to order — ships in{" "}
+              {POLICY.handlingTimeDays} · Damaged or misprinted? We&apos;ll
+              replace it — report within {POD_POLICY.claimWindowDays} days of
+              delivery.{" "}
+              <Link
+                href="/returns-policy"
+                className="text-mint-500 hover:text-mint-400 transition-colors"
+              >
+                Return policy
+              </Link>{" "}
+              ·{" "}
+              <Link
+                href="/shipping-policy"
+                className="text-mint-500 hover:text-mint-400 transition-colors"
+              >
+                shipping info
+              </Link>{" "}
+              ·{" "}
+              <Link
+                href="/contact"
+                className="text-mint-500 hover:text-mint-400 transition-colors"
+              >
+                contact
+              </Link>
+            </p>
+          ) : (
+            <p className="text-xs text-ink-faint">
+              Secure checkout · {POLICY.returnWindowDays}-day{" "}
+              <Link
+                href="/returns-policy"
+                className="text-mint-500 hover:text-mint-400 transition-colors"
+              >
+                returns
+              </Link>{" "}
+              ·{" "}
+              <Link
+                href="/shipping-policy"
+                className="text-mint-500 hover:text-mint-400 transition-colors"
+              >
+                shipping info
+              </Link>{" "}
+              ·{" "}
+              <Link
+                href="/contact"
+                className="text-mint-500 hover:text-mint-400 transition-colors"
+              >
+                contact
+              </Link>
+            </p>
+          )}
 
           {view.sku && (
             <p className="text-xs text-ink-faint">SKU: {view.sku}</p>


### PR DESCRIPTION
Residual #193 copy: the slug-route static teaser (fail-open branch of /<merchant>/product/<slug>) still promised '14-day returns' on POD. Parses the BE's new top-level productType sibling and branches via the ONE detector (@/lib/pod isPodProduct): POD renders the exact #193 made-to-order line (same strings/constants + Return policy link); non-POD byte-identical; missing field → existing copy (fail-open, safe against older BE). Depends on droplinked-backend feat/seo-structured-data-expose-type (fail-open until deployed). Gates: tsc clean on touched files · smoke 3/3 · next build ✓.