### PR TITLE
GTFU: dev → main — flip Premium PDP live on prod (#197/#198/#199/#200)

### DIFF
--- a/src/app/(routes)/[productId]/components/premium/Accordion.tsx
+++ b/src/app/(routes)/[productId]/components/premium/Accordion.tsx
@@ -10,7 +10,7 @@
  * HTML; only the open/close toggle is client behavior).
  */
 
-import { useState, type ReactNode } from 'react';
+import { useId, useState, type ReactNode } from 'react';
 
 export function AccordionItem({
   title,
@@ -22,13 +22,15 @@ export function AccordionItem({
   defaultOpen?: boolean;
 }) {
   const [open, setOpen] = useState(defaultOpen);
+  const panelId = useId();
   return (
     <div className="border-b border-neutral-200">
       <button
         type="button"
         aria-expanded={open}
+        aria-controls={panelId}
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center justify-between py-4 text-left"
+        className="flex w-full items-center justify-between py-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:ring-offset-2"
       >
         <span className="text-[13px] font-semibold uppercase tracking-[0.12em] text-neutral-900">
           {title}
@@ -51,7 +53,9 @@ export function AccordionItem({
         </svg>
       </button>
       {/* Keep content mounted (SEO/agents read it; toggle is display-only). */}
-      <div className={open ? 'pb-5' : 'hidden'}>{children}</div>
+      <div id={panelId} role="region" aria-label={title} className={open ? 'pb-5' : 'hidden'}>
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/app/(routes)/[productId]/components/premium/MediaGallery.tsx
+++ b/src/app/(routes)/[productId]/components/premium/MediaGallery.tsx
@@ -51,7 +51,7 @@ export default function MediaGallery({
               type="button"
               aria-label={`View image ${i + 1}`}
               onClick={() => setCurrent(m.url)}
-              className={`relative h-16 w-16 overflow-hidden rounded-sm bg-neutral-50 transition-shadow ${
+              className={`relative h-16 w-16 overflow-hidden rounded-sm bg-neutral-50 transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:ring-offset-2 ${
                 current === m.url
                   ? 'ring-1 ring-neutral-900'
                   : 'ring-1 ring-transparent hover:ring-neutral-300'
@@ -74,7 +74,7 @@ export default function MediaGallery({
         type="button"
         aria-label="Open image gallery"
         onClick={() => setLightboxOpen(true)}
-        className="relative aspect-[4/5] w-full cursor-zoom-in overflow-hidden rounded-sm bg-neutral-50"
+        className="relative aspect-[4/5] w-full cursor-zoom-in overflow-hidden rounded-sm bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:ring-offset-2"
       >
         {current && (
           <Image

--- a/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
+++ b/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
@@ -178,15 +178,16 @@ export default function PremiumDetails({
             <span className="font-semibold">Color</span>
             {option.color && <span className="text-neutral-500"> — {option.color}</span>}
           </p>
-          <div className="mt-2.5 flex flex-wrap gap-2">
+          <div className="mt-2.5 flex flex-wrap gap-2" role="group" aria-label="Color">
             {colors.map((c) => (
               <button
                 key={c.caption}
                 type="button"
+                title={c.caption}
                 aria-label={`Color ${c.caption}`}
                 aria-pressed={option.color === c.caption}
                 onClick={() => setOption((prev) => ({ ...prev, color: c.caption }))}
-                className={`h-9 w-9 rounded-full border border-neutral-300 transition-shadow ${
+                className={`h-9 w-9 rounded-full border border-neutral-300 transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:ring-offset-2 ${
                   option.color === c.caption
                     ? 'ring-1 ring-neutral-900 ring-offset-2'
                     : 'hover:ring-1 hover:ring-neutral-400 hover:ring-offset-2'
@@ -219,7 +220,7 @@ export default function PremiumDetails({
               Size guide
             </a>
           </div>
-          <div className="mt-2.5 grid grid-cols-5 gap-2 sm:grid-cols-6">
+          <div className="mt-2.5 grid grid-cols-5 gap-2 sm:grid-cols-6" role="group" aria-label="Size">
             {sizes.map((s) => {
               const selected = option.size === s.caption;
               const available = sizeAvailable(s.caption);
@@ -230,7 +231,7 @@ export default function PremiumDetails({
                   disabled={!available}
                   aria-pressed={selected}
                   onClick={() => setOption((prev) => ({ ...prev, size: s.caption }))}
-                  className={`h-10 rounded-sm border text-[13px] transition-colors ${
+                  className={`h-10 rounded-sm border text-[13px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:ring-offset-2 ${
                     selected
                       ? 'border-neutral-900 bg-neutral-900 text-white'
                       : available
@@ -248,22 +249,34 @@ export default function PremiumDetails({
 
       {/* Quantity — deliberately quiet */}
       <div className="mt-7 flex items-center gap-4">
-        <p className="text-[13px] font-semibold text-neutral-900">Quantity</p>
-        <div className="flex h-9 items-center rounded-sm border border-neutral-300">
+        <p className="text-[13px] font-semibold text-neutral-900" id="premium-qty-label">
+          Quantity
+        </p>
+        <div
+          className="flex h-9 items-center rounded-sm border border-neutral-300"
+          role="group"
+          aria-labelledby="premium-qty-label"
+        >
           <button
             type="button"
             aria-label="Decrease quantity"
             onClick={() => setQuantity((q) => Math.max(1, q - 1))}
-            className="w-9 text-neutral-500 hover:text-neutral-900"
+            className="w-9 text-neutral-500 hover:text-neutral-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-900"
           >
             −
           </button>
-          <span className="w-8 text-center text-[13px] tabular-nums">{quantity}</span>
+          <span
+            className="w-8 text-center text-[13px] tabular-nums"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {quantity}
+          </span>
           <button
             type="button"
             aria-label="Increase quantity"
             onClick={() => setQuantity((q) => Math.min(99, q + 1))}
-            className="w-9 text-neutral-500 hover:text-neutral-900"
+            className="w-9 text-neutral-500 hover:text-neutral-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neutral-900"
           >
             +
           </button>
@@ -275,9 +288,16 @@ export default function PremiumDetails({
         type="button"
         onClick={buy}
         disabled={busy}
-        className="mt-8 h-12 w-full rounded-sm bg-neutral-900 text-[13px] font-semibold uppercase tracking-[0.14em] text-white transition-colors hover:bg-neutral-700 disabled:opacity-60"
+        aria-busy={busy}
+        className="mt-8 h-12 w-full rounded-sm bg-neutral-900 text-[13px] font-semibold uppercase tracking-[0.14em] text-white transition-colors hover:bg-neutral-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:ring-offset-2 disabled:opacity-60"
       >
-        {MOR_CHECKOUT_ENABLED ? 'Buy now' : 'Add to bag'}
+        {busy
+          ? MOR_CHECKOUT_ENABLED
+            ? 'Starting checkout…'
+            : 'Adding…'
+          : MOR_CHECKOUT_ENABLED
+            ? 'Buy now'
+            : 'Add to bag'}
       </button>
 
       {/* Authenticity slot (product-passport strategy 2026-07-16). NOT a
@@ -306,8 +326,8 @@ export default function PremiumDetails({
         </p>
       ) : (
         <p className="mt-6 text-[12px] leading-5 text-neutral-500">
-          Secure checkout · {POLICY.returnWindowDays}-day returns · Made to order —
-          ships in {POLICY.handlingTimeDays}
+          Secure checkout · {POLICY.returnWindowDays}-day returns · Ships in{' '}
+          {POLICY.handlingTimeDays}
         </p>
       )}
     </div>

--- a/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
+++ b/src/app/(routes)/[productId]/components/premium/PremiumDetails.tsx
@@ -39,6 +39,60 @@ const numericSize = (caption: string) => {
   return m ? parseFloat(m[0]) : Number.POSITIVE_INFINITY;
 };
 
+// A usable CSS color literal — hex / rgb() / hsl(). A single-word CSS color
+// keyword ("navy", "white") also paints, but a multi-word merchant color name
+// ("Heather Grey", "Off White", "Navy Blue") is NOT valid CSS and paints
+// nothing — an invisible swatch.
+const CSS_COLOR = /^(#|rgb|hsl)/i;
+
+// Common multi-word (and a few ambiguous single-word) merchant color names →
+// representative hex, so a named-only color still renders a sensible chip.
+const NAMED_HEX: Record<string, string> = {
+  'heather grey': '#b0b3b8',
+  'heather gray': '#b0b3b8',
+  'cool heather': '#a9b3b6',
+  'steel grey': '#47525c',
+  'steel gray': '#47525c',
+  'off white': '#f7f4ef',
+  'navy blue': '#1f2a44',
+  'midnight navy': '#161d2b',
+  'sky blue': '#87ceeb',
+  'light blue': '#add8e6',
+  'royal blue': '#2b4fbb',
+  'forest green': '#228b22',
+  'olive green': '#6b7a3a',
+  'hot pink': '#ff69b4',
+  'light grey': '#d3d3d3',
+  'light gray': '#d3d3d3',
+  'dark grey': '#4b4f54',
+  'dark gray': '#4b4f54',
+  'burnt orange': '#cc5500',
+  'dusty rose': '#c08497',
+  'charcoal grey': '#36454f',
+  'charcoal gray': '#36454f',
+};
+
+// A last-resort neutral so a swatch is NEVER invisible.
+const NEUTRAL_SWATCH = '#e5e5e5';
+
+/**
+ * Resolve a guaranteed-paintable swatch color. Prefer the stored hex/rgb/hsl
+ * `value` (valid-hex swatches are unchanged); then a known named-color map;
+ * then a bare single-word CSS keyword; otherwise a neutral chip. The color
+ * NAME is always surfaced via title/aria-label at the call site so a neutral
+ * fallback is never ambiguous.
+ */
+const swatchColor = (caption?: string | null, value?: string | null): string => {
+  const v = String(value ?? '').trim();
+  if (CSS_COLOR.test(v)) return v; // stored hex/rgb/hsl wins — no regression
+  const cap = String(caption ?? '').trim();
+  if (CSS_COLOR.test(cap)) return cap; // caption itself may carry a hex
+  const key = cap.toLowerCase();
+  if (NAMED_HEX[key]) return NAMED_HEX[key]; // multi-word name → representative hex
+  if (key && !key.includes(' ')) return key; // single CSS keyword ("navy") paints
+  return NEUTRAL_SWATCH; // never invisible
+};
+
 export default function PremiumDetails({
   product,
   brandName,
@@ -56,14 +110,6 @@ export default function PremiumDetails({
   const [quantity, setQuantity] = useState(1);
   const [busy, setBusy] = useState(false);
 
-  const sku: ISku | null | undefined = useMemo(
-    () =>
-      product?.product_type === 'DIGITAL'
-        ? product?.skuIDs?.[0]
-        : findSkuAsOption({ color: option.color, size: option.size, skuIDs: product?.skuIDs }),
-    [product, option, findSkuAsOption],
-  );
-
   const colors = useMemo(() => getOptions(product?.skuIDs, 'color'), [product, getOptions]);
   const sizes = useMemo(
     () =>
@@ -72,6 +118,29 @@ export default function PremiumDetails({
       ),
     [product, getOptions],
   );
+
+  // A no-variant / single-variant physical product exposes NO color or size
+  // options, so option-based resolution can never match: getFirstOption yields
+  // {color:null,size:null} and findSkuAsOption returns null for a null/null
+  // query — leaving `sku` null so Buy throws "Missing variant" while the price
+  // (which falls back to skuIDs[0]) still renders, masking the dead button.
+  // Fall back to skuIDs[0] — the exact sku the price uses — so single-SKU
+  // products are purchasable. When variant options DO exist but the chosen
+  // combo is unresolvable we deliberately do NOT fall back (that would sell the
+  // wrong variant); that state disables the CTA below.
+  const hasVariantOptions = colors.length > 0 || sizes.length > 0;
+
+  const sku: ISku | null | undefined = useMemo(() => {
+    if (product?.product_type === 'DIGITAL') return product?.skuIDs?.[0];
+    const matched = findSkuAsOption({
+      color: option.color,
+      size: option.size,
+      skuIDs: product?.skuIDs,
+    });
+    if (matched) return matched;
+    return hasVariantOptions ? null : product?.skuIDs?.[0];
+  }, [product, option, findSkuAsOption, hasVariantOptions]);
+
   const sizesForColor = useMemo(
     () => (option.color ? skuIDsMatchColor(product?.skuIDs, option.color) : null),
     [product, option.color, skuIDsMatchColor],
@@ -97,8 +166,22 @@ export default function PremiumDetails({
   // delivery. Non-POD copy stays byte-identical.
   const pod = isPodProduct(product);
 
+  // Stock gate. POD (made-to-order via Printful) and DIGITAL carry no finite
+  // stock — every POD sku reports inventory.quantity 0 yet is fully purchasable
+  // — so they are ALWAYS in stock here; gating them on quantity would wrongly
+  // kill Buy on the entire made-to-order catalog. A physical, non-POD sku is
+  // out of stock only when it reports a definite, exhausted quantity; an
+  // unknown quantity stays buyable (fail-open toward the sale). This is the
+  // per-combo signal: a resolvable-but-out-of-stock color+size disables the
+  // CTA, distinct from the no-option fallback above (which stays buyable).
+  const madeToOrder = pod || product?.product_type === 'DIGITAL';
+  const stockLeft = Number(sku?.quantity) - Number(sku?.sold_units ?? 0);
+  const outOfStock =
+    !!sku && !madeToOrder && Number.isFinite(sku?.quantity) && stockLeft <= 0;
+  const canBuy = !!sku?._id && !outOfStock;
+
   const buy = async () => {
-    if (busy) return;
+    if (busy || !canBuy) return;
     setBusy(true);
 
     const work = MOR_CHECKOUT_ENABLED
@@ -192,11 +275,7 @@ export default function PremiumDetails({
                     ? 'ring-1 ring-neutral-900 ring-offset-2'
                     : 'hover:ring-1 hover:ring-neutral-400 hover:ring-offset-2'
                 }`}
-                style={{
-                  backgroundColor: /^#|^rgb|^hsl/.test(String(c.value))
-                    ? String(c.value)
-                    : String(c.caption).toLowerCase(),
-                }}
+                style={{ backgroundColor: swatchColor(c.caption, c.value) }}
               />
             ))}
           </div>
@@ -287,17 +366,22 @@ export default function PremiumDetails({
       <button
         type="button"
         onClick={buy}
-        disabled={busy}
+        disabled={busy || !canBuy}
         aria-busy={busy}
-        className="mt-8 h-12 w-full rounded-sm bg-neutral-900 text-[13px] font-semibold uppercase tracking-[0.14em] text-white transition-colors hover:bg-neutral-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:ring-offset-2 disabled:opacity-60"
+        aria-disabled={busy || !canBuy}
+        className="mt-8 h-12 w-full rounded-sm bg-neutral-900 text-[13px] font-semibold uppercase tracking-[0.14em] text-white transition-colors hover:bg-neutral-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-neutral-900"
       >
         {busy
           ? MOR_CHECKOUT_ENABLED
             ? 'Starting checkout…'
             : 'Adding…'
-          : MOR_CHECKOUT_ENABLED
-            ? 'Buy now'
-            : 'Add to bag'}
+          : !sku?._id
+            ? 'Unavailable'
+            : outOfStock
+              ? 'Out of stock'
+              : MOR_CHECKOUT_ENABLED
+                ? 'Buy now'
+                : 'Add to bag'}
       </button>
 
       {/* Authenticity slot (product-passport strategy 2026-07-16). NOT a

--- a/src/app/(routes)/[productId]/components/premium/PremiumProductExperience.tsx
+++ b/src/app/(routes)/[productId]/components/premium/PremiumProductExperience.tsx
@@ -106,8 +106,8 @@ export default function PremiumProductExperience({
               <AccordionItem title="Shipping & returns">
                 <div className="flex flex-col gap-2 text-[14px] leading-6 text-neutral-600">
                   <p>
-                    Every piece is made to order and ships in {POLICY.handlingTimeDays}{' '}
-                    with tracking.
+                    {isPodProduct(product) ? 'Made to order and ships' : 'Ships'} in{' '}
+                    {POLICY.handlingTimeDays} with tracking.
                   </p>
                   {isPodProduct(product) ? (
                     // POD (Printful) terms: made to order, so no size-change /

--- a/src/app/(routes)/[productId]/product/[slug]/lib/structured-data.ts
+++ b/src/app/(routes)/[productId]/product/[slug]/lib/structured-data.ts
@@ -76,10 +76,29 @@ export interface OpenGraphBlock {
   [key: string]: string | undefined;
 }
 
+/**
+ * Normalised product type exposed by the BE as a top-level SIBLING of
+ * `jsonLd` (droplinked-backend `feat/seo-structured-data-expose-type`).
+ * `pod` = print-on-demand (made to order) — the teaser trust row must
+ * render Printful's made-to-order terms (see POD_POLICY in site.ts),
+ * never the standard return window. The BE OMITS the field when the
+ * stored type is absent/unknown; older BE builds don't send it at all —
+ * consumers must fail-open to the existing non-POD copy either way.
+ */
+export type StructuredDataProductType = "pod" | "physical" | "digital";
+
+const KNOWN_PRODUCT_TYPES = new Set<StructuredDataProductType>([
+  "pod",
+  "physical",
+  "digital",
+]);
+
 export interface StructuredData {
   productId: string;
   /** Canonical URL — normalised to the served shop.droplinked.com host. */
   canonicalUrl: string;
+  /** Absent on older BE builds / unknown types — treat as non-POD. */
+  productType?: StructuredDataProductType;
   jsonLd: ProductJsonLd;
   openGraph: OpenGraphBlock;
 }
@@ -160,9 +179,18 @@ function parseStructuredData(
       ? { ...(r.openGraph as OpenGraphBlock), "og:url": servedUrl }
       : { "og:url": servedUrl };
 
+  // Fail-open type parse: only the known vocabulary passes through; any
+  // other/missing value leaves the field absent (→ existing non-POD copy).
+  const productType =
+    typeof r.productType === "string" &&
+    KNOWN_PRODUCT_TYPES.has(r.productType as StructuredDataProductType)
+      ? (r.productType as StructuredDataProductType)
+      : undefined;
+
   return {
     productId: typeof r.productId === "string" ? r.productId : "",
     canonicalUrl: servedUrl,
+    ...(productType ? { productType } : {}),
     jsonLd,
     openGraph,
   };

--- a/src/app/(routes)/[productId]/product/[slug]/page.tsx
+++ b/src/app/(routes)/[productId]/product/[slug]/page.tsx
@@ -39,7 +39,8 @@ import {
   buildServedUrl,
 } from "./lib/structured-data";
 import { sanitizeHtml, htmlToText } from "./lib/sanitize-html";
-import { POLICY } from "@/lib/site";
+import { POD_POLICY, POLICY } from "@/lib/site";
+import { isPodProduct } from "@/lib/pod";
 import { titleCaseHandle } from "@/lib/utils/handle/handle";
 import { UNIFIED_PDP_ENABLED } from "@/lib/variables/variables";
 import { getInteractiveProduct } from "../../lib/product-data";
@@ -125,6 +126,14 @@ export default async function ProductPage({ params }: PageProps) {
   // reviewer cannot get past. Fall back to the canonical URL only when the
   // structured-data payload carried no product id.
   const purchaseUrl = data.productId ? `/${data.productId}` : view.canonicalUrl;
+
+  // POD (made to order via Printful): the static-teaser trust row must show
+  // the SAME made-to-order terms as the live PDP (PremiumDetails, PR #193),
+  // never the standard return window. Branches on the structured-data
+  // envelope's `productType` sibling field; routed through the ONE detector
+  // in @/lib/pod so the spelling logic never forks. Missing field (older BE,
+  // unknown type) → false → existing copy, byte-identical (fail-open).
+  const pod = isPodProduct({ type: data.productType ?? "", product_type: "" });
 
   // ── Unified PDP ────────────────────────────────────────────────────────
   // When enabled, resolve the SAME rich interactive product the /<productId>
@@ -268,30 +277,61 @@ export default async function ProductPage({ params }: PageProps) {
             {view.inStock ? "Buy now" : "View product"}
           </Link>
 
-          {/* Trust affordances a reviewer sees on the feed landing page. */}
-          <p className="text-xs text-ink-faint">
-            Secure checkout · {POLICY.returnWindowDays}-day{" "}
-            <Link
-              href="/returns-policy"
-              className="text-mint-500 hover:text-mint-400 transition-colors"
-            >
-              returns
-            </Link>{" "}
-            ·{" "}
-            <Link
-              href="/shipping-policy"
-              className="text-mint-500 hover:text-mint-400 transition-colors"
-            >
-              shipping info
-            </Link>{" "}
-            ·{" "}
-            <Link
-              href="/contact"
-              className="text-mint-500 hover:text-mint-400 transition-colors"
-            >
-              contact
-            </Link>
-          </p>
+          {/* Trust affordances a reviewer sees on the feed landing page.
+              POD items carry Printful's made-to-order terms (the exact #193
+              line) instead of the return window; non-POD stays byte-identical. */}
+          {pod ? (
+            <p className="text-xs text-ink-faint">
+              Secure checkout · Made to order — ships in{" "}
+              {POLICY.handlingTimeDays} · Damaged or misprinted? We&apos;ll
+              replace it — report within {POD_POLICY.claimWindowDays} days of
+              delivery.{" "}
+              <Link
+                href="/returns-policy"
+                className="text-mint-500 hover:text-mint-400 transition-colors"
+              >
+                Return policy
+              </Link>{" "}
+              ·{" "}
+              <Link
+                href="/shipping-policy"
+                className="text-mint-500 hover:text-mint-400 transition-colors"
+              >
+                shipping info
+              </Link>{" "}
+              ·{" "}
+              <Link
+                href="/contact"
+                className="text-mint-500 hover:text-mint-400 transition-colors"
+              >
+                contact
+              </Link>
+            </p>
+          ) : (
+            <p className="text-xs text-ink-faint">
+              Secure checkout · {POLICY.returnWindowDays}-day{" "}
+              <Link
+                href="/returns-policy"
+                className="text-mint-500 hover:text-mint-400 transition-colors"
+              >
+                returns
+              </Link>{" "}
+              ·{" "}
+              <Link
+                href="/shipping-policy"
+                className="text-mint-500 hover:text-mint-400 transition-colors"
+              >
+                shipping info
+              </Link>{" "}
+              ·{" "}
+              <Link
+                href="/contact"
+                className="text-mint-500 hover:text-mint-400 transition-colors"
+              >
+                contact
+              </Link>
+            </p>
+          )}
 
           {view.sku && (
             <p className="text-xs text-ink-faint">SKU: {view.sku}</p>

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -25,9 +25,8 @@ export const SITE = {
   /** One-line description of what the platform is (no placeholder copy). */
   tagline: "Powering the next generation of commerce.",
   description:
-    "droplinked is the commerce platform for modern brands — sell physical " +
-    "and digital products, get found by AI shopping agents and affiliates, " +
-    "and get paid through providers you already trust.",
+    "droplinked helps modern brands sell. Drive agentic discovery, prove " +
+    "authenticity onchain, and get paid faster.",
   /** Primary customer support channel. */
   supportEmail: "support@droplinked.com",
   /** Customer-service phone (matches Merchant Center → Business info contact). */


### PR DESCRIPTION
## GTFU dev → main — Premium PDP prod flip

Ships the premium-PDP completion set to prod and **flips the flag on**:
- **#198** premium PDP design-QA completion pass
- **#199** buy-box blockers — no-variant sku fallback, multi-word named-color swatches, OOS CTA disable
- **#197** POD static-teaser trust row shows made-to-order terms (not the 14-day window)
- **#200** footer description sharpened (agentic discovery · onchain authenticity · faster payouts)

### Prod flip
`main.yml` on dev sets `NEXT_PUBLIC_PREMIUM_PDP_ENABLED=true` → this GTFU **enables the premium PDP on prod**.

### Safety
- **Merge-commit** (NOT squash): dev is behind main by 2 commits, but those are only the prior GTFU merge nodes (#194/#196) — no main-only content, so nothing is reverted.
- Buy-box edge cases code-verified in `PremiumDetails.tsx` (canBuy sku-gate, swatchColor never-invisible, OOS excludes POD/made-to-order).
- **Revert-ready**: revert this merge commit to flip the flag back off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)