### PR TITLE
fix: add recovery actions to not-found page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,9 +1,38 @@
-import React from 'react'
+import Link from 'next/link';
 
-const NotFound = () => {
+export default function NotFound() {
   return (
-    <div>NotFound</div>
-  )
-}
+    <main
+      className="flex min-h-[70vh] flex-col items-center justify-center px-6 py-24 text-center"
+      aria-labelledby="not-found-title"
+    >
+      <p className="mb-4 select-none text-5xl font-semibold text-foreground/30" aria-hidden="true">
+        404
+      </p>
 
-export default NotFound
+      <h1 id="not-found-title" className="mb-2 text-2xl font-semibold text-foreground">
+        Page not found
+      </h1>
+
+      <p className="mb-8 max-w-md text-sm text-foreground/60">
+        The storefront or product you&apos;re looking for may have moved, expired,
+        or is not available yet.
+      </p>
+
+      <div className="flex flex-col items-center gap-4 sm:flex-row">
+        <Link
+          href="/"
+          className="inline-flex items-center justify-center rounded-sm bg-foreground px-5 py-3 text-sm font-medium text-background transition-colors hover:bg-hovered hover:text-hovered-foreground"
+        >
+          Browse products
+        </Link>
+        <Link
+          href="/contact"
+          className="text-sm font-medium text-mint-500 transition-colors hover:text-mint-400"
+        >
+          Contact support
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/tests/not-found.spec.ts
+++ b/tests/not-found.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Not-found recovery', () => {
+  test('invalid storefront links show recovery actions below the fixed header', async ({ page }) => {
+    await page.goto('/qa-missing-storefront');
+
+    const heading = page.getByRole('heading', { name: 'Page not found' });
+    await expect(heading).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Browse products' })).toHaveAttribute('href', '/');
+    await expect(page.getByRole('link', { name: 'Contact support' })).toHaveAttribute('href', '/contact');
+
+    const header = page.locator('header').first();
+    const headingBox = await heading.boundingBox();
+    const headerBox = await header.boundingBox();
+
+    expect(headingBox).not.toBeNull();
+    expect(headerBox).not.toBeNull();
+    expect(headingBox!.y).toBeGreaterThanOrEqual(headerBox!.y + headerBox!.height);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the global `NotFound` placeholder with an accessible recovery page so shoppers who follow missing storefront or product links can understand what happened and return to the catalog or contact support. Adds a Playwright regression test that also guards against the fixed header obscuring the recovery content.

## Closes / addresses

N/A — net-new work discovered during a QA review of `droplinked.com`.

## Reproduce (bug fixes) / Describe the new behavior (features)

**User story**

> As a shopper who follows an unavailable storefront or product link, I need a clear recovery page so I understand what happened and can continue browsing or contact support.

**Before**

1. Visit an invalid product/storefront route, for example `https://shop.droplinked.com/qa-missing-storefront`.
2. The route renders the global `src/app/not-found.tsx`.
3. The only body content is `NotFound`, positioned at `y=0` underneath the fixed 80 px header (`z-index: 20`).
4. The shopper effectively sees a blank page followed by the site footer, with no explanation or recovery action.

**After**

The page shows a semantic `Page not found` heading, concise storefront/product guidance, a `Browse products` action, and a `Contact support` action. The content is centered below the fixed header and works with the existing responsive layout.

## Root cause / approach

The global fallback was a raw `<div>NotFound</div>` with no layout spacing, semantics, or navigation. Because the site header is fixed, that div rendered behind it.

The fix keeps scope local to `src/app/not-found.tsx`:

- uses semantic `<main>` and `<h1>` elements connected by `aria-labelledby`
- reuses existing foreground, background, mint, hover, and responsive utility classes
- provides catalog and support recovery links
- adds a Playwright test that asserts the heading and links are visible and that the heading's bounding box begins below the fixed header

## Visual diff (UI-touching PRs)

Before/after screenshots are attached in the first PR comment.

## Test plan

- [x] `npm test` — 3/3 smoke tests pass
- [x] `npx eslint src/app/not-found.tsx tests/not-found.spec.ts` — clean
- [x] `git diff --check` — clean
- [x] Manually verified at `http://localhost:4312/qa-local-missing-store`
- [x] Confirmed the heading begins at `y=269`, below the fixed header ending at `y=80`
- [x] Playwright discovers the regression test in all 5 configured mobile/tablet projects
- [ ] Playwright browser execution locally — macOS denied the headless Chromium Mach-port registration in this sandbox; the same behavior was independently verified through the interactive browser

A production build compiled successfully before page-data collection encountered the repository's existing `/BingSiteAuth.xml` environment/build failure; no build error pointed to the files changed here.

## DEV smoke plan (run after merge to dev, before LIVE promotion)

1. Open `https://shopdev.droplinked.com/qa-missing-storefront` (or any guaranteed-missing first-segment route).
2. Confirm `Page not found` is visible below the header on desktop and mobile.
3. Confirm `Browse products` routes to `/`.
4. Confirm `Contact support` routes to `/contact`.
5. Repeat with an invalid `/<merchant>/product/<slug>` URL.

## LIVE smoke plan (run after operator merges dev→main)

Repeat the DEV path on `https://shop.droplinked.com/qa-missing-storefront`, then verify one valid product route remains unchanged.

## Rollback target

- Last-known-good main commit: `64bca46`
- Rollback: revert this PR

## Risk

Low. This changes only the global not-found UI and adds a browser regression test. Valid storefronts, products, checkout, and payment flows are untouched.

## Out of scope (NOT in this PR)

- Dynamic invalid product/storefront routes currently return HTTP 200 soft-404 responses even when `notFound()` renders; status-code handling requires a separate Next.js/server-rendering investigation.
- `/orders/<invalid-order>` currently returns HTTP 500; it is a separate order-fetch/error-handling path and requires the deployment API context to diagnose safely.
- The existing `/m/<missing-merchant>` page already has helpful recovery content but returns HTTP 200; this PR does not change it.

---

## Operator merge checklist

- [ ] CI green
- [ ] Reviewed diff
- [ ] Merged to `main` via dev→main GTFU
- [ ] Smoked on prod shop-builder URL — green
- [ ] No regression; PR closed
