### PR TITLE
GTFU: postcss CVE-2026-45623 to prod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "autoprefixer": "^10.5.2",
         "eslint": "^8",
         "eslint-config-next": "15.3.0",
-        "postcss": "^8",
+        "postcss": "^8.5.18",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
       }
@@ -11152,9 +11152,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -11715,34 +11715,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/next/node_modules/semver": {
@@ -12313,9 +12285,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -12332,7 +12304,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "autoprefixer": "^10.5.2",
     "eslint": "^8",
     "eslint-config-next": "15.3.0",
-    "postcss": "^8",
+    "postcss": "^8.5.18",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   },
@@ -84,6 +84,7 @@
     "lodash-es": "^4.18.1",
     "minimatch": "^9.0.9",
     "picomatch": "^4.0.4",
+    "postcss": "^8.5.18",
     "rollup": "^4.27.0",
     "svgo": "^3.3.3",
     "tar": "^7.5.0",


### PR DESCRIPTION
## Closes / addresses

Promotes #212 to production. HIGH-severity `postcss` advisory.

## What ships

Exactly one change — `postcss` forced to **8.5.25** (floor 8.5.18). Verified by `gh api compare/main...dev`: the only dev-only commits are the fix and its merge.

| | |
|---|---|
| CVE | CVE-2026-45623 — arbitrary file read / info disclosure via attacker-controlled `sourceMappingURL` in a CSS comment |
| before | 8.5.16 direct + **8.4.31 nested under `next`** |
| after | 8.5.25, single hoisted copy |

## The nested copy is the point

`postcss` was a direct devDependency **and** `next` pins `postcss@8.4.31` exactly, so npm had hoisted a second copy at `node_modules/next/node_modules/postcss`. **Bumping only the direct range would have reported green while leaving the vulnerable copy in the tree.** Fixed with both a range bump and a top-level `overrides` entry; every resolved instance now reports 8.5.25, confirmed on disk as a single physical copy.

Also clears alerts #158 (≥8.5.12) and #121 (≥8.5.10).

## Verification

`npm ci` clean, `npm run build` **exit 0** (captured explicitly, not eyeballed), CSS artifacts emitted to `.next/static/css/` — so the postcss/tailwind pipeline genuinely ran against the new version. PR checks green on #212.

## Merge discipline

**Merge commit, not squash.** `dev` is behind `main` by 5; a squash would revert those commits.

## Note

Regenerating the lockfile on npm 10.9.3 also stripped `libc` metadata from sharp's optional platform packages — npm-version churn, unrelated to postcss. Restored, and `npm ci` + build were re-run *after* the restore, so the lockfile here is the one that was verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LK1tY7oRna6jBG8J2o3o9i