### PR TITLE
ci: source-branch policy must run on ALL PRs, not just main-targeted

### DIFF
--- a/.github/workflows/enforce-pr-source-branch.yml
+++ b/.github/workflows/enforce-pr-source-branch.yml
@@ -2,7 +2,6 @@ name: PR Source Branch Policy
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
-    branches: [main]
 jobs:
   enforce-source-branch:
     runs-on: ubuntu-latest
@@ -10,6 +9,14 @@ jobs:
       - name: Check PR head branch
         run: |
           HEAD="${{ github.head_ref }}"
+          BASE="${{ github.base_ref }}"
+          # Policy applies ONLY to PRs into main. Without this the job never
+          # re-runs after a PR is retargeted away from main, freezing a red
+          # check that can never clear.
+          if [[ "$BASE" != "main" ]]; then
+            echo "PR targets \'$BASE\', not main - dev-first policy does not apply."
+            exit 0
+          fi
           if [[ "$HEAD" == "dev" || "$HEAD" == hotfix/* || "$HEAD" == dependabot/* ]]; then
             echo "PR source '$HEAD' satisfies the dev-first policy"
             exit 0


### PR DESCRIPTION
## Closes / addresses

Unblocks stuck PRs whose `enforce-source-branch` check is frozen red.

## The deadlock

`enforce-pr-source-branch.yml` triggers on `branches: [main]` only:

1. A PR opens against `main` from a feature branch → policy correctly fails it.
2. You fix it the way the policy asks — retarget to `dev`.
3. **The workflow never fires again**, because the PR no longer targets `main`.
4. The red check freezes forever, describing a violation that no longer exists.

**Fixing the violation is what makes it unfixable.** Six PRs across three repos were in that state today.

## The change

Runs on every `pull_request`, gated on `github.base_ref`:

| base | behaviour |
|---|---|
| `main` | policy applies — unchanged |
| anything else | passes explicitly |

**The policy is not weakened** — it still only constrains PRs into `main`. PRs into other bases now *report* instead of never running.

A check that cannot report is indistinguishable from one that failed — the same defect class as a check that silently passes.

Same fix as droplinked/droplinked-shop-builder#1336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LK1tY7oRna6jBG8J2o3o9i