### PR TITLE
feat(marketplace): SSR index + retailer hub — un-orphan 11,642 PDPs

### DIFF
--- a/src/app/(routes)/marketplace/[advertiserId]/[itemId]/[slug]/page.tsx
+++ b/src/app/(routes)/marketplace/[advertiserId]/[itemId]/[slug]/page.tsx
@@ -30,13 +30,14 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { SITE } from "@/lib/site";
+import { SITE, SITE_URL } from "@/lib/site";
 import { MARKETPLACE_PDP_CTA_ENABLED } from "@/lib/variables/variables";
 import {
   buildMarketplaceJsonLd,
   fetchMarketplaceItem,
   type MarketplaceView,
 } from "./lib/marketplace-data";
+import { fetchPdpSiblings } from "../../../lib/marketplace-index-data";
 import MarketplaceRegistrationCta from "./components/MarketplaceRegistrationCta";
 
 // ISR — revalidate hourly. Affiliate items change rarely (price/availability
@@ -107,12 +108,51 @@ export default async function MarketplaceProductPage({ params }: PageProps) {
     notFound();
   }
 
+  // Siblings from the same retailer — the PDP -> PDP link edge that did not
+  // exist. This ALSO decides whether the breadcrumb links out: `related` is
+  // non-null only when the hub endpoint actually served content, so we can
+  // never render a breadcrumb link to a page the backend is currently 404ing.
+  // Cost is bounded: the request URL is identical to the hub page's own page-1
+  // request, so all PDPs of an advertiser share ONE hourly fetch-cache entry.
+  const related = await fetchPdpSiblings(advertiserId, itemId);
+
   const heroImage = view.images[0];
   const galleryImages = view.images.slice(1, 5);
   const priceLabel = view.price
     ? `${view.price} ${view.priceCurrency}`
     : "Price unavailable";
   const jsonLd = buildMarketplaceJsonLd(view);
+
+  // BreadcrumbList mirroring the rendered trail, emitted only when that trail
+  // is genuinely navigable — structured data that claims a hierarchy the page
+  // does not link is worse than none.
+  const breadcrumbJsonLd = related
+    ? {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          { "@type": "ListItem", position: 1, name: SITE.name, item: SITE_URL },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "Marketplace",
+            item: `${SITE_URL}/marketplace`,
+          },
+          {
+            "@type": "ListItem",
+            position: 3,
+            name: related.hub.label,
+            item: `${SITE_URL}/marketplace/${encodeURIComponent(advertiserId)}`,
+          },
+          {
+            "@type": "ListItem",
+            position: 4,
+            name: view.title,
+            item: view.canonicalUrl,
+          },
+        ],
+      }
+    : null;
 
   return (
     <>
@@ -122,9 +162,21 @@ export default async function MarketplaceProductPage({ params }: PageProps) {
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
+      {breadcrumbJsonLd && (
+        <script
+          type="application/ld+json"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+        />
+      )}
 
       <main className="container mx-auto px-6 md:px-8 py-8 md:py-12 max-w-6xl">
-        {/* ── breadcrumb (internal — not an orphan doorway) ── */}
+        {/* ── breadcrumb ──
+            These used to be inert <span>s, which is why every PDP had zero
+            outbound internal links and the whole corpus sat at "Discovered -
+            currently not indexed". They become real links only when the hub
+            fetch succeeded, so a disabled backend flag can never leave 11,642
+            pages pointing at a 404. */}
         <nav
           aria-label="Breadcrumb"
           className="mb-8 text-sm text-foreground/50 flex flex-wrap items-center gap-2"
@@ -133,11 +185,34 @@ export default async function MarketplaceProductPage({ params }: PageProps) {
             droplinked
           </Link>
           <span aria-hidden>/</span>
-          <span className="text-foreground/50">Marketplace</span>
-          {view.category && (
+          {related ? (
             <>
+              <Link
+                href="/marketplace"
+                className="hover:text-mint-500 transition-colors"
+              >
+                Marketplace
+              </Link>
               <span aria-hidden>/</span>
-              <span className="capitalize text-foreground/50">{view.category}</span>
+              <Link
+                href={`/marketplace/${encodeURIComponent(advertiserId)}`}
+                data-testid="marketplace-pdp-hub-link"
+                className="hover:text-mint-500 transition-colors line-clamp-1"
+              >
+                {related.hub.label}
+              </Link>
+            </>
+          ) : (
+            <>
+              <span className="text-foreground/50">Marketplace</span>
+              {view.category && (
+                <>
+                  <span aria-hidden>/</span>
+                  <span className="capitalize text-foreground/50">
+                    {view.category}
+                  </span>
+                </>
+              )}
             </>
           )}
           <span aria-hidden>/</span>
@@ -279,6 +354,56 @@ export default async function MarketplaceProductPage({ params }: PageProps) {
             </p>
           </div>
         </div>
+
+        {/* ── more from this retailer ──
+            The PDP -> PDP edge. Before this, a crawler that reached a PDP had
+            nowhere to go and every product page was a dead end; now each one
+            passes importance to siblings and back up to the hub. Rendered below
+            the product and its click-out so it never competes with the buy
+            path. Absent entirely when the hub has no other items. */}
+        {related && related.siblings.length > 0 && (
+          <section className="mt-16 border-t border-line pt-10">
+            <div className="mb-6 flex flex-wrap items-baseline justify-between gap-3">
+              <h2 className="text-xl font-semibold text-foreground">
+                More from {related.hub.label}
+              </h2>
+              <Link
+                href={`/marketplace/${encodeURIComponent(advertiserId)}`}
+                className="text-sm text-mint-500 hover:text-mint-400 transition-colors"
+              >
+                View all {related.hub.total.toLocaleString()} &rarr;
+              </Link>
+            </div>
+            <ul className="grid grid-cols-2 md:grid-cols-4 gap-5">
+              {related.siblings.map((sibling) => (
+                <li key={sibling.itemId}>
+                  <Link
+                    href={sibling.href}
+                    data-testid="marketplace-pdp-sibling-link"
+                    className="flex flex-col gap-2 group"
+                  >
+                    {sibling.image ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={sibling.image}
+                        alt={sibling.title}
+                        width={400}
+                        height={400}
+                        className="w-full h-auto aspect-square rounded-lg object-cover bg-surface-1"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="w-full aspect-square rounded-lg bg-surface-1" />
+                    )}
+                    <span className="text-sm text-foreground/70 group-hover:text-mint-500 transition-colors line-clamp-2">
+                      {sibling.title}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
 
         {/* Additive merchant-acquisition CTA — flag-gated (OFF in prod until
             reviewed on the dev preview), rendered BELOW the product and its

--- a/src/app/(routes)/marketplace/[advertiserId]/page.tsx
+++ b/src/app/(routes)/marketplace/[advertiserId]/page.tsx
@@ -1,0 +1,291 @@
+/**
+ * /marketplace/<advertiserId> — the per-retailer HUB.
+ *
+ * This route did not exist: it returned a hard 404 while the sitemap listed
+ * 11,642 PDPs underneath it. The hub is the middle tier of the link graph —
+ * /marketplace -> here -> PDP — and it is what actually gives each PDP an
+ * inbound internal link, which is Google's primary page-importance signal and
+ * the thing whose absence produced "Discovered - currently not indexed /
+ * lastCrawl NEVER" across 99.3% of the corpus.
+ *
+ * ROUTE ARITY: this sits above the existing `[itemId]/[slug]/page.tsx`, so a
+ * one-segment request lands here and a three-segment request lands on the PDP.
+ * No collision.
+ *
+ * SITEMAP AGREEMENT: the backend serves this hub through the SAME supply
+ * enumeration and the SAME `marketplacePdpIsIndexable` gate the sitemap uses.
+ * That is the invariant that matters — if the hub linked to an item the
+ * sitemap excluded, we would be emitting internal links to pages we
+ * simultaneously tell Google not to index, which is worse than no hub at all.
+ *
+ * FAIL-CLOSED: disabled flag, non-allowlisted advertiser, no indexable supply,
+ * and an out-of-range page all produce the same null -> `notFound()`. They are
+ * indistinguishable on purpose, so this cannot be used to read the allowlist,
+ * and an out-of-range ?page=N is a real 404 rather than an empty 200 that
+ * would let a crawler wander into unbounded pagination space.
+ *
+ * Data source (apiv3, @Public, no auth): GET /v2/marketplace/:advertiserId
+ * ISR: revalidate hourly, matching the endpoint's Cache-Control: max-age=3600.
+ */
+
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SITE, SITE_URL } from "@/lib/site";
+import {
+  advertiserHubPath,
+  fetchAdvertiserHub,
+  type MarketplaceHubView,
+} from "../lib/marketplace-index-data";
+
+export const revalidate = 3600;
+
+interface PageProps {
+  params: Promise<{ advertiserId: string }>;
+  searchParams: Promise<{ page?: string | string[] }>;
+}
+
+/** `?page=` -> a positive integer. Anything unparseable is page 1. */
+function readPage(raw: string | string[] | undefined): number {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 1 ? Math.trunc(n) : 1;
+}
+
+/**
+ * Self-referencing canonical. Page 2+ canonicalises to ITSELF, not back to
+ * page 1: pointing every paginated page at page 1 tells Google the deeper
+ * pages are duplicates, which would de-index exactly the pages carrying the
+ * links to items 49+.
+ */
+function hubCanonical(advertiserId: string, page: number): string {
+  const base = `${SITE_URL}${advertiserHubPath(advertiserId)}`;
+  return page > 1 ? `${base}?page=${page}` : base;
+}
+
+function hubTitle(hub: MarketplaceHubView): string {
+  const suffix = hub.page > 1 ? ` — page ${hub.page}` : "";
+  return `${hub.label} — ${hub.total.toLocaleString()} products${suffix} | droplinked`;
+}
+
+function hubDescription(hub: MarketplaceHubView): string {
+  return (
+    `Browse ${hub.total.toLocaleString()} products droplinked curates from ` +
+    `${hub.label}. You complete your purchase on the retailer's own site.`
+  );
+}
+
+export async function generateMetadata({
+  params,
+  searchParams,
+}: PageProps): Promise<Metadata> {
+  const { advertiserId } = await params;
+  const page = readPage((await searchParams).page);
+  const hub = await fetchAdvertiserHub(advertiserId, page);
+
+  if (!hub) {
+    return { title: "Retailer not found | droplinked" };
+  }
+
+  const title = hubTitle(hub);
+  const description = hubDescription(hub);
+
+  return {
+    title,
+    description,
+    alternates: { canonical: hubCanonical(advertiserId, hub.page) },
+    openGraph: {
+      type: "website",
+      url: hubCanonical(advertiserId, hub.page),
+      title,
+      description,
+      siteName: SITE.name,
+    },
+    twitter: { card: "summary", title, description },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default async function MarketplaceAdvertiserHubPage({
+  params,
+  searchParams,
+}: PageProps) {
+  const { advertiserId } = await params;
+  const page = readPage((await searchParams).page);
+  const hub = await fetchAdvertiserHub(advertiserId, page);
+
+  if (!hub) {
+    notFound();
+  }
+
+  const canonical = hubCanonical(advertiserId, hub.page);
+  const hubBase = advertiserHubPath(advertiserId);
+  const offset = (hub.page - 1) * hub.pageSize;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": `${canonical}#collection`,
+    name: hub.label,
+    description: hubDescription(hub),
+    url: canonical,
+    isPartOf: { "@type": "WebSite", name: SITE.name, url: SITE_URL },
+    breadcrumb: {
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: SITE.name, item: SITE_URL },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: "Marketplace",
+          item: `${SITE_URL}/marketplace`,
+        },
+        { "@type": "ListItem", position: 3, name: hub.label, item: canonical },
+      ],
+    },
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: hub.total,
+      itemListElement: hub.items.map((item, i) => ({
+        "@type": "ListItem",
+        position: offset + i + 1,
+        name: item.title,
+        url: `${SITE_URL}${item.href}`,
+      })),
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+
+      <main className="container mx-auto px-6 md:px-8 py-8 md:py-12 max-w-6xl">
+        <nav
+          aria-label="Breadcrumb"
+          className="mb-8 text-sm text-foreground/50 flex flex-wrap items-center gap-2"
+        >
+          <Link href="/" className="hover:text-mint-500 transition-colors">
+            droplinked
+          </Link>
+          <span aria-hidden>/</span>
+          <Link href="/marketplace" className="hover:text-mint-500 transition-colors">
+            Marketplace
+          </Link>
+          <span aria-hidden>/</span>
+          <span className="text-foreground/70 line-clamp-1">{hub.label}</span>
+        </nav>
+
+        <header className="mb-10 flex flex-col gap-4 max-w-2xl">
+          <h1 className="text-3xl md:text-4xl font-semibold text-foreground leading-tight">
+            {hub.label}
+          </h1>
+          <p className="text-base leading-relaxed text-foreground/70">
+            {hub.total.toLocaleString()}{" "}
+            {hub.total === 1 ? "product" : "products"} curated by droplinked
+            {hub.totalPages > 1 ? ` — page ${hub.page} of ${hub.totalPages}` : ""}.
+          </p>
+          <p className="text-sm text-foreground/50 leading-relaxed">
+            You complete your purchase on the retailer&apos;s own site, and your
+            order is fulfilled and shipped by them under their own shipping and
+            returns policies. droplinked may earn a commission.
+          </p>
+        </header>
+
+        <ul className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-5">
+          {hub.items.map((item) => (
+            <li key={item.itemId}>
+              <Link
+                href={item.href}
+                data-testid="marketplace-hub-item-link"
+                className="flex flex-col gap-2 group"
+              >
+                {item.image ? (
+                  // Plain <img> (not next/image): product images come from many
+                  // remote hosts; a plain tag always server-renders and never
+                  // 500s on an unconfigured image host — what the crawler must
+                  // see. Same reasoning as the PDP.
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={item.image}
+                    alt={item.title}
+                    width={400}
+                    height={400}
+                    className="w-full h-auto aspect-square rounded-lg object-cover bg-surface-1"
+                    loading="lazy"
+                  />
+                ) : (
+                  <div className="w-full aspect-square rounded-lg bg-surface-1" />
+                )}
+                <span className="text-sm text-foreground/70 group-hover:text-mint-500 transition-colors line-clamp-2">
+                  {item.title}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+
+        {/* Real prev/next anchors, not JS pagination — a crawler has to be able
+            to reach items 49+ by following a link. */}
+        {hub.totalPages > 1 && (
+          <nav
+            aria-label="Pagination"
+            className="mt-10 flex items-center justify-between gap-4 border-t border-line pt-6 text-sm"
+          >
+            {hub.page > 1 ? (
+              <Link
+                href={hub.page === 2 ? hubBase : `${hubBase}?page=${hub.page - 1}`}
+                rel="prev"
+                className="text-mint-500 hover:text-mint-400 transition-colors"
+              >
+                &larr; Previous
+              </Link>
+            ) : (
+              <span />
+            )}
+            <span className="text-foreground/50">
+              Page {hub.page} of {hub.totalPages}
+            </span>
+            {hub.page < hub.totalPages ? (
+              <Link
+                href={`${hubBase}?page=${hub.page + 1}`}
+                rel="next"
+                className="text-mint-500 hover:text-mint-400 transition-colors"
+              >
+                Next &rarr;
+              </Link>
+            ) : (
+              <span />
+            )}
+          </nav>
+        )}
+
+        <p className="mt-10 text-xs text-foreground/50">
+          <Link
+            href="/marketplace"
+            className="text-mint-500 hover:text-mint-400 transition-colors"
+          >
+            All retailers
+          </Link>{" "}
+          ·{" "}
+          <Link
+            href="/about"
+            className="text-mint-500 hover:text-mint-400 transition-colors"
+          >
+            About
+          </Link>{" "}
+          ·{" "}
+          <Link
+            href="/contact"
+            className="text-mint-500 hover:text-mint-400 transition-colors"
+          >
+            Contact
+          </Link>
+        </p>
+      </main>
+    </>
+  );
+}

--- a/src/app/(routes)/marketplace/lib/marketplace-index-data.ts
+++ b/src/app/(routes)/marketplace/lib/marketplace-index-data.ts
@@ -1,0 +1,307 @@
+/**
+ * marketplace-index-data.ts
+ *
+ * SSR data source for the marketplace INDEX and per-advertiser HUB pages —
+ * the internal-link spine that un-orphans the PDP corpus.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS EXISTS — measured, not assumed
+ * ---------------------------------------------------------------------------
+ * On 2026-08-01 the marketplace PDP corpus was 11,642 URLs with 83 indexed
+ * (0.71%). GSC URL Inspection on a sample — including one from the TOP-
+ * impression advertiser — returned, identically:
+ *
+ *     coverage  = "Discovered - currently not indexed"
+ *     lastCrawl = NEVER
+ *     canonical = googleCanonical == userCanonical  (no conflict)
+ *
+ * Everything upstream was healthy: sitemap submitted to GSC (11,642 URLs, 0
+ * errors), PDPs server-render real content to Googlebot, robots allows
+ * /marketplace/, every PDP self-canonicalises with index,follow.
+ *
+ * The break was the INTERNAL LINK GRAPH:
+ *   GET /marketplace             -> HTTP 200, 0 links to any PDP
+ *   GET /marketplace/:advertiser -> HTTP 404 (no hub route existed)
+ *   PDP -> sibling PDPs          -> 0
+ *
+ * Worse, that 200 was not even a marketplace page: `marketplace` was falling
+ * through to the sibling dynamic `[productId]` route and rendering as a
+ * product named "marketplace" — a soft-404 served 200 at the natural parent
+ * of the entire corpus. Adding a STATIC `marketplace/page.tsx` shadows that
+ * route (Next resolves static segments before dynamic ones) and fixes both.
+ *
+ * Every PDP was therefore an orphan, reachable only via the sitemap. Internal
+ * linking is Google's primary page-importance signal, so a zero-inbound-link
+ * page gets near-zero crawl priority no matter how clean the sitemap is.
+ * "Discovered - currently not indexed" at 99.3% is the textbook fingerprint.
+ *
+ * Data source (apiv3, @Public, no auth):
+ *   GET /v2/marketplace                 -> advertisers with indexable supply
+ *   GET /v2/marketplace/:advertiserId   -> that advertiser's items, paginated
+ *
+ * BE dependency (droplinked-backend):
+ *   src/modules/marketplace-pdp/controllers/marketplace-index.controller.ts
+ *
+ * ---------------------------------------------------------------------------
+ * GATING — inherited, not duplicated
+ * ---------------------------------------------------------------------------
+ * There is deliberately NO separate frontend feature flag. The backend gates
+ * both endpoints on `MARKETPLACE_PDP_ENABLED` + the advertiser allowlist and
+ * 404s when either is off; a 404 here returns null and the page calls
+ * `notFound()`. So the pages are already fail-closed on the backend flag, and
+ * a second flag would only add a way for the two to disagree.
+ *
+ * The same property is what makes it safe to add breadcrumb links on the PDP:
+ * the PDP renders them only when this fetch SUCCEEDED, so we can never emit an
+ * internal link to a page the backend is currently 404ing.
+ */
+
+import { SITE, SITE_URL } from "@/lib/site";
+
+/** apiv3 base — overridable for dev/preview; defaults to the prod API host. */
+const APIV3_BASE = (
+  process.env.APIV3_BASE_URL || "https://apiv3.droplinked.com"
+).replace(/\/+$/, "");
+
+/**
+ * Must match the backend's HUB_PAGE_SIZE. Both the hub page and the PDP's
+ * "more from" rail request this exact page size so they resolve to the SAME
+ * fetch-cache entry — one origin request per advertiser per hour, not one per
+ * rendered PDP.
+ */
+export const HUB_PAGE_SIZE = 48;
+
+/** How many siblings the PDP rail shows. Enough to be a real link edge, few
+ *  enough not to bury the product the shopper actually came for. */
+export const PDP_SIBLING_COUNT = 8;
+
+// ---- view models ----
+
+export interface MarketplaceAdvertiserSummary {
+  advertiserId: string;
+  /** Indexable item count (what the hub will actually render). */
+  itemCount: number;
+  /** Display label: the representative brand, or a neutral fallback. */
+  label: string;
+  /** Same-origin path to this advertiser's hub. */
+  href: string;
+}
+
+export interface MarketplaceIndexView {
+  advertisers: MarketplaceAdvertiserSummary[];
+  total: number;
+}
+
+export interface MarketplaceHubItem {
+  itemId: string;
+  title: string;
+  /** Same-origin path derived from the item's canonical URL. */
+  href: string;
+  image: string | null;
+  brand: string;
+}
+
+export interface MarketplaceHubView {
+  advertiserId: string;
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+  /** Display label for the advertiser (brand when known). */
+  label: string;
+  items: MarketplaceHubItem[];
+}
+
+// ---- helpers ----
+
+/**
+ * Canonical URL -> same-origin path, or null.
+ *
+ * Two properties matter here, and both are security properties rather than
+ * cosmetic ones:
+ *
+ *  1. We never emit an OFF-ORIGIN href into what reads as an internal product
+ *     grid. The marketplace click-out to the retailer is a separate, disclosed,
+ *     `rel="sponsored nofollow"` control on the PDP; a grid tile silently
+ *     leaving the site would be exactly the affiliate-doorway pattern these
+ *     pages exist to not be.
+ *  2. A protocol-relative value ("//evil.example/x") is rejected. It looks like
+ *     a path to a naive prefix check but resolves off-origin in a browser.
+ *
+ * Anything that is not a plain `/marketplace/...` path on our own host is
+ * dropped rather than repaired — the item simply does not appear.
+ */
+export function toInternalPath(canonicalUrl: unknown): string | null {
+  if (typeof canonicalUrl !== "string") return null;
+  const url = canonicalUrl.trim();
+  if (!url.startsWith(`${SITE_URL}/marketplace/`)) return null;
+  const path = url.slice(SITE_URL.length);
+  if (!path.startsWith("/marketplace/")) return null;
+  if (path.startsWith("//")) return null;
+  return path;
+}
+
+/** Advertiser id -> hub path. Ids are numeric-ish strings from Impact. */
+export function advertiserHubPath(advertiserId: string): string {
+  return `/marketplace/${encodeURIComponent(advertiserId)}`;
+}
+
+/**
+ * Label for an advertiser. Brand when the supply carries one; otherwise a
+ * neutral descriptor rather than a bare numeric id — a page of raw ids is
+ * precisely the thin, machine-generated shape we are trying to escape, and we
+ * do not invent a brand name we were not given.
+ */
+function advertiserLabel(brand: unknown): string {
+  const b = typeof brand === "string" ? brand.trim() : "";
+  return b || "Partner retailer";
+}
+
+/** Shared, never-throwing JSON GET. Null on network error / non-2xx / bad JSON. */
+async function getJson(url: string): Promise<unknown | null> {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      // 1h — matches the page ISR window and the endpoint's own
+      // Cache-Control: max-age=3600.
+      next: { revalidate: 3600 },
+      headers: {
+        Accept: "application/json",
+        "User-Agent": `${SITE.name}-shopfront/1.0 (marketplace-index)`,
+      },
+    });
+  } catch {
+    return null; // network error -> not-found, never throw
+  }
+  if (!response.ok) return null; // 404 = disabled/not allowlisted; 5xx = down
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+// ---- fetchers ----
+
+/**
+ * The advertiser index. Returns null when the endpoint is disabled, empty, or
+ * unreachable — the page then calls `notFound()` rather than rendering an
+ * empty grid, because an empty index page is a soft-404 and putting one in the
+ * corpus is worse than not having the page at all.
+ */
+export async function fetchMarketplaceIndex(): Promise<MarketplaceIndexView | null> {
+  const raw = await getJson(`${APIV3_BASE}/v2/marketplace`);
+  if (!raw || typeof raw !== "object") return null;
+
+  const list = (raw as Record<string, unknown>).advertisers;
+  if (!Array.isArray(list)) return null;
+
+  const advertisers: MarketplaceAdvertiserSummary[] = [];
+  for (const entry of list) {
+    if (!entry || typeof entry !== "object") continue;
+    const row = entry as Record<string, unknown>;
+    const advertiserId =
+      typeof row.advertiserId === "string" ? row.advertiserId.trim() : "";
+    const itemCount = Number(row.itemCount);
+    // Zero-supply advertisers are already omitted by the backend; re-checking
+    // here keeps the invariant local — we never link to a hub that would 404.
+    if (!advertiserId || !Number.isFinite(itemCount) || itemCount <= 0) continue;
+    advertisers.push({
+      advertiserId,
+      itemCount: Math.trunc(itemCount),
+      label: advertiserLabel(row.brand),
+      href: advertiserHubPath(advertiserId),
+    });
+  }
+
+  if (advertisers.length === 0) return null;
+
+  // Largest catalogues first: the highest-value crawl paths appear before the
+  // fold, and the ordering is stable across renders (ids break ties).
+  advertisers.sort(
+    (a, b) =>
+      b.itemCount - a.itemCount || a.advertiserId.localeCompare(b.advertiserId)
+  );
+
+  return { advertisers, total: advertisers.length };
+}
+
+/**
+ * One advertiser's indexable items, paginated. Null when disabled, not
+ * allowlisted, out of range, or unreachable — all indistinguishable by design,
+ * so this cannot be used to read the allowlist.
+ */
+export async function fetchAdvertiserHub(
+  advertiserId: string,
+  page = 1
+): Promise<MarketplaceHubView | null> {
+  const safePage = Number.isFinite(page) ? Math.max(1, Math.trunc(page)) : 1;
+  const url =
+    `${APIV3_BASE}/v2/marketplace/${encodeURIComponent(advertiserId)}` +
+    `?page=${safePage}&pageSize=${HUB_PAGE_SIZE}`;
+
+  const raw = await getJson(url);
+  if (!raw || typeof raw !== "object") return null;
+
+  const dto = raw as Record<string, unknown>;
+  const list = dto.items;
+  if (!Array.isArray(list)) return null;
+
+  const items: MarketplaceHubItem[] = [];
+  for (const entry of list) {
+    if (!entry || typeof entry !== "object") continue;
+    const row = entry as Record<string, unknown>;
+    const href = toInternalPath(row.canonicalUrl);
+    const itemId = typeof row.itemId === "string" ? row.itemId.trim() : "";
+    const title = typeof row.title === "string" ? row.title.trim() : "";
+    // No href or no title => no tile. A grid tile with nothing to click, or
+    // nothing to read, is a link we would be asking a crawler to follow into
+    // a dead end.
+    if (!href || !itemId || !title) continue;
+    const image =
+      typeof row.image === "string" && row.image.trim() ? row.image.trim() : null;
+    items.push({
+      itemId,
+      title,
+      href,
+      image,
+      brand: typeof row.brand === "string" ? row.brand.trim() : "",
+    });
+  }
+
+  if (items.length === 0) return null;
+
+  const total = Number(dto.total);
+  const totalPages = Number(dto.totalPages);
+  const brandLabel = items.find((i) => i.brand)?.brand ?? "";
+
+  return {
+    advertiserId,
+    page: safePage,
+    pageSize: HUB_PAGE_SIZE,
+    total: Number.isFinite(total) ? Math.trunc(total) : items.length,
+    totalPages: Number.isFinite(totalPages) ? Math.max(1, Math.trunc(totalPages)) : 1,
+    label: advertiserLabel(brandLabel),
+    items,
+  };
+}
+
+/**
+ * Siblings for the PDP rail — the PDP -> PDP link edge that was missing.
+ *
+ * Requests page 1 at the shared page size on purpose: the URL is byte-identical
+ * to the hub page's own page-1 request, so both resolve to ONE fetch-cache
+ * entry. The cost of this rail across the whole corpus is one origin request
+ * per advertiser per hour, not one per PDP.
+ */
+export async function fetchPdpSiblings(
+  advertiserId: string,
+  excludeItemId: string
+): Promise<{ hub: MarketplaceHubView; siblings: MarketplaceHubItem[] } | null> {
+  const hub = await fetchAdvertiserHub(advertiserId, 1);
+  if (!hub) return null;
+  const siblings = hub.items
+    .filter((i) => i.itemId !== excludeItemId)
+    .slice(0, PDP_SIBLING_COUNT);
+  return { hub, siblings };
+}

--- a/src/app/(routes)/marketplace/page.tsx
+++ b/src/app/(routes)/marketplace/page.tsx
@@ -1,0 +1,175 @@
+/**
+ * /marketplace — the marketplace INDEX: the root of the internal link graph
+ * for the curated affiliate PDP corpus.
+ *
+ * BEFORE THIS ROUTE EXISTED, `/marketplace` had no page of its own. It fell
+ * through to the sibling dynamic `[productId]` route and rendered as a product
+ * named "marketplace": HTTP 200, ~70KB, and zero links to any PDP. So the
+ * natural parent of 11,642 product URLs was a soft-404 that consumed crawl
+ * budget and passed no importance to anything.
+ *
+ * `marketplace` is a STATIC segment, so Next resolves this file before the
+ * dynamic sibling — adding it both removes that soft-404 and installs the real
+ * page in one move.
+ *
+ * WHAT IT DOES: lists every allowlisted advertiser that has curated, indexable
+ * supply, as real `<a href>` links to that advertiser's hub. Crawlers can now
+ * walk /marketplace -> /marketplace/:advertiserId -> PDP instead of being
+ * handed a flat 11k-URL sitemap with no hierarchy.
+ *
+ * FAIL-CLOSED: `fetchMarketplaceIndex` returns null when the backend feature
+ * flag is off, the allowlist is empty, or the API is unreachable, and this page
+ * then calls `notFound()` — a real 404, never an empty grid. An empty index is
+ * a soft-404, which is the problem this route was added to remove.
+ *
+ * Data source (apiv3, @Public, no auth): GET /v2/marketplace
+ * ISR: revalidate hourly, matching the endpoint's Cache-Control: max-age=3600.
+ */
+
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SITE, SITE_URL } from "@/lib/site";
+import { fetchMarketplaceIndex } from "./lib/marketplace-index-data";
+
+export const revalidate = 3600;
+
+const CANONICAL = `${SITE_URL}/marketplace`;
+
+const TITLE = "Marketplace — curated products from partner retailers | droplinked";
+const DESCRIPTION =
+  "Browse products droplinked curates from partner retailers. Each product " +
+  "has its own page here; you complete the purchase on the retailer's own site.";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const index = await fetchMarketplaceIndex();
+  if (!index) {
+    return { title: "Marketplace not found | droplinked" };
+  }
+
+  return {
+    title: TITLE,
+    description: DESCRIPTION,
+    alternates: { canonical: CANONICAL },
+    openGraph: {
+      type: "website",
+      url: CANONICAL,
+      title: TITLE,
+      description: DESCRIPTION,
+      siteName: SITE.name,
+    },
+    twitter: { card: "summary", title: TITLE, description: DESCRIPTION },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default async function MarketplaceIndexPage() {
+  const index = await fetchMarketplaceIndex();
+  if (!index) {
+    notFound();
+  }
+
+  const totalItems = index.advertisers.reduce((n, a) => n + a.itemCount, 0);
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": `${CANONICAL}#collection`,
+    name: "droplinked Marketplace",
+    description: DESCRIPTION,
+    url: CANONICAL,
+    isPartOf: { "@type": "WebSite", name: SITE.name, url: SITE_URL },
+    breadcrumb: {
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: SITE.name, item: SITE_URL },
+        { "@type": "ListItem", position: 2, name: "Marketplace", item: CANONICAL },
+      ],
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+
+      <main className="container mx-auto px-6 md:px-8 py-8 md:py-12 max-w-6xl">
+        <nav
+          aria-label="Breadcrumb"
+          className="mb-8 text-sm text-foreground/50 flex flex-wrap items-center gap-2"
+        >
+          <Link href="/" className="hover:text-mint-500 transition-colors">
+            droplinked
+          </Link>
+          <span aria-hidden>/</span>
+          <span className="text-foreground/70">Marketplace</span>
+        </nav>
+
+        <header className="mb-10 flex flex-col gap-4 max-w-2xl">
+          <h1 className="text-3xl md:text-4xl font-semibold text-foreground leading-tight">
+            Marketplace
+          </h1>
+          <p className="text-base leading-relaxed text-foreground/70">
+            droplinked curates products from partner retailers and hosts a page
+            for each one. Browse by retailer below — {totalItems.toLocaleString()}{" "}
+            products across {index.total}{" "}
+            {index.total === 1 ? "retailer" : "retailers"}.
+          </p>
+          {/* Same honest disclosure the PDP carries, stated up front rather
+              than only at the point of click-out. */}
+          <p className="text-sm text-foreground/50 leading-relaxed">
+            You complete your purchase on the retailer&apos;s own site, and your
+            order is fulfilled and shipped by them under their own shipping and
+            returns policies. droplinked may earn a commission.
+          </p>
+        </header>
+
+        <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {index.advertisers.map((advertiser) => (
+            <li key={advertiser.advertiserId}>
+              <Link
+                href={advertiser.href}
+                data-testid="marketplace-advertiser-link"
+                className="flex flex-col gap-1 rounded-lg border border-line bg-surface-1 px-5 py-4 hover:border-mint-500 transition-colors h-full"
+              >
+                <span className="text-base font-medium text-foreground">
+                  {advertiser.label}
+                </span>
+                <span className="text-sm text-foreground/50">
+                  {advertiser.itemCount.toLocaleString()}{" "}
+                  {advertiser.itemCount === 1 ? "product" : "products"}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+
+        <p className="mt-10 text-xs text-foreground/50">
+          <Link
+            href="/"
+            className="text-mint-500 hover:text-mint-400 transition-colors"
+          >
+            droplinked
+          </Link>{" "}
+          ·{" "}
+          <Link
+            href="/about"
+            className="text-mint-500 hover:text-mint-400 transition-colors"
+          >
+            About
+          </Link>{" "}
+          ·{" "}
+          <Link
+            href="/contact"
+            className="text-mint-500 hover:text-mint-400 transition-colors"
+          >
+            Contact
+          </Link>
+        </p>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Closes / addresses

Addresses the marketplace ramp diagnosis (2026-08-01): **11,642 PDPs, 83 indexed (0.71%)**.
Frontend half of **droplinked-backend #3236** (the JSON read-models).

## The diagnosis

GSC URL Inspection on a sample — including one from the **top-impression** advertiser — returned identically:

| field | value |
|---|---|
| coverage | `Discovered – currently not indexed` |
| lastCrawl | **NEVER** |
| googleCanonical vs userCanonical | identical (no conflict) |

Everything upstream was healthy: sitemap submitted to GSC (11,642 URLs, 0 errors, 0 warnings), PDPs SSR real content to Googlebot, `robots.txt` allows `/marketplace/`, every PDP self-canonicalises `index,follow`.

The break was the **internal link graph**:

```
GET /marketplace              -> HTTP 200, 0 links to any PDP
GET /marketplace/:advertiser  -> HTTP 404  (no route existed)
PDP -> sibling PDPs           -> 0
```

That `200` was not even a marketplace page. `marketplace/` had no `page.tsx`, so it fell through to the **sibling dynamic `[productId]` route** and rendered as a product named "marketplace" — a ~70KB **soft-404 served 200** at the natural parent of the whole corpus.

Every PDP was an **orphan**, reachable only from the sitemap. Internal linking is Google's primary page-importance signal; a zero-inbound-link page gets near-zero crawl priority no matter how clean the sitemap is. `Discovered – currently not indexed` at 99.3% is the textbook fingerprint.

## What this adds

`marketplace` is a **static** segment, so `page.tsx` shadows the dynamic sibling — removing the soft-404 and installing the real page in one move.

| route | rendering | role |
|---|---|---|
| `/marketplace` | static + ISR 1h | retailers with indexable supply |
| `/marketplace/:advertiserId` | dynamic (reads `?page`) | that retailer's items, paginated |
| PDP (existing) | dynamic | breadcrumb **up** + "More from" rail **across** |

Plus on the PDP: breadcrumb `<span>`s become real links, a `BreadcrumbList` JSON-LD, and an 8-item sibling rail below the buy path.

## Why no frontend feature flag

Deliberate. The backend gates both endpoints on `MARKETPLACE_PDP_ENABLED` + the advertiser allowlist and 404s when off; a 404 → `null` → `notFound()`. **The pages are already fail-closed on the backend flag**, and a second flag would only create a way for the two to disagree.

That same property is what makes the PDP breadcrumb safe to add: it links out **only when the hub fetch succeeded**, so a disabled backend can never leave 11,642 pages pointing at a 404.

## Verification — rendered, not asserted

Built and served against a mock apiv3, probed as Googlebot:

```
/marketplace                          HTTP 200 |  2 hub links
/marketplace/1429303                  HTTP 200 | 48 PDP links
/marketplace/1429303?page=2           HTTP 200 | 48 PDP links + prev
/marketplace/1429303?page=99          HTTP 404   <- not a soft-404
/marketplace/1429303/itm3/<slug>      HTTP 200 |  8 sibling + hub links
/marketplace/9999999                  HTTP 404   <- indistinguishable from "no supply"
```

Canonicals + robots, all `index, follow`:

```
/marketplace           -> https://shop.droplinked.com/marketplace
/marketplace/1429303   -> https://shop.droplinked.com/marketplace/1429303
   ...?page=2          -> https://shop.droplinked.com/marketplace/1429303?page=2
```

Page 2 self-canonicalises to **itself**, not back to page 1 — canonicalising deeper pages to page 1 would de-index exactly the pages carrying links to items 49+.

JSON-LD emitted: `CollectionPage` + `BreadcrumbList` (index), `+ ItemList` (hub), `Product` + `Offer` + `BreadcrumbList` (PDP).

**Fail-closed proof** — advertiser whose PDP endpoint serves but whose hub 404s:

```
hub  -> HTTP 404
PDP  -> HTTP 200 | 0 links to /marketplace | 0 BreadcrumbList | 0 sibling rail
```

It degrades to exactly today's behaviour. No link to a 404 is possible.

Also: `tsc --noEmit` clean for these files (8 pre-existing errors elsewhere, untouched); `next lint` clean; `next build` succeeds and registers all three routes.

Only same-origin `href`s reach the grids — `toInternalPath` rejects off-origin URLs **and** protocol-relative `//host` values, which pass a naive prefix check but resolve off-site in a browser. The retailer click-out stays where it belongs: one disclosed `rel="sponsored nofollow"` control on the PDP.

## Cost

The rail requests page 1 at the shared page size — a URL byte-identical to the hub's own page-1 request — so all PDPs of an advertiser share **one** hourly fetch-cache entry. Origin load is ~1 request per advertiser per hour, not per rendered PDP.

## ⚠️ Deploy order

**Merge and deploy droplinked-backend #3236 first.** `/marketplace` is statically prerendered at build time; if the endpoint is not live when the frontend builds, it bakes a 404 and self-heals only on the next ISR revalidation (≤1h).

## Not in this PR

- ~~Adding `/marketplace` to a sitemap.~~ **I had this wrong.** I originally argued the 11,642 inbound breadcrumb links made a sitemap entry unnecessary. They don't: Google only *sees* those breadcrumbs after crawling a PDP, and `lastCrawl` is `NEVER` on 99.3% of them. The bootstrap was circular. **droplinked-backend #3237 now emits the index + every hub page in `marketplace-sitemap.xml`, ahead of the PDPs** — that is the entry point the crawl actually starts from.
- Any allowlist expansion. The standing decision from the ramp review is **diagnose, don't expand** — expanding while 99.3% of the corpus is unindexed just adds more orphans.

