### PR TITLE
GTFU: dev→main — dependency/CI hygiene + security patches

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Fetch dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Closes / addresses

Promotes `dev` → `main`. **2 commits**, dependency/CI scope only.

## What ships

```
.github/workflows/dependabot-auto-merge.yml
```

Contents are limited to: dependency-hygiene CI port, the `npm update` (not `npm install`) refresh fix, `dependabot/fetch-metadata` v2→v3, and merged security patches (postcss GHSA-r28c, brace-expansion). **No product behaviour change.**

## Discipline

- Cut from a throwaway `hotfix/*` at dev HEAD, **not `head=dev`** — this repo's `delete_branch_on_merge` would otherwise destroy `dev` (it did exactly that on four repos on 2026-08-01).
- GTFU is a **merge commit, not a squash**, so anything that landed directly on `main` is preserved rather than reverted.

## Verification

Security patches in this range were each verified by full lockfile **key-set** comparison (0 packages added, 0 removed beyond the intended nested vulnerable copy) rather than `git diff --stat`, which cannot distinguish a benign prune from a destructive one.