### PR TITLE
fix(premium-pdp): buy-box blockers — no-variant sku fallback, named-color swatches, OOS CTA

### DIFF
--- a/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
+++ b/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
@@ -39,6 +39,60 @@ const numericSize = (caption: string) => {
   return m ? parseFloat(m[0]) : Number.POSITIVE_INFINITY;
 };
 
+// A usable CSS color literal — hex / rgb() / hsl(). A single-word CSS color
+// keyword ("navy", "white") also paints, but a multi-word merchant color name
+// ("Heather Grey", "Off White", "Navy Blue") is NOT valid CSS and paints
+// nothing — an invisible swatch.
+const CSS_COLOR = /^(#|rgb|hsl)/i;
+
+// Common multi-word (and a few ambiguous single-word) merchant color names →
+// representative hex, so a named-only color still renders a sensible chip.
+const NAMED_HEX: Record<string, string> = {
+  'heather grey': '#b0b3b8',
+  'heather gray': '#b0b3b8',
+  'cool heather': '#a9b3b6',
+  'steel grey': '#47525c',
+  'steel gray': '#47525c',
+  'off white': '#f7f4ef',
+  'navy blue': '#1f2a44',
+  'midnight navy': '#161d2b',
+  'sky blue': '#87ceeb',
+  'light blue': '#add8e6',
+  'royal blue': '#2b4fbb',
+  'forest green': '#228b22',
+  'olive green': '#6b7a3a',
+  'hot pink': '#ff69b4',
+  'light grey': '#d3d3d3',
+  'light gray': '#d3d3d3',
+  'dark grey': '#4b4f54',
+  'dark gray': '#4b4f54',
+  'burnt orange': '#cc5500',
+  'dusty rose': '#c08497',
+  'charcoal grey': '#36454f',
+  'charcoal gray': '#36454f',
+};
+
+// A last-resort neutral so a swatch is NEVER invisible.
+const NEUTRAL_SWATCH = '#e5e5e5';
+
+/**
+ * Resolve a guaranteed-paintable swatch color. Prefer the stored hex/rgb/hsl
+ * `value` (valid-hex swatches are unchanged); then a known named-color map;
+ * then a bare single-word CSS keyword; otherwise a neutral chip. The color
+ * NAME is always surfaced via title/aria-label at the call site so a neutral
+ * fallback is never ambiguous.
+ */
+const swatchColor = (caption?: string | null, value?: string | null): string => {
+  const v = String(value ?? '').trim();
+  if (CSS_COLOR.test(v)) return v; // stored hex/rgb/hsl wins — no regression
+  const cap = String(caption ?? '').trim();
+  if (CSS_COLOR.test(cap)) return cap; // caption itself may carry a hex
+  const key = cap.toLowerCase();
+  if (NAMED_HEX[key]) return NAMED_HEX[key]; // multi-word name → representative hex
+  if (key && !key.includes(' ')) return key; // single CSS keyword ("navy") paints
+  return NEUTRAL_SWATCH; // never invisible
+};
+
 export default function PremiumDetails({
   product,
   brandName,
@@ -56,14 +110,6 @@ export default function PremiumDetails({
   const [quantity, setQuantity] = useState(1);
   const [busy, setBusy] = useState(false);
 
-  const sku: ISku | null | undefined = useMemo(
-    () =>
-      product?.product_type === 'DIGITAL'
-        ? product?.skuIDs?.[0]
-        : findSkuAsOption({ color: option.color, size: option.size, skuIDs: product?.skuIDs }),
-    [product, option, findSkuAsOption],
-  );
-
   const colors = useMemo(() => getOptions(product?.skuIDs, 'color'), [product, getOptions]);
   const sizes = useMemo(
     () =>
@@ -72,6 +118,29 @@ export default function PremiumDetails({
       ),
     [product, getOptions],
   );
+
+  // A no-variant / single-variant physical product exposes NO color or size
+  // options, so option-based resolution can never match: getFirstOption yields
+  // {color:null,size:null} and findSkuAsOption returns null for a null/null
+  // query — leaving `sku` null so Buy throws "Missing variant" while the price
+  // (which falls back to skuIDs[0]) still renders, masking the dead button.
+  // Fall back to skuIDs[0] — the exact sku the price uses — so single-SKU
+  // products are purchasable. When variant options DO exist but the chosen
+  // combo is unresolvable we deliberately do NOT fall back (that would sell the
+  // wrong variant); that state disables the CTA below.
+  const hasVariantOptions = colors.length > 0 || sizes.length > 0;
+
+  const sku: ISku | null | undefined = useMemo(() => {
+    if (product?.product_type === 'DIGITAL') return product?.skuIDs?.[0];
+    const matched = findSkuAsOption({
+      color: option.color,
+      size: option.size,
+      skuIDs: product?.skuIDs,
+    });
+    if (matched) return matched;
+    return hasVariantOptions ? null : product?.skuIDs?.[0];
+  }, [product, option, findSkuAsOption, hasVariantOptions]);
+
   const sizesForColor = useMemo(
     () => (option.color ? skuIDsMatchColor(product?.skuIDs, option.color) : null),
     [product, option.color, skuIDsMatchColor],
@@ -97,8 +166,22 @@ export default function PremiumDetails({
   // delivery. Non-POD copy stays byte-identical.
   const pod = isPodProduct(product);
 
+  // Stock gate. POD (made-to-order via Printful) and DIGITAL carry no finite
+  // stock — every POD sku reports inventory.quantity 0 yet is fully purchasable
+  // — so they are ALWAYS in stock here; gating them on quantity would wrongly
+  // kill Buy on the entire made-to-order catalog. A physical, non-POD sku is
+  // out of stock only when it reports a definite, exhausted quantity; an
+  // unknown quantity stays buyable (fail-open toward the sale). This is the
+  // per-combo signal: a resolvable-but-out-of-stock color+size disables the
+  // CTA, distinct from the no-option fallback above (which stays buyable).
+  const madeToOrder = pod || product?.product_type === 'DIGITAL';
+  const stockLeft = Number(sku?.quantity) - Number(sku?.sold_units ?? 0);
+  const outOfStock =
+    !!sku && !madeToOrder && Number.isFinite(sku?.quantity) && stockLeft <= 0;
+  const canBuy = !!sku?._id && !outOfStock;
+
   const buy = async () => {
-    if (busy) return;
+    if (busy || !canBuy) return;
     setBusy(true);
 
     const work = MOR_CHECKOUT_ENABLED
@@ -183,6 +266,7 @@ export default function PremiumDetails({
               <button
                 key={c.caption}
                 type="button"
+                title={c.caption}
                 aria-label={`Color ${c.caption}`}
                 aria-pressed={option.color === c.caption}
                 onClick={() => setOption((prev) => ({ ...prev, color: c.caption }))}
@@ -191,11 +275,7 @@ export default function PremiumDetails({
                     ? 'ring-1 ring-neutral-900 ring-offset-2'
                     : 'hover:ring-1 hover:ring-neutral-400 hover:ring-offset-2'
                 }`}
-                style={{
-                  backgroundColor: /^#|^rgb|^hsl/.test(String(c.value))
-                    ? String(c.value)
-                    : String(c.caption).toLowerCase(),
-                }}
+                style={{ backgroundColor: swatchColor(c.caption, c.value) }}
               />
             ))}
           </div>
@@ -274,10 +354,17 @@ export default function PremiumDetails({
       <button
         type="button"
         onClick={buy}
-        disabled={busy}
-        className="mt-8 h-12 w-full rounded-sm bg-neutral-900 text-[13px] font-semibold uppercase tracking-[0.14em] text-white transition-colors hover:bg-neutral-700 disabled:opacity-60"
+        disabled={busy || !canBuy}
+        aria-disabled={busy || !canBuy}
+        className="mt-8 h-12 w-full rounded-sm bg-neutral-900 text-[13px] font-semibold uppercase tracking-[0.14em] text-white transition-colors hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-neutral-900"
       >
-        {MOR_CHECKOUT_ENABLED ? 'Buy now' : 'Add to bag'}
+        {!sku?._id
+          ? 'Unavailable'
+          : outOfStock
+            ? 'Out of stock'
+            : MOR_CHECKOUT_ENABLED
+              ? 'Buy now'
+              : 'Add to bag'}
       </button>
 
       {/* Authenticity slot (product-passport strategy 2026-07-16). NOT a


### PR DESCRIPTION
## Closes / addresses
The three **blocking buy-box bugs** deferred as proposals by the premium-PDP design-QA pass (**#198**) because they touch the purchase path and dev lacked a variant-rich product. Premium PDP = #182 (merged), flag `NEXT_PUBLIC_PREMIUM_PDP_ENABLED` (ON in `dev.yml`). All changes are confined to the flag-gated `premium/*` path, so the flag-OFF (legacy) body stays **byte-identical**. One file: `src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx` (+104 / −17).

## The 3 fixes
**1. No-variant physical product → dead Buy button.**
`getFirstOption` yields `{color:null,size:null}` and `findSkuAsOption(null,null)` returns `null`, so `sku` was null and Buy threw — while the price (which falls back to `skuIDs[0]`) still rendered, masking it. Now, when a product exposes **no** color/size options, `sku` resolves to `skuIDs[0]` (the same sku the price uses) so single-SKU / no-option products are purchasable. When variant options **do** exist but the chosen combo is unresolvable we deliberately do **not** fall back (that would sell the wrong variant) — that state disables the CTA (#3).

**2. Multi-word named-color swatch → blank swatch.**
The swatch fell back to `caption.toLowerCase()` when there was no hex `value`; a multi-word name ("Heather Grey", "Off White", "Navy Blue") is invalid CSS → transparent. New `swatchColor()` prefers the stored hex/rgb/hsl `value` (**valid-hex swatches unchanged**), then a named-color→hex map, then a bare single CSS keyword, then a neutral chip — a swatch is never invisible, and the color name is always surfaced via `title`/`aria-label`.

**3. Out-of-stock combo CTA.**
A resolvable-but-OOS color+size still showed "Buy now" then failed with a misleading "Checkout is unavailable" toast. The CTA now **disables and relabels**: "Out of stock" for a resolved-but-exhausted sku, "Unavailable" when no sku resolves. **POD (made-to-order) and DIGITAL are always in stock here** — every POD sku reports `inventory.quantity: 0` yet is fully purchasable, so gating them on quantity would kill Buy across the entire made-to-order catalog; they are excluded. A physical non-POD sku is OOS only on a definite exhausted quantity (unknown quantity stays buyable — fail-open toward the sale). Null-sku vs OOS-sku are distinct states, coupled cleanly with #1.

## Verified live (dev preview / real products)
- **Blocker #1 — VERIFIED end-to-end.** Dev no-variant smoke product `6a1e37ff88399c3b429977bc` (physical, single SKU, no options, qty 100). BEFORE (live `shopdev`): clicking Buy makes **no** network request (sku null → throws → dead button). AFTER (this build, served locally against the dev API): clicking Buy fires **`POST /api/mor-checkout/session`** with a valid `skuId`. The dev backend returns 404 for these seeded smoke products (a dev-data / MoR-eligibility limitation, not the frontend); on prod — where MoR is live and products are MoR-eligible — this same path creates a real checkout session.
- **Blocker #3 POD-safety — VERIFIED.** Prod POD product `66895dcd4f0bbb0e97767a46` (all SKUs `quantity: 0`): CTA stays enabled "Buy now" (`aria-disabled="false"`), confirming POD is correctly excluded from the OOS gate (a naive `quantity<=0` gate would have disabled the whole catalog).
- **Blocker #2 no-regression — VERIFIED.** Same prod product renders all 6 swatches visibly, including multi-word **Cool Heather** and **Steel Grey** (via their stored hex).

## Verified by deterministic logic assertion (no live dev product for these exact inputs)
- **Blocker #2 fix path** (multi-word name with **no** hex value): `swatchColor('Heather Grey','Heather Grey')` → `#b0b3b8` (paintable), vs the old code → `"heather grey"` (invalid CSS, invisible). Unknown multi-word → neutral `#e5e5e5`.
- **Blocker #3 fix path** (physical OOS): physical `quantity 0` → OOS/disabled; physical `quantity 5 sold 5` → OOS; physical unknown/NaN qty → buyable (fail-open).
- 14/14 assertions pass.

## Gates
- `next build` (dev env: premium+MoR+root-catalog ON, dev API base): **0 errors**.
- `tsc --noEmit`: **8 pre-existing errors in 7 unrelated files** (checkout/footer/header/cart), **0 new** — baseline unchanged.
- smoke (`npm test`): **3/3 pass**.

## Honest scope
- Blocker #1 is genuinely fixed **and** exercised live (Buy now now invokes the checkout path). A full green e2e on **dev** is blocked by the dev backend 404-ing the seeded smoke products for MoR — an environmental limitation, not this change.
- Blockers #2 and #3 are fixed; their **no-regression / POD-safety** paths are verified live against a real prod variant product, and their **fix-specific** paths (named-only non-hex color; physical out-of-stock) are verified by deterministic logic assertion because **dev has no variant-rich or out-of-stock product** to exercise them on a live PDP. Recommend a final visual pass once a variant-rich + an OOS product exist on dev.

## Coordination
Open PR **#198** (design-QA polish) also touches `PremiumDetails.tsx` (quantity-stepper a11y region) and is not yet merged to `dev`. Regions differ (buy-box logic vs. stepper markup); a small merge may be needed if both land — operator sequences.

**Do NOT merge — operator-gated.** Base `dev`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)