### PR TITLE
fix(marketplace): hub heading uses the normalised label, not the raw feed name

### DIFF
--- a/src/app/(routes)/marketplace/lib/marketplace-index-data.ts
+++ b/src/app/(routes)/marketplace/lib/marketplace-index-data.ts
@@ -273,7 +273,17 @@ export async function fetchAdvertiserHub(
 
   const total = Number(dto.total);
   const totalPages = Number(dto.totalPages);
-  const brandLabel = items.find((i) => i.brand)?.brand ?? "";
+  // Prefer the API's top-level `label`: it is NORMALISED server-side, whereas
+  // items[].brand is the raw Impact value and is frequently the merchant's FEED
+  // name rather than a brand ("SharkNinja Product Feed 2025",
+  // "Hickory Farms 2024 ProductsUP (12/5)"). Deriving the heading from the raw
+  // item here would re-introduce exactly the plumbing the backend just stripped
+  // — and put it in this page's <h1> and <title>. Falls back to the item brand
+  // only for an older backend that predates the field.
+  const brandLabel =
+    (typeof dto.label === "string" && dto.label.trim()) ||
+    items.find((i) => i.brand)?.brand ||
+    "";
 
   return {
     advertiserId,


### PR DESCRIPTION
## Closes / addresses

Frontend half of **droplinked-backend #3241**.

`items[].brand` is the raw Impact value and is frequently the merchant's **feed** name rather than a brand. 15 of the 29 live advertisers were feed-shaped:

```
SharkNinja Product Feed 2025
Hickory Farms 2024 ProductsUP (12/5)
Lenovo_Impact_Radius_CA_NEW
vineyard vines catalog - Versa Feed
```

Verified against prod before this change — the hub rendered:

```
<h1>    SharkNinja Product Feed 2025
<title> SharkNinja Product Feed 2025 — 500 products | droplinked
```

on an **indexable** page. Deriving the heading from the raw item re-introduces exactly the plumbing #3241 strips server-side.

## The change

Prefer the API's top-level `label` (normalised server-side), falling back to `items[].brand` only for a backend that predates the field.

**Order-independent:** safe to merge before or after #3241. Before, the fallback keeps today's behaviour; after, headings become `SharkNinja`.

`tsc --noEmit` clean for these files; `next build` succeeds and still registers all three marketplace routes.