### PR TITLE
ci: allow dependabot/* → main for security auto-fixes

### DIFF
--- a/.github/workflows/enforce-pr-source-branch.yml
+++ b/.github/workflows/enforce-pr-source-branch.yml
@@ -10,12 +10,12 @@ jobs:
       - name: Check PR head branch
         run: |
           HEAD="${{ github.head_ref }}"
-          if [[ "$HEAD" == "dev" || "$HEAD" == hotfix/* ]]; then
+          if [[ "$HEAD" == "dev" || "$HEAD" == hotfix/* || "$HEAD" == dependabot/* ]]; then
             echo "PR source '$HEAD' satisfies the dev-first policy"
             exit 0
           fi
           echo "::error::PR head '$HEAD' violates the dev-first policy."
-          echo "Required head branch for PRs targeting main: 'dev' OR 'hotfix/*'"
+          echo "Required head branch for PRs targeting main: 'dev', 'hotfix/*', OR 'dependabot/*' (security auto-fixes)"
           echo "Exception path 'hotfix/*' is for active integration debugging with external partners"
           echo "where dev parity does not exist (e.g. Telr E0x partner bisect). Operator merges still required."
           echo "Reference: workspace playbook droplinked-repo-sync-equilibrium-playbook-2026-06-05.md"


### PR DESCRIPTION
## What
Add `dependabot/*` to the `enforce-source-branch` allow-list (alongside `dev` and `hotfix/*`).

## Why
Dependabot **security-update** PRs branch from `dependabot/*`, which the dev-first policy rejected — so security fixes (js-yaml CVE-2026-59869, postcss, brace-expansion …) could not merge to `main` even with Smoke + verify green. This unblocks them permanently.

Operator merges still required; Smoke + verify still gate. Routed via `hotfix/*` so this PR itself satisfies the policy.