### PR TITLE
fix(deps): bump postcss to >=8.5.18 (CVE-2026-45623 arbitrary file read)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "autoprefixer": "^10.5.2",
         "eslint": "^8",
         "eslint-config-next": "15.3.0",
-        "postcss": "^8",
+        "postcss": "^8.5.18",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
       }
@@ -11152,9 +11152,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -11715,34 +11715,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/next/node_modules/semver": {
@@ -12313,9 +12285,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -12332,7 +12304,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "autoprefixer": "^10.5.2",
     "eslint": "^8",
     "eslint-config-next": "15.3.0",
-    "postcss": "^8",
+    "postcss": "^8.5.18",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   },
@@ -84,6 +84,7 @@
     "lodash-es": "^4.18.1",
     "minimatch": "^9.0.9",
     "picomatch": "^4.0.4",
+    "postcss": "^8.5.18",
     "rollup": "^4.27.0",
     "svgo": "^3.3.3",
     "tar": "^7.5.0",


### PR DESCRIPTION
## CVE-2026-45623 — postcss arbitrary file read / information disclosure

`postcss` below **8.5.18** follows an attacker-controlled `sourceMappingURL`
comment in CSS. The source-map resolver reads the referenced path off disk and
inlines its contents into the generated source map — so any pipeline that
compiles untrusted or partially-untrusted CSS (theme fragments, merchant-supplied
styles, third-party packages) can be coaxed into exfiltrating **any file readable
by the build process** into a build artifact.

This single bump also clears alerts **#158** (needs >=8.5.12) and **#121**
(needs >=8.5.10).

## Direct or transitive? — **Both**

That distinction mattered here, and fixing only one half would have been a false
fix:

| Instance | Before | Source |
|---|---|---|
| `node_modules/postcss` | **8.5.16** | direct `devDependencies` entry `"postcss": "^8"` |
| `node_modules/next/node_modules/postcss` | **8.4.31** | transitive — `next` pins `postcss@8.4.31` exactly, so npm hoisted a second nested copy |

Bumping only the direct range would have left the nested **8.4.31** copy in the
tree and the repo still vulnerable. So this PR uses **both mechanisms**:

1. **Direct** — `devDependencies.postcss`: `^8` → `^8.5.18`
2. **Override** — added `"postcss": "^8.5.18"` to the existing top-level
   `overrides` block, which forces `next`'s pinned `8.4.31` up and collapses it
   onto the single hoisted copy

Lockfile regenerated with `npm install --package-lock-only`. `package-lock.json`
was **not** hand-edited.

## Proof — `npm ls postcss --all`

Run after a clean `npm ci` on this branch:

```
next-shopfront@0.1.0 /private/tmp/nsf-postcss
├─┬ autoprefixer@10.5.2
│ └── postcss@8.5.25 deduped
├─┬ next@15.5.19
│ └── postcss@8.5.25 deduped
├── postcss@8.5.25 overridden
└─┬ tailwindcss@3.4.19
  ├─┬ postcss-import@15.1.0
  │ └── postcss@8.5.25 deduped
  ├─┬ postcss-js@4.1.0
  │ └── postcss@8.5.25 deduped
  ├─┬ postcss-load-config@6.0.1
  │ └── postcss@8.5.25 deduped
  ├─┬ postcss-nested@6.2.0
  │ └── postcss@8.5.25 deduped
  └── postcss@8.5.25 deduped
```

**Every instance resolves to 8.5.25** — above the 8.5.18 floor. `^8.5.18` picked
up the newest satisfying release rather than 8.5.18 exactly, which is expected
for a caret range.

Confirmed physically on disk too — the nested copy is gone, there is now exactly
one:

```
node_modules/postcss -> 8.5.25
```

## Build verification — yes, actually run

- `npm ci` — clean, 900 packages, no errors (lockfile is valid and installable)
- `npm run build` — **exit code 0**, captured explicitly rather than eyeballed
- CSS artifacts emitted under `.next/static/css/` (5 files), which confirms the
  postcss/tailwind pipeline genuinely executed against the new version rather
  than being skipped

The pre-existing `@sentry/nextjs` `onRouterTransitionStart` advisory still prints
during the build. It predates this change and is unrelated.

## Diff scope

Only `package.json` and `package-lock.json`. The lockfile diff is 8 insertions /
36 deletions and is entirely postcss-scoped:

- direct range + root `postcss` 8.5.16 → 8.5.25
- nested `next/node_modules/postcss` 8.4.31 entry removed (deduped by the override)
- `nanoid` 3.3.12 → 3.3.16 — a required transitive of postcss 8.5.25, which
  declares `nanoid: ^3.3.16`

One note on incidental churn: regenerating the lockfile on npm 10.9.3 initially
stripped the `libc` metadata fields from sharp's 16 optional platform packages
(`@img/sharp-*`). That is npm version churn, unrelated to postcss, and dropping
it would let npm resolve both glibc and musl variants on Linux. I restored those
fields so the diff stays strictly postcss-scoped. `npm ci` was run *after* the
restore, so the lockfile in this PR is the exact one that installs and builds
cleanly.

## Residual

This clears the postcss alerts only. Dependabot still reports other unrelated
advisories on `dev`; they are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LK1tY7oRna6jBG8J2o3o9i
