### PR TITLE
polish(pdp): premium PDP design-QA completion pass

### DIFF
--- a/src/app/(routes)/[productId]/components/premium/Accordion.tsx
+++ b/src/app/(routes)/[productId]/components/premium/Accordion.tsx
@@ -10,7 +10,7 @@
  * HTML; only the open/close toggle is client behavior).
  */
 
-import { useState, type ReactNode } from 'react';
+import { useId, useState, type ReactNode } from 'react';
 
 export function AccordionItem({
   title,
@@ -22,13 +22,15 @@ export function AccordionItem({
   defaultOpen?: boolean;
 }) {
   const [open, setOpen] = useState(defaultOpen);
+  const panelId = useId();
   return (
     <div className="border-b border-neutral-200">
       <button
         type="button"
         aria-expanded={open}
+        aria-controls={panelId}
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center justify-between py-4 text-left"
+        className="flex w-full items-center justify-between py-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:ring-offset-2"
       >
         <span className="text-[13px] font-semibold uppercase tracking-[0.12em] text-neutral-900">
           {title}
@@ -51,7 +53,9 @@ export function AccordionItem({
         </svg>
       </button>
       {/* Keep content mounted (SEO/agents read it; toggle is display-only). */}
-      <div className={open ? 'pb-5' : 'hidden'}>{children}</div>
+      <div id={panelId} role="region" aria-label={title} className={open ? 'pb-5' : 'hidden'}>
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/app/(routes)/[productId]/components/premium/MediaGallery.tsx
+++ b/src/app/(routes)/[productId]/components/premium/MediaGallery.tsx
@@ -51,7 +51,7 @@ export default function MediaGallery({
               type="button"
               aria-label={`View image ${i + 1}`}
               onClick={() => setCurrent(m.url)}
-              className={`relative h-16 w-16 overflow-hidden rounded-sm bg-neutral-50 transition-shadow ${
+              className={`relative h-16 w-16 overflow-hidden rounded-sm bg-neutral-50 transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:ring-offset-2 ${
                 current === m.url
                   ? 'ring-1 ring-neutral-900'
                   : 'ring-1 ring-transparent hover:ring-neutral-300'
@@ -74,7 +74,7 @@ export default function MediaGallery({
         type="button"
         aria-label="Open image gallery"
         onClick={() => setLightboxOpen(true)}
-        className="relative aspect-[4/5] w-full cursor-zoom-in overflow-hidden rounded-sm bg-neutral-50"
+        className="relative aspect-[4/5] w-full cursor-zoom-in overflow-hidden rounded-sm bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:ring-offset-2"
       >
         {current && (
           <Image

--- a/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
+++ b/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
@@ -178,15 +178,16 @@ export default function PremiumDetails({
             <span className="font-semibold">Color</span>
             {option.color && <span className="text-neutral-500"> — {option.color}</span>}
           </p>
-          <div className="mt-2.5 flex flex-wrap gap-2">
+          <div className="mt-2.5 flex flex-wrap gap-2" role="group" aria-label="Color">
             {colors.map((c) => (
               <button
                 key={c.caption}
                 type="button"
+                title={c.caption}
                 aria-label={`Color ${c.caption}`}
                 aria-pressed={option.color === c.caption}
                 onClick={() => setOption((prev) => ({ ...prev, color: c.caption }))}
-                className={`h-9 w-9 rounded-full border border-neutral-300 transition-shadow ${
+                className={`h-9 w-9 rounded-full border border-neutral-300 transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:ring-offset-2 ${
                   option.color === c.caption
                     ? 'ring-1 ring-neutral-900 ring-offset-2'
                     : 'hover:ring-1 hover:ring-neutral-400 hover:ring-offset-2'
@@ -219,7 +220,7 @@ export default function PremiumDetails({
               Size guide
             </a>
           </div>
-          <div className="mt-2.5 grid grid-cols-5 gap-2 sm:grid-cols-6">
+          <div className="mt-2.5 grid grid-cols-5 gap-2 sm:grid-cols-6" role="group" aria-label="Size">
             {sizes.map((s) => {
               const selected = option.size === s.caption;
               const available = sizeAvailable(s.caption);
@@ -230,7 +231,7 @@ export default function PremiumDetails({
                   disabled={!available}
                   aria-pressed={selected}
                   onClick={() => setOption((prev) => ({ ...prev, size: s.caption }))}
-                  className={`h-10 rounded-sm border text-[13px] transition-colors ${
+                  className={`h-10 rounded-sm border text-[13px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:ring-offset-2 ${
                     selected
                       ? 'border-neutral-900 bg-neutral-900 text-white'
                       : available
@@ -248,22 +249,34 @@ export default function PremiumDetails({
 
       {/* Quantity — deliberately quiet */}
       <div className="mt-7 flex items-center gap-4">
-        <p className="text-[13px] font-semibold text-neutral-900">Quantity</p>
-        <div className="flex h-9 items-center rounded-sm border border-neutral-300">
+        <p className="text-[13px] font-semibold text-neutral-900" id="premium-qty-label">
+          Quantity
+        </p>
+        <div
+          className="flex h-9 items-center rounded-sm border border-neutral-300"
+          role="group"
+          aria-labelledby="premium-qty-label"
+        >
           <button
             type="button"
             aria-label="Decrease quantity"
             onClick={() => setQuantity((q) => Math.max(1, q - 1))}
-            className="w-9 text-neutral-500 hover:text-neutral-900"
+            className="w-9 text-neutral-500 hover:text-neutral-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-900"
           >
             −
           </button>
-          <span className="w-8 text-center text-[13px] tabular-nums">{quantity}</span>
+          <span
+            className="w-8 text-center text-[13px] tabular-nums"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {quantity}
+          </span>
           <button
             type="button"
             aria-label="Increase quantity"
             onClick={() => setQuantity((q) => Math.min(99, q + 1))}
-            className="w-9 text-neutral-500 hover:text-neutral-900"
+            className="w-9 text-neutral-500 hover:text-neutral-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-900"
           >
             +
           </button>
@@ -275,9 +288,16 @@ export default function PremiumDetails({
         type="button"
         onClick={buy}
         disabled={busy}
-        className="mt-8 h-12 w-full rounded-sm bg-neutral-900 text-[13px] font-semibold uppercase tracking-[0.14em] text-white transition-colors hover:bg-neutral-700 disabled:opacity-60"
+        aria-busy={busy}
+        className="mt-8 h-12 w-full rounded-sm bg-neutral-900 text-[13px] font-semibold uppercase tracking-[0.14em] text-white transition-colors hover:bg-neutral-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:ring-offset-2 disabled:opacity-60"
       >
-        {MOR_CHECKOUT_ENABLED ? 'Buy now' : 'Add to bag'}
+        {busy
+          ? MOR_CHECKOUT_ENABLED
+            ? 'Starting checkout…'
+            : 'Adding…'
+          : MOR_CHECKOUT_ENABLED
+            ? 'Buy now'
+            : 'Add to bag'}
       </button>
 
       {/* Authenticity slot (product-passport strategy 2026-07-16). NOT a
@@ -306,8 +326,8 @@ export default function PremiumDetails({
         </p>
       ) : (
         <p className="mt-6 text-[12px] leading-5 text-neutral-500">
-          Secure checkout · {POLICY.returnWindowDays}-day returns · Made to order —
-          ships in {POLICY.handlingTimeDays}
+          Secure checkout · {POLICY.returnWindowDays}-day returns · Ships in{' '}
+          {POLICY.handlingTimeDays}
         </p>
       )}
     </div>

--- a/src/app/(routes)/[productId]/components/premium/PremiumProductExperience.tsx
+++ b/src/app/(routes)/[productId]/components/premium/PremiumProductExperience.tsx
@@ -106,8 +106,8 @@ export default function PremiumProductExperience({
               <AccordionItem title="Shipping & returns">
                 <div className="flex flex-col gap-2 text-[14px] leading-6 text-neutral-600">
                   <p>
-                    Every piece is made to order and ships in {POLICY.handlingTimeDays}{' '}
-                    with tracking.
+                    {isPodProduct(product) ? 'Made to order and ships' : 'Ships'} in{' '}
+                    {POLICY.handlingTimeDays} with tracking.
                   </p>
                   {isPodProduct(product) ? (
                     // POD (Printful) terms: made to order, so no size-change /


### PR DESCRIPTION
## Why
Design-QA + completion pass on the flag-gated **premium PDP** (merged in #182, held OFF on prod pending the operator's design-QA sign-off). The operator likes the direction and wants it review-ready and Bloomingdale's-grade.

Every change lives inside the `premium/` component set, so the legacy body stays **byte-identical whenever `NEXT_PUBLIC_PREMIUM_PDP_ENABLED` is OFF** (prod unaffected). Nothing here changes the flag default or touches prod.

## What

**Copy**
- The non-POD trust row and the "Shipping & returns" accordion asserted **"Made to order"** for *every* product — including stocked, non-POD goods, where it is factually wrong (visible today on the dev preview). Now reads **"Ships in {handlingTimeDays}"** for non-POD; POD copy (made-to-order + Printful claim window) is untouched.

**Accessibility**
- `focus-visible` rings on every interactive control (size pills, color swatches, gallery thumbnails, hero, Buy CTA, quantity steppers, accordion headers) — keyboard focus was previously invisible.
- `role="group"` + accessible labels on the Color / Size / Quantity clusters.
- `aria-live="polite"` on the quantity count.
- Accordion panels linked to their headers via `aria-controls`/`id`, exposed as labelled `region`s.

**UX / microcopy**
- Buy CTA reflects in-flight state ("Starting checkout…" / "Adding…") + `aria-busy` while the promise is pending.
- Native `title` tooltip on color swatches.

## Safety
- Flag OFF → legacy body byte-identical (all edits are inside flag-gated `premium/*`).
- No flag-default change; no prod workflow change; no purchase-path logic change.

## Verification
- `tsc --noEmit`: no new errors in `premium/` (8 pre-existing baseline errors elsewhere unchanged).
- `next build`: **0 errors**.
- smoke: **3/3**.

## Follow-ups (proposed, not in this PR — see design-QA notes)
- **BLOCKING to verify:** no-variant physical products resolve `sku = null` (Buy throws a generic error) — needs a purchase-path fix + live verification.
- CTA disabled/"Unavailable" state for out-of-stock color+size combos.
- Named-color swatch mapping (multi-word names like "Heather Grey" render as an invalid/transparent CSS color) — needs a name→hex map.
- Brand line on the bare `/{productId}` id route (brand only passed on the slug route today).
- "Related / You may also like" module.