### PR TITLE
security(deps): next -> 15.5.21 floor (3 runtime HIGH + 5 MEDIUM SSRF/DoS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "ethers": "^5.7.2",
         "formik": "^2.4.5",
         "material-ui-popup-state": "^5.0.10",
-        "next": "^15.5.18",
+        "next": "^15.5.21",
         "next-themes": "^0.4.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3781,9 +3781,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.19.tgz",
-      "integrity": "sha512-sWWluFvcv5v3Fxznmf2ZfjyoVQt/64oCnYqS90inQWGzMPK1VjvekPiz3OPHKmFT30EnHrjlbyaHLt3M0vWabw==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.23.tgz",
+      "integrity": "sha512-Mv3Z9hVbFcPnoLevsZ6rnX1TBtyHb5E17yN7HTPDXSXxeNsGBjUFrdbjRXKKXIOhfth7/cg6Ay7PZ2UFawaWsQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -3797,9 +3797,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.19.tgz",
-      "integrity": "sha512-jx9wWlTKueHKPvVOndyr7WuaevWCkuYqsQ8gC0TMPKAVWG3MhcdMrjfo9tvIZNXd0QOUYXXvAcZ325y8Uq7uzg==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.23.tgz",
+      "integrity": "sha512-SrEwOROH/rhA03F59hHtdhgtfZMWGzr5duDBWgRQt2rS3mJhqMKOcnNx6txOd0/i3E3D3uFKYFvyHsEiwQxzag==",
       "cpu": [
         "arm64"
       ],
@@ -3813,9 +3813,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.19.tgz",
-      "integrity": "sha512-291KFcsIQ3OenRdiUDFOR6W3wezzH4auENXm1gbm1Bjd4ANMMRgxPrWTUztQN43BnVoVuMnHCrLeECIMwgFKbA==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.23.tgz",
+      "integrity": "sha512-f0FpFbG2EhDCuptBGcfrLcYMDuQAhe6m1QA4VVfXFrIBoFXvXt/olGbBkYkloKlXQtmhuzvtdYyuu/6zf07GIg==",
       "cpu": [
         "x64"
       ],
@@ -3829,9 +3829,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.19.tgz",
-      "integrity": "sha512-WeH+nelQyyMeE2f8FxBRZNrGipya5zHZV2vjzfCOAYyiI6am+NbnWAAldOBFQBB2w0DjJcsvrKqoFT2b7+5YoA==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.23.tgz",
+      "integrity": "sha512-WlNtfepUXKX2u2ZsJZ8c3c8+tJSRZqsYzoMwLOY72A8ucKCCgxgNhiePA3qzFYahVWrwcQd8jOeJmBinc+VFVQ==",
       "cpu": [
         "arm64"
       ],
@@ -3845,9 +3845,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.19.tgz",
-      "integrity": "sha512-5xTOE0lDlDCSSfp+BAif7j17VRRCjWp//ZPZy6NI0QpdrhxtQnsZguSx0xAAZ0c9XZLrLLwCe/XVe5YPrRilKw==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.23.tgz",
+      "integrity": "sha512-W/6qKk7UG93mg14PmQC+2urt69MIdwTBLNQ6MJyeC4wOCIHCjz+VfgssvS1pK7mgYBtLC1g6VKNoHD9xB0WWGg==",
       "cpu": [
         "arm64"
       ],
@@ -3861,9 +3861,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.19.tgz",
-      "integrity": "sha512-LTxRmMgqqMv05Had879W00Fm53quiJd3Zuz8h1JSNJ3nGSlbZ/7Tjs1tKyScgN3Au3t3MyPsjPlq60fMmSHLsg==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.23.tgz",
+      "integrity": "sha512-vzefI32mi6VMk96RaTAyxApgfGbiFzQBXVsekEjsDv1fr48mlABTWx0sUYhaYCBHWqCalxmz3DxbxFcbFvzNtw==",
       "cpu": [
         "x64"
       ],
@@ -3877,9 +3877,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.19.tgz",
-      "integrity": "sha512-eoNQSpA5PQfB9wBO4RA47MTDXWz1fizy9Y3Z6e4DetYIF3dvjuu8sj7aIGn/bFCU6lnFzTK34NtCaffP4NsQ7Q==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.23.tgz",
+      "integrity": "sha512-qppK/3dTGOTI+aoWWBZc3DshFIhrzgL8guATlaN9V6M1QJxbkP/rhEZ22tdICsQ/2WWXopMZ2Jokzj2u3uKY3Q==",
       "cpu": [
         "x64"
       ],
@@ -3893,9 +3893,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.19.tgz",
-      "integrity": "sha512-6UNt2dFuCHOe446sm/Kp69nUe8/wIhnh9bm6Xcqw4qEWCOppLMOvhTBVgvM7invVUNr4SPpP6NOQsACtn2IN9Q==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.23.tgz",
+      "integrity": "sha512-Wc29KFOdT7XBcII3Vtmw7aoU8Uk3Mes/FNJfhFeSHdYBFJWMcR/DsI8U9BCPUhq/uycsUVuqSKGthW15tLsigA==",
       "cpu": [
         "arm64"
       ],
@@ -3909,9 +3909,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.19.tgz",
-      "integrity": "sha512-PhmojAHyqMne56HBLGu9dhDnHPuFmEjrXSQMM/nW0J6j849lk3ESrVtqNJcCk8CKOV7brpTTbaYAjwKPzKM69w==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.23.tgz",
+      "integrity": "sha512-/C7wRW4fa9s/PKA18zGPPpVmx8ycgVpP8yOxro4gzGTzjPJdscbAP3ODeFvgiIovxD176Z2J/SXO9t8PJKHLeQ==",
       "cpu": [
         "x64"
       ],
@@ -10702,12 +10702,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.19.tgz",
-      "integrity": "sha512-xNOW6tYshGX1/Oi3F8uuk4gpDeWsSUE/1Z0G5uUMekIxaQ0xc03UXd9II0VQHYMWviMeA0OHpJFAKsHf8bTYVg==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.23.tgz",
+      "integrity": "sha512-Gvd2WKgvxIXCGotxcI1im/Uf3rS3J3oZGw0g/uskg6AVBZhyE3aAbujkYWzS3xLmEPEtTLfkaVQUKK0KMTSIkA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.19",
+        "@next/env": "15.5.23",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -10720,14 +10720,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.19",
-        "@next/swc-darwin-x64": "15.5.19",
-        "@next/swc-linux-arm64-gnu": "15.5.19",
-        "@next/swc-linux-arm64-musl": "15.5.19",
-        "@next/swc-linux-x64-gnu": "15.5.19",
-        "@next/swc-linux-x64-musl": "15.5.19",
-        "@next/swc-win32-arm64-msvc": "15.5.19",
-        "@next/swc-win32-x64-msvc": "15.5.19",
+        "@next/swc-darwin-arm64": "15.5.23",
+        "@next/swc-darwin-x64": "15.5.23",
+        "@next/swc-linux-arm64-gnu": "15.5.23",
+        "@next/swc-linux-arm64-musl": "15.5.23",
+        "@next/swc-linux-x64-gnu": "15.5.23",
+        "@next/swc-linux-x64-musl": "15.5.23",
+        "@next/swc-win32-arm64-msvc": "15.5.23",
+        "@next/swc-win32-x64-msvc": "15.5.23",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ethers": "^5.7.2",
     "formik": "^2.4.5",
     "material-ui-popup-state": "^5.0.10",
-    "next": "^15.5.18",
+    "next": "^15.5.21",
     "next-themes": "^0.4.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Closes all 8 open `next` advisories on this repo in one patch-level bump.
Every one is runtime scope and every one is patched in 15.5.21:

HIGH
  CVE-2026-64645  SSRF in rewrites via attacker-controlled destination hostname
  CVE-2026-64649  SSRF in Server Actions on custom deployments
  CVE-2026-64641  DoS in the App Router via Server Actions
MEDIUM
  CVE-2026-64643, CVE-2026-64644, CVE-2026-64646, CVE-2026-64647, CVE-2026-64648

package.json floor moves ^15.5.18 -> ^15.5.21 (the exact advisory floor, so
the declared range can no longer intersect a vulnerable version); the
lockfile resolves 15.5.19 -> 15.5.23, the newest patch on the same minor.
No minor or major movement - this is 15.5.x throughout.

Why this is hand-rolled instead of merging Dependabot #210
----------------------------------------------------------
#210 targets the same fix but was branched on 2026-08-01 and regenerating
its lockfile WITHOUT --legacy-peer-deps changes the repo's peer-resolution
posture. Merging it into current main yields, on top of the intended 10
entries, 53 additional packages:

  @droplinked_inc/wallet-connection@0.1.1
  @droplinked_inc/web3-kit@0.1.0
  webpack@5.109.2, terser@5.49.0, minimizer-webpack-plugin@5.6.1,
  @webassemblyjs/* (14 packages), schema-utils, ajv-formats, jest-worker, ...

Those two @droplinked_inc packages are peerDependencies of
@droplinked_inc/web3@1.0.0. The Dockerfile and CI install with
`npm ci --legacy-peer-deps`, which does not auto-install peers, so main's
lockfile correctly omits them. Dependabot's regeneration pulls them in and
silently adds a wallet library plus a second bundler toolchain to a live
checkout surface. Measured, not assumed: I merged #210 into current main
locally and diffed the resulting lockfile.

This branch instead runs
`npm install --package-lock-only --legacy-peer-deps` on current main, which
produces exactly 10 changed entries, 0 added, 0 removed - an 80-line diff.

#210 and its sibling #207 should be closed as superseded.

Verification (on this branch, node 22 to match node:22-alpine in the Dockerfile)
-------------------------------------------------------------------------------
- npm ci --legacy-peer-deps: clean, 845 packages, resolves next 15.5.23
- npm run build: green, full route table emitted
- npm test (src/__smoke__): 3/3 pass
- npm start, then real pages fetched and asserted on CONTENT, not status:
    /marketplace  200, rendered "11,900 products across 29 retailers" plus
                  named retailers (SharkNinja, SFERRA Fine Linens, vineyard
                  vines, ...) with per-retailer product counts
    /marketplace/1235414
                  200, <title>SharkNinja - 500 products | droplinked</title>
    /marketplace/1235414/622356216968/ninja-40-oz-48-oz-pitcher-splash-guard-120kku-sharkninja
                  200, real product title, "price":"27.99", JSON-LD
                  schema.org block present
    /home 200, /terms 200, /privacy-policy 200
  i.e. the storefront is fetching live catalogue data and rendering it, not
  just returning 200s.

NOT verified: checkout completion / payment capture (needs live PSP creds),
and the mobile Playwright suite was not run.