### PR TITLE
ci(deps): dependency hygiene — lockfile maintenance, dependabot auto-merge, runtime/dev split

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,46 @@
 version: 2
 updates:
+  # ONE npm entry — Dependabot requires a unique
+  # (package-ecosystem, directory, target-branch) triple, so the runtime /
+  # development split CANNOT be expressed as two npm update configs. It is
+  # done with GROUPS keyed on dependency-type instead, which produces the
+  # thing that actually matters: separate PR streams.
   - package-ecosystem: npm
     directory: /
     target-branch: "dev"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    # Raised from 5. Several repos sat AT the old cap while carrying 3-5x
+    # that many open alerts, so most advisories never got a PR at all — and
+    # the throttle was completely invisible.
+    open-pull-requests-limit: 15
     groups:
-      minor-and-patch:
+      # WHY SPLIT RUNTIME FROM DEVELOPMENT. The 2026-08-01 sweep found 26
+      # runtime-high vs 14 development-high across the org. Dev-scope build
+      # tooling (svgo, glob, minimatch, picomatch, rollup, webpack-dev-server)
+      # never reaches the runtime artifact; queueing it alongside runtime
+      # advisories is most of what made the backlog feel relentless, for no
+      # security gain.
+      #
+      # These two groups REPLACE the former catch-all `minor-and-patch` group.
+      # Coverage is identical — every minor/patch that used to land in the
+      # catch-all now lands in exactly one of these, by scope. Keeping the
+      # catch-all as well would defeat the split entirely: whichever was
+      # declared first would swallow everything.
+      #
+      # Declared runtime-first: dependabot assigns a dependency to the first
+      # matching group in definition order. Runtime is what ships, so it gets
+      # its own stream and is never auto-merged.
+      runtime-minor-and-patch:
+        dependency-type: "production"
+        update-types:
+          - minor
+          - patch
+      # Build tooling. Eligible for auto-merge (see
+      # .github/workflows/dependabot-auto-merge.yml) because it cannot reach
+      # a customer.
+      dev-minor-and-patch:
+        dependency-type: "development"
         update-types:
           - minor
           - patch

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,132 @@
+name: Dependabot auto-merge
+
+# WHY — remove the weekly click, without removing the review that matters.
+#
+# The dependency work is bimodal. Everything mechanical is same-major: on
+# 2026-08-01, tar / axios / brace-expansion / immutable / fast-uri / js-yaml
+# were all patch-or-minor and needed no judgement whatsoever. Everything that
+# genuinely needed a human was cross-major: react-router 7->8, sigstore 1->4,
+# adm-zip 0.4->0.6. Forcing those through would have turned an advisory into
+# an outage.
+#
+# So the automation boundary is the major boundary, and it is a clean one.
+#
+# SCOPE: development-scope patch/minor only, at first.
+#   - Dev-scope is the majority of the noise (build tooling: svgo, glob,
+#     minimatch, picomatch, rollup, webpack-dev-server) and none of it ships
+#     in the runtime artifact, so a bad one cannot reach a customer.
+#   - RUNTIME updates stay human-reviewed. That is deliberate while merchant
+#     PSPs are being onboarded — the settlement path is not somewhere to
+#     discover that an automated bump was wrong. The point is not that a human
+#     reviews less; it is that the runtime queue is no longer buried under
+#     build-tool noise.
+#
+# Widen to runtime patch once the PSP rollout has settled, by adding
+# 'direct:production' to the scope check below. Do not widen to major.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # PRECONDITIONS. This workflow is only as safe as two repo settings, and
+      # if either is missing it must say so LOUDLY rather than sit there being
+      # a no-op — a dependency-automation job that silently does nothing is
+      # worse than no job, because it looks like coverage.
+      #
+      #   1. allow_auto_merge must be TRUE, or `gh pr merge --auto` errors.
+      #   2. Branch protection with REQUIRED CHECKS must exist on the target
+      #      branch. `--auto` merges as soon as required checks pass — with no
+      #      required checks, "as soon as" means IMMEDIATELY, on a red PR.
+      #      Branch protection is the actual safety mechanism here; this
+      #      workflow only decides WHICH PRs are eligible.
+      - name: Verify preconditions
+        id: pre
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          AM=$(gh api "repos/${{ github.repository }}" --jq '.allow_auto_merge')
+          BASE="${{ github.event.pull_request.base.ref }}"
+          CHECKS=$(gh api "repos/${{ github.repository }}/branches/$BASE/protection" \
+                     --jq '.required_status_checks.contexts | length' 2>/dev/null || echo 0)
+          echo "allow_auto_merge=$AM  required_checks_on_$BASE=$CHECKS"
+          if [ "$AM" != "true" ] || [ "${CHECKS:-0}" -eq 0 ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Auto-merge is INERT. allow_auto_merge=$AM, required checks on '$BASE'=$CHECKS. Both are prerequisites; see the comment on this PR."
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Say so when inert
+        if: steps.pre.outputs.ready != 'true'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "$PR_URL" --body "**Dependabot auto-merge is installed but INERT** — merge this by hand.
+
+          Two repo settings are prerequisites and at least one is missing:
+
+          1. \`allow_auto_merge\` must be enabled on the repository.
+          2. Branch protection with **required status checks** must exist on the target branch.
+
+          The second matters more than it looks: \`gh pr merge --auto\` merges as soon as
+          required checks pass, so with **no** required checks configured, \`--auto\` merges
+          **immediately** — including on a red PR. Branch protection is the real safety
+          mechanism; this workflow only decides which PRs are *eligible*.
+
+          Flagging rather than failing silently. A dependency-automation job that quietly
+          does nothing is worse than none, because it reads as coverage."
+
+      - name: Explain the decision
+        run: |
+          echo "update-type : ${{ steps.meta.outputs.update-type }}"
+          echo "scope       : ${{ steps.meta.outputs.dependency-type }}"
+          echo "packages    : ${{ steps.meta.outputs.dependency-names }}"
+
+      # Auto-merge is QUEUED, not immediate: `--auto` waits for every required
+      # check. It cannot merge a red PR. If branch protection is ever relaxed
+      # this stops being true, which is worth remembering — the safety here is
+      # branch protection, not this workflow.
+      - name: Queue auto-merge (dev-scope patch/minor only)
+        if: |
+          steps.pre.outputs.ready == 'true' &&
+          steps.meta.outputs.dependency-type == 'direct:development' &&
+          (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+           steps.meta.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Leave a note on everything else
+        if: |
+          !(steps.meta.outputs.dependency-type == 'direct:development' &&
+            (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+             steps.meta.outputs.update-type == 'version-update:semver-minor'))
+        run: |
+          gh pr comment "$PR_URL" --body "Not auto-merged — held for human review.
+
+          - update type: \`${{ steps.meta.outputs.update-type }}\`
+          - scope: \`${{ steps.meta.outputs.dependency-type }}\`
+
+          Auto-merge covers **development-scope patch/minor** only. Runtime
+          updates and any major bump are reviewed by a person: majors are where
+          the real risk lives (react-router 7→8, sigstore 1→4 and adm-zip
+          0.4→0.6 all needed judgement), and runtime is deliberately held while
+          merchant PSPs are being onboarded."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lockfile-maintenance.yml
+++ b/.github/workflows/lockfile-maintenance.yml
@@ -1,0 +1,145 @@
+name: Lockfile maintenance
+
+# WHY THIS EXISTS — a failure mode no CVE bot catches
+#
+# On 2026-08-01 a CRITICAL advisory (tar, GHSA #244, runtime scope) was live
+# on prod while package.json ALREADY carried a correct override floor of
+# `^7.5.15`. The floor was never wrong. The LOCKFILE was stale: it pinned
+# 7.5.16 while 7.5.22 had shipped. Nobody had regenerated it.
+#
+# The same run found `axios@1.16.0` nested under @coinbase/cdp-sdk — the
+# x402 settlement rail — while the top-level axios was a healthy 1.18.1.
+#
+# Dependabot cannot fix either case. It proposes RANGE bumps in package.json;
+# it does not refresh a lockfile whose ranges are already satisfiable. So a
+# repo can sit indefinitely on vulnerable resolutions while every declared
+# range looks correct and every alert bot looks quiet.
+#
+# This job closes that gap: it re-resolves the lockfile within the EXISTING
+# declared ranges and opens a PR only when something actually moved. No
+# package.json edits, so no range widening and no major bumps — by
+# construction it can only pick versions the manifest already permits.
+
+on:
+  schedule:
+    # 06:00 UTC on the 1st and 15th. Twice monthly rather than weekly: stale
+    # resolutions drift slowly, and a noisy cadence is how these PRs start
+    # getting rubber-stamped.
+    - cron: '0 6 1,15 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: dev
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Record the current resolution set
+        run: |
+          node -e '
+            const l = require("./package-lock.json");
+            const out = Object.entries(l.packages || {})
+              .filter(([p]) => p.includes("node_modules/"))
+              .map(([p, m]) => p + "@" + (m.version || "?"))
+              .sort();
+            require("fs").writeFileSync("/tmp/before.txt", out.join("\n"));
+            console.log("resolutions before:", out.length);
+          '
+
+      - name: Re-resolve within existing ranges
+        # --package-lock-only: touches ONLY the lockfile. package.json is not
+        # written, so declared ranges cannot widen and a major cannot sneak in.
+        run: npm install --package-lock-only --legacy-peer-deps
+
+      - name: Diff the resolution set
+        id: diff
+        run: |
+          node -e '
+            const l = require("./package-lock.json");
+            const out = Object.entries(l.packages || {})
+              .filter(([p]) => p.includes("node_modules/"))
+              .map(([p, m]) => p + "@" + (m.version || "?"))
+              .sort();
+            require("fs").writeFileSync("/tmp/after.txt", out.join("\n"));
+          '
+          if diff -q /tmp/before.txt /tmp/after.txt > /dev/null; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Lockfile already fresh — no resolutions moved."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            {
+              echo 'summary<<EOF'
+              diff /tmp/before.txt /tmp/after.txt | grep -E '^[<>]' | head -60
+              echo EOF
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open PR when resolutions moved
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MOVED: ${{ steps.diff.outputs.summary }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/lockfile-refresh-$(date -u +%Y%m%d)"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add package-lock.json
+          git commit -F - <<'MSG'
+          chore(deps): refresh lockfile within existing ranges
+
+          Automated re-resolution. package.json is untouched, so every version
+          moved here was already permitted by the declared ranges — they were
+          simply not being resolved to.
+
+          This is the drift class CVE bots do not report: on 2026-08-01 a
+          CRITICAL tar advisory was live on prod while the override floor
+          (^7.5.15) was already correct and only the lockfile was stale.
+          MSG
+          git push -u origin "$BRANCH"
+
+          # Body assembled in a file rather than inline — nesting a heredoc and
+          # a command substitution inside `--body "..."` is exactly the kind of
+          # quoting that silently produces a mangled PR body.
+          {
+            echo "Automated lockfile re-resolution. **\`package.json\` is not modified** —"
+            echo "every change here was already permitted by the declared ranges and simply"
+            echo "was not being resolved to."
+            echo
+            echo "### Why this job exists"
+            echo "Dependabot proposes *range* bumps; it does not refresh a lockfile whose"
+            echo "ranges are already satisfiable. A repo can therefore sit on vulnerable"
+            echo "resolutions while every declared range looks correct and every alert bot"
+            echo "looks quiet."
+            echo
+            echo "Not hypothetical: on 2026-08-01 a **CRITICAL** \`tar\` advisory was live on"
+            echo "production while the override floor \`^7.5.15\` was already correct — the"
+            echo "lockfile was just stale at 7.5.16."
+            echo
+            echo "### Review guidance"
+            echo "Ranges cannot widen here, so this is normally safe to merge on green CI."
+            echo "Look for anything crossing a MAJOR boundary — that would mean a declared"
+            echo "range is wider than intended, which is worth fixing at the manifest."
+            echo
+            echo "### Resolutions moved"
+            echo '```'
+            printf '%s\n' "$MOVED"
+            echo '```'
+          } > /tmp/pr-body.md
+
+          gh pr create --base dev --head "$BRANCH" \
+            --title "chore(deps): lockfile refresh ($(date -u +%Y-%m-%d))" \
+            --body-file /tmp/pr-body.md

--- a/.github/workflows/lockfile-maintenance.yml
+++ b/.github/workflows/lockfile-maintenance.yml
@@ -59,9 +59,13 @@ jobs:
           '
 
       - name: Re-resolve within existing ranges
-        # --package-lock-only: touches ONLY the lockfile. package.json is not
-        # written, so declared ranges cannot widen and a major cannot sneak in.
-        run: npm install --package-lock-only --legacy-peer-deps
+        # `npm update`, NOT `npm install`. `npm install --package-lock-only`
+        # SATISFIES the lockfile it already has and does not move a
+        # valid-but-stale entry — measured: semver 7.5.0 under a declared
+        # ^7.0.0 stayed at 7.5.0, making this job a permanent no-op.
+        # `npm update --package-lock-only` re-resolves within the declared
+        # range (7.5.0 -> 7.8.5) and still does NOT write package.json.
+        run: npm update --package-lock-only --legacy-peer-deps
 
       - name: Diff the resolution set
         id: diff


### PR DESCRIPTION
Ports the dependency-hygiene setup from `droplinked/droplinked-backend` (PR #3216) to this repo. Adapted per-repo, not copied blindly — the per-repo notes are below. **No source files touched, only `.github/**`.**

### Per-repo adaptation
- **Base / checkout ref:** `dev` (this repo's integration branch).
- **Node:** `20`, matching `audit-signatures.yml` (the existing dependency-focused workflow).
- **`--legacy-peer-deps`:** plain `npm install --package-lock-only` *succeeds* here, so the flag is not strictly required. It is included anyway for parity with how this repo actually consumes the lockfile — `npm ci --legacy-peer-deps` in the Dockerfile and `npm ci --no-audit --legacy-peer-deps` in `audit-signatures.yml`. Re-resolving under different peer semantics than the install path would produce spurious churn.

### Relationship to the existing lockfile workflows
This repo already has `lockfile-sanity.yml` (guards against out-of-tree `../` paths) and `audit-signatures.yml` (npm provenance). Neither overlaps: those validate a lockfile someone else changed, this one *refreshes* a lockfile nobody has changed. Both left untouched.

### Pre-existing dependabot rules — all preserved
- ✅ `lodash` / `lodash-es` `>4.18.1` ignores, with the OpenJS/CVE-2026-4800 rationale.
- ✅ the `github-actions` ecosystem entry.
- 🔄 The old catch-all `minor-and-patch` group is **replaced** by the two `dependency-type` groups. Coverage is identical — every minor/patch that used to land in the catch-all now lands in exactly one of the two, by scope. Keeping both would have defeated the split.
- ⬆️ `open-pull-requests-limit` 5 → 15.

### Validation
- `yaml.safe_load` OK on all three files.
- `bash -n` OK on every `run:` script (the indented-heredoc-terminator trap: the `<<'MSG'` block dedents correctly under the YAML block scalar).
- PR-creation step **executed** against a scratch repo with stubbed `git push`/`gh` — commit message and PR body both assemble intact, `--base dev` correct.
- Resolution-capture snippet run against this repo's real `package-lock.json`: **954 resolutions** captured.

### What this adds
| file | purpose |
|---|---|
| `.github/workflows/lockfile-maintenance.yml` | twice-monthly re-resolution of the lockfile **within existing declared ranges**. Opens a PR only when resolutions actually moved. |
| `.github/workflows/dependabot-auto-merge.yml` | auto-merges **development-scope patch/minor only**. Runtime and all majors stay human-reviewed. |
| `.github/dependabot.yml` | adds the runtime/development split and raises the PR cap. |

### Why lockfile maintenance exists
Dependabot proposes *range* bumps in `package.json`; it does not refresh a lockfile whose ranges are already satisfiable. A repo can therefore sit indefinitely on vulnerable resolutions while every declared range looks correct and every alert bot looks quiet.

Not hypothetical: on 2026-08-01 a **CRITICAL** `tar` advisory was live on production while the override floor `^7.5.15` was already correct — only the lockfile was stale, pinned at 7.5.16 while 7.5.22 had shipped.

### Why the auto-merge boundary is the major boundary
The dependency work is bimodal. Everything mechanical is same-major (tar, axios, brace-expansion, js-yaml). Everything that genuinely needed a human was cross-major (react-router 7→8, sigstore 1→4, adm-zip 0.4→0.6) — forcing those through would have turned an advisory into an outage.

Scope is deliberately narrow at first: **development-scope patch/minor only**. Dev-scope build tooling never reaches the runtime artifact, so a bad one cannot reach a customer. Runtime stays human-reviewed while merchant PSPs are being onboarded.

> **Note — auto-merge is inert until two repo settings exist:** `allow_auto_merge` on the repo, and branch protection with **required status checks** on the target branch. `gh pr merge --auto` merges as soon as required checks pass, so with *no* required checks that means *immediately*, including on a red PR. Branch protection is the real safety mechanism; this workflow only decides which PRs are eligible. The workflow detects both and comments loudly on the PR rather than silently no-op'ing.

### The dependabot split, and the constraint behind it
Dependabot requires a unique `(package-ecosystem, directory, target-branch)` triple, so the runtime/development split **cannot** be two npm entries — that is rejected by GitHub's validator. It is one entry with two `groups` keyed on `dependency-type`, runtime declared first (Dependabot assigns each dependency to the first matching group in definition order).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LK1tY7oRna6jBG8J2o3o9i
